### PR TITLE
docs: add installation steps via Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ uv tool install rumdl
 uv tool run rumdl check .
 ```
 
+### Using Nix (macOS/Linux)
+
+```bash
+nix-channel --update
+nix-env --install --attr nixpkgs.rumdl
+```
+
+Alternatively, you can use flakes to run it without installation.
+
+```bash
+nix run --extra-experimental-features 'flakes nix-command' nixpkgs/nixpkgs-unstable#rumdl -- --version
+```
+
 ### Download binary
 
 ```bash


### PR DESCRIPTION
Thanks for your great work on this project!
The nixpkgs binary cache is now available.
Could we add Nix installation steps, similar to the Homebrew instructions?

You can test these steps using the official Docker image.

```console
> podman run -it nixos/nix:2.32.1
bash-5.2# nix run --extra-experimental-features 'flakes nix-command' nixpkgs/nixpkgs-unstable#rumdl -- --version
rumdl 0.0.162
```

ref: https://github.com/NixOS/nixpkgs/pull/446292, https://github.com/NixOS/nixpkgs/pull/453101