### PR TITLE
fix(docs): remove line that splits table in rules documentation in two

### DIFF
--- a/docs/md046.md
+++ b/docs/md046.md
@@ -89,7 +89,6 @@ style = "consistent"  # Options: "consistent", "fenced", "indented"
 | Value        | Description                                       |
 | ------------ | ------------------------------------------------- |
 | `consistent` | All code blocks must use the same style (default) |
-
 | `fenced` | All code blocks must use fenced style (``` or ~~~) |
 | `indented` | All code blocks must use indented style (4 spaces) |
 


### PR DESCRIPTION
Remove line that splits table in rules documentation in two

https://github.com/rvben/rumdl/blob/94fa0f9e97532c48e5b69892bfb514de8df5a0c6/docs/md046.md?plain=1#L92