### PR TITLE
fix(MD013): keep closing quote with parenthetical splits

### DIFF
--- a/src/utils/text_reflow.rs
+++ b/src/utils/text_reflow.rs
@@ -1687,15 +1687,17 @@ fn split_at_parenthetical(
         && let Some((end_local, inner)) = paren_group_end(text, element_spans, 0)
         && inner.contains(' ')
     {
-        // If clause punctuation immediately follows the closing ')', attach it
-        // to the parenthetical so the continuation line does not start with a
-        // bare comma or semicolon (e.g., "(foo, bar), then" → "(foo, bar),"
-        // on one line and "then" on the next).
+        // If closing quotes or clause punctuation immediately follow the closing
+        // ')', attach them to the parenthetical so the continuation line does
+        // not start with a bare quote, comma, or semicolon.
         let tail = &text[end_local..];
-        let (first_end, rest_start) = match tail.chars().next() {
-            Some(c) if is_clause_punctuation(c) => (end_local + c.len_utf8(), end_local + c.len_utf8()),
-            _ => (end_local, end_local),
-        };
+        let attached_len = tail
+            .char_indices()
+            .take_while(|(_, c)| is_closing_quote(*c) || is_clause_punctuation(*c))
+            .last()
+            .map_or(0, |(idx, c)| idx + c.len_utf8());
+        let first_end = end_local + attached_len;
+        let rest_start = first_end;
         let first = &text[..first_end];
         let first_len = display_len(first, length_mode);
         // No MIN_SPLIT_RATIO check: a parenthetical unit is always a valid

--- a/tests/utils/text_reflow_test.rs
+++ b/tests/utils/text_reflow_test.rs
@@ -88,6 +88,27 @@ fn test_preserve_links() {
 }
 
 #[test]
+fn test_reflow_keeps_closing_quote_with_parenthetical_placeholder() {
+    let options = ReflowOptions {
+        line_length: 80,
+        semantic_line_breaks: true,
+        ..Default::default()
+    };
+
+    let input = "The toolbar surfaces the action with a hint of the form \"Retry (may still fail — check: <provider-specific remediation hint>)\" for delayed failures.";
+    let result = reflow_markdown(input, &options);
+
+    assert!(
+        result.contains("<provider-specific remediation hint>)\""),
+        "closing quote should stay attached to the parenthetical placeholder:\n{result}"
+    );
+    assert!(
+        !result.contains("\n\" for delayed"),
+        "reflow should not move the closing quote to its own continuation line:\n{result}"
+    );
+}
+
+#[test]
 fn test_reference_link_patterns_fixed() {
     let options = ReflowOptions {
         line_length: 80,


### PR DESCRIPTION
## Description

Fixes MD013 semantic reflow so closing quotes immediately after a parenthetical split stay attached to the parenthetical text. This avoids producing continuation lines that begin with a stray quote.

The implementation extends the existing parenthetical split handling to attach closing quotes as well as clause punctuation after the closing parenthesis.

The regression test and bug fix were created in cooperation with Codex.

Fixes: #600

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [ ] Manual testing performed

Added regression test:

- `test_reflow_keeps_closing_quote_with_parenthetical_placeholder`

Validated locally:

```bash
make test-dev
make fmt
make lint
```

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)
