### PR TITLE
fix(MD013): preserve BDD step boundaries during reflow

### DIFF
--- a/src/utils/text_reflow.rs
+++ b/src/utils/text_reflow.rs
@@ -438,6 +438,13 @@ fn is_unordered_list_marker(s: &str) -> bool {
         && (s.len() == 1 || s.as_bytes().get(1) == Some(&b' '))
 }
 
+/// Check if a trimmed line starts with a bold BDD/Gherkin step keyword.
+fn is_bdd_step_line(s: &str) -> bool {
+    ["**Given**", "**When**", "**Then**", "**And**", "**But**"]
+        .iter()
+        .any(|keyword| s.starts_with(keyword))
+}
+
 /// Shared structural checks for block boundary detection.
 /// Checks elements that only depend on the trimmed line content.
 fn is_block_boundary_core(trimmed: &str) -> bool {
@@ -450,6 +457,7 @@ fn is_block_boundary_core(trimmed: &str) -> bool {
         || is_horizontal_rule(trimmed)
         || is_unordered_list_marker(trimmed)
         || is_numbered_list_item(trimmed)
+        || is_bdd_step_line(trimmed)
         || is_definition_list_item(trimmed)
         || trimmed.starts_with(":::")
 }

--- a/tests/utils/text_reflow_test.rs
+++ b/tests/utils/text_reflow_test.rs
@@ -88,6 +88,41 @@ fn test_preserve_links() {
 }
 
 #[test]
+fn test_reflow_preserves_bdd_step_line_boundaries() {
+    let options = ReflowOptions {
+        line_length: 80,
+        semantic_line_breaks: true,
+        ..Default::default()
+    };
+
+    let input = "\
+### Scenario: Preserve line-oriented steps
+
+**Given** a customer account has an active subscription with several linked devices
+**When** the operator disables access for one linked device from the support console
+**Then** the audit trail records the device-specific access change without changing other devices
+";
+    let result = reflow_markdown(input, &options);
+
+    assert!(
+        result.contains("\n**Given**"),
+        "Given step should remain at the start of its own line:\n{result}"
+    );
+    assert!(
+        result.contains("\n**When**"),
+        "When step should remain at the start of its own line:\n{result}"
+    );
+    assert!(
+        result.contains("\n**Then**"),
+        "Then step should remain at the start of its own line:\n{result}"
+    );
+    assert!(
+        !result.contains("devices **When**"),
+        "Step boundaries must not be collapsed into one paragraph:\n{result}"
+    );
+}
+
+#[test]
 fn test_reference_link_patterns_fixed() {
     let options = ReflowOptions {
         line_length: 80,


### PR DESCRIPTION
## Description

Fixes MD013 semantic reflow so bold BDD/Gherkin-style step lines are treated as block boundaries. This keeps `**Given**`, `**When**`, `**Then**`, `**And**`, and `**But**` steps from being merged into surrounding paragraph text.

The regression test and bug fix were created in cooperation with Codex.

Fixes: #599

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [ ] Manual testing performed

Added regression test:

- `test_reflow_preserves_bdd_step_line_boundaries`

Validated locally:

```bash
make test-dev
make fmt
make lint
```

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)
