### PR TITLE
feat(code-block-tools): add buf:format and buf:lint builtin tool

### DIFF
--- a/src/code_block_tools/config.rs
+++ b/src/code_block_tools/config.rs
@@ -175,6 +175,13 @@ pub struct ToolDefinition {
     /// Additional arguments for format mode (appended to command)
     #[serde(default)]
     pub format_args: Vec<String>,
+
+    /// If set, write input to a temp file with this extension and pass the path
+    /// as the last argument instead of using stdin.
+    ///
+    /// Use this for tools that require a real file path (e.g. `buf format`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temp_file_extension: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -189,6 +196,7 @@ impl Default for ToolDefinition {
             stdout: true,
             lint_args: Vec::new(),
             format_args: Vec::new(),
+            temp_file_extension: None,
         }
     }
 }

--- a/src/code_block_tools/executor.rs
+++ b/src/code_block_tools/executor.rs
@@ -131,14 +131,8 @@ impl ToolExecutor {
 
     /// Execute a tool with the given input.
     ///
-    /// # Arguments
-    /// * `tool_def` - Tool definition with command and arguments
-    /// * `input` - Content to pass via stdin
-    /// * `is_format_mode` - Whether to use format_args (true) or lint_args (false)
-    /// * `timeout_ms` - Optional timeout override
-    ///
-    /// # Returns
-    /// Tool output on success, or an error.
+    /// If `tool_def.temp_file_extension` is set, the input is written to a temp file and
+    /// its path is appended as the last argument instead of being passed via stdin.
     pub fn execute(
         &self,
         tool_def: &ToolDefinition,
@@ -162,31 +156,52 @@ impl ToolExecutor {
             });
         }
 
-        // Build command
+        // Build command with base arguments and mode-specific flags
         let mut cmd = Command::new(tool_name);
-
-        // Add base arguments
         if tool_def.command.len() > 1 {
             cmd.args(&tool_def.command[1..]);
         }
-
-        // Add mode-specific arguments
-        let extra_args = if is_format_mode {
-            &tool_def.format_args
-        } else {
-            &tool_def.lint_args
-        };
+        let extra_args = if is_format_mode { &tool_def.format_args } else { &tool_def.lint_args };
         if !extra_args.is_empty() {
             cmd.args(extra_args);
         }
 
-        // Configure stdin/stdout
-        if tool_def.stdin {
-            cmd.stdin(Stdio::piped());
-        }
+        // For tools that need a real file path, write input to a temp file and pass its path.
+        // Otherwise configure stdin so the caller can pipe input through it.
+        let temp_path = if let Some(ext) = &tool_def.temp_file_extension {
+            let path = std::env::temp_dir().join(format!("rumdl_cbt_{}.{ext}", std::process::id()));
+            std::fs::write(&path, input.as_bytes()).map_err(|e| ExecutorError::IoError {
+                message: format!("Failed to write temp file: {e}"),
+            })?;
+            cmd.arg(&path);
+            Some(path)
+        } else {
+            if tool_def.stdin {
+                cmd.stdin(Stdio::piped());
+            }
+            None
+        };
+
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
 
+        let result = self.run_child(cmd, tool_def.stdin.then_some(input), tool_name, timeout_ms);
+
+        if let Some(path) = temp_path {
+            let _ = std::fs::remove_file(path);
+        }
+
+        result
+    }
+
+    /// Spawn `cmd`, optionally write `stdin_input`, wait with timeout, and collect output.
+    fn run_child(
+        &self,
+        mut cmd: Command,
+        stdin_input: Option<&str>,
+        tool_name: &str,
+        timeout_ms: Option<u64>,
+    ) -> Result<ToolOutput, ExecutorError> {
         // Spawn process
         let mut child = cmd.spawn().map_err(|e| ExecutorError::IoError {
             message: format!("Failed to spawn '{tool_name}': {e}"),
@@ -204,7 +219,7 @@ impl ToolExecutor {
         // Write stdin if required.
         // BrokenPipe is ignored: the tool may exit before consuming all input
         // (e.g., `true` or a linter that validates without reading fully).
-        if tool_def.stdin
+        if let Some(input) = stdin_input
             && let Some(mut stdin) = child.stdin.take()
             && let Err(e) = stdin.write_all(input.as_bytes())
             && e.kind() != std::io::ErrorKind::BrokenPipe
@@ -234,7 +249,7 @@ impl ToolExecutor {
                     let _ = join_reader(stdout_handle.take());
                     let _ = join_reader(stderr_handle.take());
                     return Err(ExecutorError::Timeout {
-                        tool: tool_name.clone(),
+                        tool: tool_name.to_string(),
                         timeout_ms: timeout.as_millis() as u64,
                     });
                 }
@@ -334,6 +349,7 @@ mod tests {
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         };
 
         let result = executor.execute(&tool_def, "test", false, None);
@@ -349,6 +365,7 @@ mod tests {
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         };
 
         let result = executor.execute(&tool_def, "test", false, None);
@@ -368,6 +385,7 @@ mod tests {
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         };
 
         let result = executor.execute(&tool_def, "hello world", false, None);
@@ -387,9 +405,49 @@ mod tests {
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         };
 
         let result = executor.execute(&tool_def, "", false, Some(5));
         assert!(matches!(result, Err(ExecutorError::Timeout { .. })));
+    }
+
+    /// Verify that `temp_file_extension` causes content to be written to a file and passed as an
+    /// argument. We use `cat` (which accepts a file path) to echo the content back to stdout.
+    #[test]
+    #[cfg(unix)]
+    #[ignore = "requires 'cat' to be available"]
+    fn test_execute_with_temp_file() {
+        let executor = ToolExecutor::default();
+        let tool_def = ToolDefinition {
+            command: vec!["cat".to_string()],
+            stdin: false,
+            stdout: true,
+            lint_args: vec![],
+            format_args: vec![],
+            temp_file_extension: Some("txt".to_string()),
+        };
+
+        let result = executor.execute(&tool_def, "hello from temp file", false, None);
+        let output = result.expect("cat via temp file should succeed");
+        assert!(output.success);
+        assert_eq!(output.stdout.trim(), "hello from temp file");
+    }
+
+    /// Verify that `temp_file_extension` + a nonexistent binary returns `ToolNotFound`.
+    #[test]
+    fn test_temp_file_tool_not_found() {
+        let executor = ToolExecutor::default();
+        let tool_def = ToolDefinition {
+            command: vec!["nonexistent-tool-xyz123".to_string()],
+            stdin: false,
+            stdout: true,
+            lint_args: vec![],
+            format_args: vec![],
+            temp_file_extension: Some("proto".to_string()),
+        };
+
+        let result = executor.execute(&tool_def, "syntax = \"proto3\";", false, None);
+        assert!(matches!(result, Err(ExecutorError::ToolNotFound { .. })));
     }
 }

--- a/src/code_block_tools/processor.rs
+++ b/src/code_block_tools/processor.rs
@@ -2708,6 +2708,7 @@ console.log('hi');
                 stdout: true,
                 lint_args: vec![],
                 format_args: vec![],
+                ..Default::default()
             },
         );
 
@@ -2748,6 +2749,7 @@ console.log('hi');
                 stdout: true,
                 lint_args: vec![],
                 format_args: vec![],
+                ..Default::default()
             },
         );
 

--- a/src/code_block_tools/registry.rs
+++ b/src/code_block_tools/registry.rs
@@ -71,6 +71,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -87,6 +88,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -99,6 +101,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -111,6 +114,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -122,6 +126,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -133,6 +138,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -144,6 +150,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -155,6 +162,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -166,6 +174,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -182,6 +191,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec!["--fix-dry-run".to_string()],
+            ..Default::default()
         },
     );
 
@@ -194,6 +204,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -206,6 +217,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["-d".to_string()], // diff mode for lint
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -218,6 +230,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -230,6 +243,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["-d".to_string()], // diff mode for lint
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -242,6 +256,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["-d".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -254,6 +269,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--dry-run".to_string(), "--Werror".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -266,6 +282,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -277,6 +294,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -289,6 +307,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -301,6 +320,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["-dry".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -313,6 +333,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -325,6 +346,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["-check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -337,6 +359,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -349,6 +372,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -361,6 +385,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec!["--autocorrect".to_string()],
+            ..Default::default()
         },
     );
 
@@ -373,6 +398,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check-idempotence".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -385,6 +411,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--validate".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -397,6 +424,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -409,6 +437,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--output=none".to_string(), "--set-exit-if-changed".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -421,6 +450,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["lint".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -433,6 +463,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--dry-run".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -445,6 +476,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec!["--reformat".to_string()],
+            ..Default::default()
         },
     );
 
@@ -456,6 +488,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -467,6 +500,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -479,6 +513,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -491,6 +526,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -502,6 +538,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -513,6 +550,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec![],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -525,6 +563,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -536,6 +575,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -547,6 +587,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -558,6 +599,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -569,6 +611,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -580,6 +623,7 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
         },
     );
 
@@ -591,6 +635,35 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
             stdout: true,
             lint_args: vec!["--check".to_string()],
             format_args: vec![],
+            ..Default::default()
+        },
+    );
+
+    // Protobuf - buf
+    // buf format/lint require a real file path; stdin is not supported.
+    m.insert(
+        "buf:format",
+        ToolDefinition {
+            command: vec!["buf".to_string(), "format".to_string()],
+            stdin: false,
+            stdout: true,
+            // In lint mode, --exit-code makes buf format exit non-zero when
+            // the file is not already formatted.
+            lint_args: vec!["--exit-code".to_string()],
+            format_args: vec![],
+            temp_file_extension: Some("proto".to_string()),
+        },
+    );
+
+    m.insert(
+        "buf:lint",
+        ToolDefinition {
+            command: vec!["buf".to_string(), "lint".to_string()],
+            stdin: false,
+            stdout: true,
+            lint_args: vec![],
+            format_args: vec![],
+            temp_file_extension: Some("proto".to_string()),
         },
     );
 
@@ -625,6 +698,7 @@ mod tests {
                 stdout: false,
                 lint_args: vec![],
                 format_args: vec![],
+            ..Default::default()
             },
         );
 
@@ -707,6 +781,23 @@ mod tests {
 
         let tool = registry.get("oxfmt:ts").expect("Should find oxfmt:ts");
         assert!(tool.command.iter().any(|s| s.contains("_.ts")));
+
+        // buf
+        let tool = registry.get("buf:format").expect("Should find buf:format");
+        assert_eq!(tool.command, vec!["buf", "format"]);
+        assert!(!tool.stdin);
+        assert!(tool.stdout);
+        assert_eq!(tool.temp_file_extension.as_deref(), Some("proto"));
+        assert_eq!(tool.lint_args, vec!["--exit-code"]);
+        assert!(tool.format_args.is_empty());
+
+        let tool = registry.get("buf:lint").expect("Should find buf:lint");
+        assert_eq!(tool.command, vec!["buf", "lint"]);
+        assert!(!tool.stdin);
+        assert!(tool.stdout);
+        assert_eq!(tool.temp_file_extension.as_deref(), Some("proto"));
+        assert!(tool.lint_args.is_empty());
+        assert!(tool.format_args.is_empty());
     }
 
     // =========================================================================


### PR DESCRIPTION
This adds support for `buf` via a tempfile workaround, due to `buf` not supporting stdin for inputs (bufbuild/buf#1035).

Open to suggestions / closing out of this PR if the complexity is not desired; I'm not super familiar with Rust and had `claude` take a shot at this. In particular, the tempfile handling looks a little complex.

Related to #381.