### PR TITLE
docs: Use `--silent` instead of `--quiet` to avoid diagnostic lines being inserted 

### DIFF
--- a/docs/usage/editors.md
+++ b/docs/usage/editors.md
@@ -74,10 +74,10 @@ let g:ale_fixers = {'markdown': ['rumdl']}
 
 ```vim
 " Format selection
-:'<,'>!rumdl fmt - --quiet
+:'<,'>!rumdl fmt - --silent
 
 " Format entire buffer
-:%!rumdl fmt - --quiet
+:%!rumdl fmt - --silent
 ```
 
 ## Helix
@@ -153,7 +153,7 @@ The server communicates via stdin/stdout using the Language Server Protocol.
 Most editors can be configured to format on save using rumdl's stdin/stdout mode:
 
 ```bash
-rumdl fmt - --quiet
+rumdl fmt - --silent
 ```
 
 This reads from stdin and outputs formatted content to stdout.


### PR DESCRIPTION
When I run with `--quiet` I get diagnostic lines like these inserted into my buffer under the visual selection:

```
<stdin>:2:1: [MD013] Line length 269 exceeds 72 characters [fixed]
<stdin>:2:1: [MD041] First line in file should be a level 1 heading
```

Using `--silent` instead just reformats the selection without inserting such diagnostic lines (as expected).