### PR TITLE
fix: edit_uri should be main not master

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -13,6 +13,7 @@ Copyright &copy; 2024-2026 Ruben Jongejan
 
 # Repository settings for edit links
 repo_url = "https://github.com/rvben/rumdl"
+edit_uri = "blob/main/docs/"
 repo_name = "rvben/rumdl"
 
 # Navigation structure - references existing files directly


### PR DESCRIPTION
The old mkdocs defaults to master and zensical is still respecting that, so right now on rumdl.dev none of the GitHub action links work

cf https://github.com/zensical/zensical/issues/321 and https://github.com/zensical/backlog/issues/93