### PR TITLE
README: Update usage examples with `uvx` commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 [![PyPI](https://img.shields.io/pypi/v/rumdl)](https://pypi.org/project/rumdl/)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/rvben/rumdl)](https://github.com/rvben/rumdl/releases/latest)
 [![GitHub stars](https://img.shields.io/github/stars/rvben/rumdl)](https://github.com/rvben/rumdl/stargazers)
-[![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/ADTJFSFUyn) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github-sponsors)](https://github.com/sponsors/rvben)
+[![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/ADTJFSFUyn)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github-sponsors)](https://github.com/sponsors/rvben)
 
 ## A modern Markdown linter and formatter, built for speed with Rust
 


### PR DESCRIPTION
This pull request updates the `README.md` to improve the formatting of badge images and to update the recommended command-line usage to use `uvx` instead of direct binary calls. This provides clearer installation and usage instructions, especially for users leveraging the `uv` tool.

Most important changes:

**Documentation formatting improvements:**
* Reformatted the badges at the top of the `README.md` so that each badge appears on its own line for better readability.

**Command usage and installation updates:**
* Updated all example commands in the "Quick Start" section to use `uvx` (e.g., `uvx rumdl check .`) instead of invoking the `rumdl` binary directly, reflecting modern best practices for running Rust binaries in Python environments.
* Changed the example for running `rumdl` without installing (in the `uv` section) from `uv tool run rumdl check .` to `uvx run rumdl check .` for consistency and accuracy.