### PR TITLE
fix(docs): remove empty configuration block from rule MD023 page

### DIFF
--- a/docs/md023.md
+++ b/docs/md023.md
@@ -46,12 +46,6 @@ Checks that headings start at the beginning of the line without any indentation.
 
 <!-- rumdl-enable MD023 -->
 
-## Configuration
-
-```toml
-[MD023]
-```
-
 ## Automatic fixes
 
 This rule automatically removes any leading spaces or tabs from heading lines, moving them to the beginning of the line.


### PR DESCRIPTION
The documentation page for rule MD023 has a configuration section that doesn't have any configuration in it (apart from a TOML section heading).