### PR TITLE
fix(MD013): preserve wildcard asterisks during reflow

### DIFF
--- a/src/utils/text_reflow.rs
+++ b/src/utils/text_reflow.rs
@@ -1350,6 +1350,14 @@ fn parse_markdown_elements_inner(text: &str, attr_lists: bool) -> Vec<Element> {
     elements
 }
 
+fn should_insert_space_before_join(current: &str) -> bool {
+    !current.is_empty()
+        && !current.ends_with(' ')
+        && !current.ends_with('(')
+        && !current.ends_with('[')
+        && !current.ends_with('-')
+}
+
 /// Reflow elements for sentence-per-line mode
 fn reflow_elements_sentence_per_line(
     elements: &[Element],
@@ -1471,12 +1479,7 @@ fn reflow_elements_sentence_per_line(
             };
 
             // Add space before element if needed, but not for adjacent elements
-            if !is_adjacent
-                && !current_line.is_empty()
-                && !current_line.ends_with(' ')
-                && !current_line.ends_with('(')
-                && !current_line.ends_with('[')
-            {
+            if !is_adjacent && should_insert_space_before_join(&current_line) {
                 current_line.push(' ');
             }
             current_line.push_str(&element_str);
@@ -1504,12 +1507,7 @@ fn handle_emphasis_sentence_split(
 
     if sentences.len() <= 1 {
         // Single sentence or no boundaries - treat as atomic
-        if !current_line.is_empty()
-            && !current_line.ends_with(' ')
-            && !current_line.ends_with('(')
-            && !current_line.ends_with('[')
-            && !current_line.ends_with('-')
-        {
+        if should_insert_space_before_join(current_line) {
             current_line.push(' ');
         }
         current_line.push_str(marker);
@@ -1533,12 +1531,7 @@ fn handle_emphasis_sentence_split(
 
             if i == 0 {
                 // First sentence: combine with current_line and emit
-                if !current_line.is_empty()
-                    && !current_line.ends_with(' ')
-                    && !current_line.ends_with('(')
-                    && !current_line.ends_with('[')
-                    && !current_line.ends_with('-')
-                {
+                if should_insert_space_before_join(current_line) {
                     current_line.push(' ');
                 }
                 current_line.push_str(marker);

--- a/src/utils/text_reflow.rs
+++ b/src/utils/text_reflow.rs
@@ -1508,6 +1508,7 @@ fn handle_emphasis_sentence_split(
             && !current_line.ends_with(' ')
             && !current_line.ends_with('(')
             && !current_line.ends_with('[')
+            && !current_line.ends_with('-')
         {
             current_line.push(' ');
         }
@@ -1536,6 +1537,7 @@ fn handle_emphasis_sentence_split(
                     && !current_line.ends_with(' ')
                     && !current_line.ends_with('(')
                     && !current_line.ends_with('[')
+                    && !current_line.ends_with('-')
                 {
                     current_line.push(' ');
                 }

--- a/tests/utils/text_reflow_test.rs
+++ b/tests/utils/text_reflow_test.rs
@@ -109,6 +109,27 @@ fn test_reflow_keeps_closing_quote_with_parenthetical_placeholder() {
 }
 
 #[test]
+fn test_reflow_preserves_literal_wildcard_asterisks() {
+    let options = ReflowOptions {
+        line_length: 80,
+        semantic_line_breaks: true,
+        ..Default::default()
+    };
+
+    let input = "- **Catalog layout.** Reference files live under `docs/items/<name>/` (`README.md`, `notes.md`, `checks.md`) and `examples/items/<name>.md`. IDs (TICKET-*, TASK-*, CASE-*) stay in the shared namespace: TICKET-17 is still called TICKET-17 inside the nested catalog.";
+    let result = reflow_markdown(input, &options);
+
+    assert!(
+        result.contains("TICKET-*"),
+        "literal wildcard ID should be preserved during reflow:\n{result}"
+    );
+    assert!(
+        !result.contains("TICKET- *"),
+        "reflow should not insert whitespace before a literal wildcard asterisk:\n{result}"
+    );
+}
+
+#[test]
 fn test_reference_link_patterns_fixed() {
     let options = ReflowOptions {
         line_length: 80,


### PR DESCRIPTION
## Description

Fixes MD013 semantic reflow so the emphasis sentence-split path does not insert a space after a hyphen before a literal wildcard asterisk. This preserves identifiers like `TICKET-*` during reflow.

The regression test and bug fix were created in cooperation with Codex.

Fixes: #597

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [ ] Manual testing performed

Added regression test:

- `test_reflow_preserves_literal_wildcard_asterisks`

Validated locally:

```bash
make test-dev
make fmt
make lint
```

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)
