### PR TITLE
docs(md046): Expand documentation for rule

### DIFF
--- a/docs/md046.md
+++ b/docs/md046.md
@@ -4,7 +4,10 @@ Aliases: `code-block-style`
 
 ## What this rule does
 
-Ensures all code blocks in your document use the same style - either fenced (with backticks) or indented (with spaces).
+Ensures all code blocks in your document:
+
+- Use the same style - either fenced (with backticks) or indented (with spaces).
+- Are closed off when using fenced style.
 
 ## Why this matters
 
@@ -99,6 +102,7 @@ When enabled, this rule will:
 - Convert all code blocks to match your configured style
 - Preserve code content and language identifiers
 - Maintain proper spacing around blocks
+- Close any fenced code blocks that aren't closed.
 
 ## Style comparison
 


### PR DESCRIPTION
Document that `rumdl` can find and fix fenced code blocks that aren't closed.