### PR TITLE
docs(readme): fix broken rules documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ rumdl implements 71 lint rules for Markdown files. Here are some key rule catego
 | **Images**     | Image alt text and references            | MD045, MD052        |
 | **Style**      | Consistent style across document         | MD031, MD032, MD035 |
 
-For a complete list of rules and their descriptions, see our [documentation](https://rumdl.dev/rules/) or run:
+For a complete list of rules and their descriptions, see our [documentation](https://rumdl.dev/RULES/) or run:
 
 ```bash
 rumdl rule


### PR DESCRIPTION
## Description

- The README has a link to https://rumdl.dev/rules/ for rules documentation, but that URL returns a 404
- The correct URL is https://rumdl.dev/RULES/ (uppercase), as seen in the header section
  https://github.com/rvben/rumdl/blob/717c12ced0042eac2d68dc0948875d3f7001c293/README.md?plain=1#L19

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [ ] Tests added/updated
- [ ] All tests passing (`make test-dev`)
- [x] Manual testing performed
    - Manually confirmed the respective URLs

## Checklist

- [ ] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [x] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)