### PR TITLE
Include hidden directories in markdown file scanning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -599,7 +599,7 @@ fn find_markdown_files(
     walk_builder.git_global(use_gitignore); // Enable/disable global gitignore
     walk_builder.git_exclude(use_gitignore); // Enable/disable .git/info/exclude
     walk_builder.parents(use_gitignore); // Enable/disable parent ignores
-    walk_builder.hidden(true); // Keep hidden files ignored unconditionally
+    walk_builder.hidden(false); // Include hidden files and directories
     walk_builder.require_git(false); // Process git ignores even if no repo detected
 
     // Add support for .markdownlintignore file


### PR DESCRIPTION
This PR addresses #102 by changing a single line in the file scanning logic.

## The Issue
Currently, `rumdl check` silently skips hidden directories (those starting with `.`) when scanning for markdown files.

## The Fix
Changed `walk_builder.hidden(true)` to `walk_builder.hidden(false)` in `src/main.rs:602`.

In the `ignore` crate's API:
- `hidden(true)` = skip hidden files/directories
- `hidden(false)` = include hidden files/directories

## Testing
Tested locally and confirmed that `rumdl check` now successfully scans hidden directories like `.documentation`.

I'm curious if there was a specific reason for excluding hidden directories originally - happy to discuss if there are concerns about this change!

Fixes #102