### PR TITLE
Update alias for MD059 rule to 'descriptive-link-text'

### DIFF
--- a/docs/md059.md
+++ b/docs/md059.md
@@ -1,6 +1,6 @@
 # MD059 - Link Text Should Be Descriptive
 
-Aliases: `table-cell-alignment`
+Aliases: `descriptive-link-text`
 
 ## What this rule does
 


### PR DESCRIPTION
- fix wrong alias
- taken from https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md