### PR TITLE
refactor: Use `ValueEnum` to define arguments

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -4,7 +4,6 @@ use colored::*;
 use core::error::Error;
 use std::fs;
 use std::path::Path;
-use std::str::FromStr;
 
 use rumdl_lib::config as rumdl_config;
 use rumdl_lib::exit_codes::exit;
@@ -16,10 +15,8 @@ use crate::CheckArgs;
 /// ensuring consistency between regular check and watch mode.
 pub fn apply_cli_overrides(sourced: &mut rumdl_config::SourcedConfig, args: &CheckArgs) {
     // Apply --flavor override if provided
-    if let Some(ref flavor_str) = args.flavor
-        && let Ok(flavor) = rumdl_config::MarkdownFlavor::from_str(flavor_str)
-    {
-        sourced.global.flavor = rumdl_config::SourcedValue::new(flavor, rumdl_config::ConfigSource::Cli);
+    if let Some(flavor) = args.flavor {
+        sourced.global.flavor = rumdl_config::SourcedValue::new(flavor.into(), rumdl_config::ConfigSource::Cli);
     }
 
     // Apply --respect-gitignore override if provided

--- a/src/lint_context/tests.rs
+++ b/src/lint_context/tests.rs
@@ -207,7 +207,7 @@ fn test_blockquote_spaced_nested_markers_are_detected() {
 "#;
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
 
-    let bq1 = ctx.lines.get(0).unwrap().blockquote.as_ref().unwrap();
+    let bq1 = ctx.lines.first().unwrap().blockquote.as_ref().unwrap();
     assert_eq!(bq1.nesting_level, 2);
     assert_eq!(bq1.prefix, "> > ");
     assert_eq!(bq1.content, "Nested quote content");

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -224,10 +224,8 @@ fn discover_with_cache(
 /// When a user passes `--flavor gfm` on the CLI, that should apply to all files
 /// regardless of which subdirectory config they use.
 fn apply_cli_config_overrides(config: &mut rumdl_config::Config, args: &crate::CheckArgs) {
-    if let Some(ref flavor_str) = args.flavor
-        && let Ok(flavor) = flavor_str.parse::<rumdl_config::MarkdownFlavor>()
-    {
-        config.global.flavor = flavor;
+    if let Some(flavor) = args.flavor {
+        config.global.flavor = flavor.into();
     }
 
     if let Some(respect_gitignore) = args.respect_gitignore {

--- a/src/utils/text_reflow.rs
+++ b/src/utils/text_reflow.rs
@@ -2372,10 +2372,10 @@ pub fn reflow_blockquote_content(
         let pieces: Vec<&str> = segment
             .iter()
             .map(|&line| {
-                if line.ends_with('\\') {
-                    line[..line.len() - 1].trim_end()
-                } else if line.ends_with("  ") {
-                    line[..line.len() - 2].trim_end()
+                if let Some(l) = line.strip_suffix('\\') {
+                    l.trim_end()
+                } else if let Some(l) = line.strip_suffix("  ") {
+                    l.trim_end()
                 } else {
                     line.trim_end()
                 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -115,22 +115,27 @@ pub fn perform_check_run(ctx: &CheckRunContext<'_>) -> (bool, bool, bool, usize)
     let env_output_format = std::env::var("RUMDL_OUTPUT_FORMAT").ok();
 
     // Determine output format with precedence: CLI → env var → config → legacy → default
-    let output_format_str = args
-        .output_format
-        .as_deref()
-        .or(env_output_format.as_deref())
-        .or(config.global.output_format.as_deref())
-        .or_else(|| {
-            // Legacy support: map --output json to --output-format json
-            if args.output == "json" { Some("json") } else { None }
-        })
-        .unwrap_or("text");
+    let output_format = if let Some(fmt) = args.output_format {
+        fmt.into()
+    } else {
+        let output_format_str = env_output_format
+            .as_deref()
+            .or(config.global.output_format.as_deref())
+            .or({
+                // Legacy support: map --output json to --output-format json
+                match args.output {
+                    crate::cli_types::Output::Json => Some("json"),
+                    crate::cli_types::Output::Text => None,
+                }
+            })
+            .unwrap_or("text");
 
-    let output_format = match OutputFormat::from_str(output_format_str) {
-        Ok(fmt) => fmt,
-        Err(e) => {
-            eprintln!("{}: {}", "Error".red().bold(), e);
-            return (true, true, true, 0);
+        match OutputFormat::from_str(output_format_str) {
+            Ok(fmt) => fmt,
+            Err(e) => {
+                eprintln!("{}: {}", "Error".red().bold(), e);
+                return (true, true, true, 0);
+            }
         }
     };
 

--- a/tests/utils/text_reflow_test.rs
+++ b/tests/utils/text_reflow_test.rs
@@ -4272,8 +4272,7 @@ fn test_reflow_paragraph_at_line_blockquote_explicit_target() {
     assert!(!lines.is_empty(), "Expected reflowed output");
     assert!(
         lines.iter().all(|line| line.starts_with("> ")),
-        "Expected explicit quote prefix on all lines: {:?}",
-        lines
+        "Expected explicit quote prefix on all lines: {lines:?}",
     );
 }
 
@@ -4287,8 +4286,7 @@ fn test_reflow_paragraph_at_line_blockquote_lazy_target() {
     assert!(lines[0].starts_with("> "));
     assert!(
         lines.iter().skip(1).any(|line| !line.starts_with('>')),
-        "Expected at least one lazy continuation line: {:?}",
-        lines
+        "Expected at least one lazy continuation line: {lines:?}",
     );
 }
 
@@ -4911,7 +4909,7 @@ fn test_reflow_blockquote_content_hard_break_preserved() {
     };
     let result = reflow_blockquote_content(&lines, "> ", BlockquoteContinuationStyle::Explicit, &options);
     assert!(
-        result.last().map_or(false, |l| l.ends_with('\\')),
+        result.last().is_some_and(|l| l.ends_with('\\')),
         "Hard break marker must be on the last output line: {result:?}"
     );
 }


### PR DESCRIPTION
## Description

Use [`clap::ValueEnum`](https://docs.rs/clap/4.5.60/clap/trait.ValueEnum.html) to define CLI arguments. This takes the possible values ​​as an enumeration.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [ ] Manual testing performed

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)