### PR TITLE
docs: minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ With intelligent caching, subsequent runs are even faster - rumdl only re-lints 
   - [Global Options](#global-options)
   - [Exit Codes](#exit-codes)
   - [Usage Examples](#usage-examples)
+- [LSP](#lsp)
 - [Configuration](#configuration)
   - [Configuration Discovery](#configuration-discovery)
   - [Editor Support (JSON Schema)](#editor-support-json-schema)


### PR DESCRIPTION
- add missing reference to LSP docs in main README
- cleanup the ToC, that is, remove the preceding headings and the ToC itself from the ToC.