### PR TITLE
docs: direct Sublime Text users to LSP for Sublime Text documentation

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -120,21 +120,10 @@ Add to your Zed settings:
 }
 ```
 
-### Sublime Text (LSP package)
+### Sublime Text
 
-Add to LSP settings (`Preferences > Package Settings > LSP > Settings`):
-
-```json
-{
-  "clients": {
-    "rumdl": {
-      "enabled": true,
-      "command": ["rumdl", "server"],
-      "selector": "text.html.markdown"
-    }
-  }
-}
-```
+For information on configuring Sublime Text with rumdl as a language server, see the
+[LSP for Sublime Text documentation](https://lsp.sublimetext.io/language_servers/#rumdl).
 
 ### Emacs (lsp-mode)
 


### PR DESCRIPTION
With https://github.com/sublimelsp/LSP/pull/2842 merged, the documentation at https://lsp.sublimetext.io can serve as the source of truth for configuring Sublime Text with rumdl as a language server.