### PR TITLE
Add completions subcommand to generate shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2066,7 @@ dependencies = [
  "blake3",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "console_error_panic_hook",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 js-sys = { version = "0.3", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 futures = { version = "0.3.31", features = ["alloc"] }
+clap_complete = "4.5.65"
 
 [features]
 default = ["parallel", "native"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,13 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap_complete::{generate, shells::Shell};
 use colored::*;
 use core::error::Error;
 use memmap2::Mmap;
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Write, stdout};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -454,6 +455,8 @@ enum Commands {
         #[arg(long)]
         status: bool,
     },
+    /// Generate shell completion scripts
+    Completions { shell: Shell },
     /// Clear the cache
     Clean,
     /// Show version information
@@ -1723,6 +1726,7 @@ build-backend = "setuptools.build_meta"
                     }
                 }
             }
+            Commands::Completions { shell } => generate(shell, &mut Cli::command(), "rumdl", &mut stdout()),
             Commands::Clean => {
                 handle_clean_command(&cli);
             }


### PR DESCRIPTION
Supports the shells handled by clap_complete - currently zsh, bash,
fish, powershell and elvish.

How to use the generated scripts depends on the shell being used:
* Zsh - Write script to a file called _rumdl in a directory included on
  the fpath
* Bash - Source the generated script, eg by adding
  `source <(rumdl completions bash)` at the end of ~/.bashrc
* Fish - Write the script to file called rumdl.fish in a directory
  included in the $fish_complete_path variable, eg
  ~/.config/fish/completions
* PowerShell - Refer to power shell documentation
* Elvish - Refer to elvish documentation
