### PR TITLE
README: Update docs links to rumdl.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@
 
 ## A modern Markdown linter and formatter, built for speed with Rust
 
-| [**Docs**](https://github.com/rvben/rumdl/blob/main/docs/RULES.md) | [**Rules**](https://github.com/rvben/rumdl/blob/main/docs/RULES.md) | [**Configuration**](#configuration) | [**vs markdownlint**](https://github.com/rvben/rumdl/blob/main/docs/markdownlint-comparison.md) |
+| [**Docs**](https://rumdl.dev)
+| [**Rules**](https://rumdl.dev/RULES)
+| [**Configuration**](https://rumdl.dev/global-settings)
+| [**Markdown Flavors**](https://rumdl.dev/flavors)
+| [**vs markdownlint**](https://rumdl.dev/markdownlint-comparison) |
 
 </div>
 


### PR DESCRIPTION
This pull request updates the documentation links in the `README.md` to point to the new official website, improving accessibility and navigation for users.

Documentation and navigation improvements:

* Updated all major documentation links in `README.md` to use the new `https://rumdl.dev` website, including links for Docs, Rules, Configuration, Markdown Flavors, and markdownlint comparison.