### PR TITLE
test: add profile focused on smoke tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -110,3 +110,18 @@ retries = { backoff = "exponential", count = 3, delay = "1s", max-delay = "10s" 
 
 # Don't fail fast - run all performance tests
 fail-fast = false
+
+# Smoke testing profile - lighter, stable test runs suitable for package managers
+[profile.smoke]
+# Exclude heavy, randomized and other potentially flaky tests
+default-filter = 'package(rumdl) and not kind(lib) and not test(/performance|benchmark|memory|linear_complexity|scaling|stress|large|comprehensive|deeply_nested|error_propagation|proptest|property_based|perf_|regression|vscode/)'
+
+test-threads = "num-cpus"
+failure-output = "immediate"
+success-output = "final"
+status-level = "pass"
+retries = 0
+
+# Don't fail fast to see all failed results
+# Useful as Nix requires rebuilds for checkPhase failures, and these tests are light
+fail-fast = false

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ test-quick:
 test-pre-commit:
 	cargo nextest run --profile pre-commit
 
+test-smoke:
+	cargo nextest run --profile smoke
+
 test-push:
 	@echo "Running CI test suite (excludes performance tests)..."
 	cargo nextest run --profile ci


### PR DESCRIPTION
The recently added property-based tests are effective for finding edge cases, but they have introduced some flakiness. Currently, the `quick` and `ci` profiles do not exclude these randomized tests.

This PR introduces a `smoke` profile to provide a lightweight and stable test suite. It excludes heavy, randomized tests to ensure consistent results, which is useful for [packaging in Nixpkgs](https://github.com/NixOS/nixpkgs/pull/484186#pullrequestreview-3708797643).

This allows us to benefit from proptest in specific contexts while maintaining a stable path for packaging and smoke testing.