### PR TITLE
fix(MD038): preserve spaces around nested backticks

### DIFF
--- a/src/rules/md038_no_space_in_code.rs
+++ b/src/rules/md038_no_space_in_code.rs
@@ -205,6 +205,26 @@ impl MD038NoSpaceInCode {
 
         false
     }
+
+    /// Check for a CommonMark parse shape produced by nested single backticks.
+    ///
+    /// In text like `` `{ outer `inner` outer }` ``, CommonMark sees two adjacent
+    /// code spans rather than one nested span. Removing the apparent leading or
+    /// trailing space from those parsed spans moves prose across the inner
+    /// backticks and changes the rendered text.
+    fn has_attached_nested_backtick_boundary(
+        &self,
+        ctx: &crate::lint_context::LintContext,
+        code_span: &crate::lint_context::CodeSpan,
+    ) -> bool {
+        let content = code_span.content.as_str();
+
+        let next_char = ctx.content[code_span.byte_end..].chars().next();
+        let prev_char = ctx.content[..code_span.byte_offset].chars().next_back();
+
+        (content.ends_with(char::is_whitespace) && next_char.is_some_and(|c| !c.is_whitespace()))
+            || (content.starts_with(char::is_whitespace) && prev_char.is_some_and(|c| !c.is_whitespace()))
+    }
 }
 
 impl Rule for MD038NoSpaceInCode {
@@ -320,6 +340,10 @@ impl Rule for MD038NoSpaceInCode {
                 // Check if this might be part of a nested backtick structure
                 // by looking for other code spans nearby that might indicate nesting
                 if self.is_likely_nested_backticks(ctx, i) {
+                    continue;
+                }
+
+                if self.has_attached_nested_backtick_boundary(ctx, code_span) {
                     continue;
                 }
 

--- a/tests/rules/md038_test.rs
+++ b/tests/rules/md038_test.rs
@@ -85,3 +85,17 @@ fn test_code_with_punctuation() {
     let result = rule.check(&ctx).unwrap();
     assert!(result.is_empty(), "Single space at both ends is valid CommonMark");
 }
+
+#[test]
+fn test_nested_backticks_do_not_lose_boundary_spaces() {
+    let rule = MD038NoSpaceInCode::new();
+    let content = "Schema example: `{ kind, mode, label (same enum as `Widget.mode` per MODEL-12) }`.";
+    let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let fixed = rule.fix(&ctx).unwrap();
+
+    assert_eq!(
+        fixed, content,
+        "MD038 should not remove spaces around backticks that appear to be nested inside a larger code-like span"
+    );
+}


### PR DESCRIPTION
## Description

Fixes MD038 so it skips a CommonMark parse shape produced by nested single backticks inside a larger code-like span. In this case, removing apparent leading or trailing spaces changes the rendered text, so the fixer should leave the content unchanged.

The regression test and bug fix were created in cooperation with Codex.

Fixes: #596

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [ ] Manual testing performed

Added regression test:

- `test_nested_backticks_do_not_lose_boundary_spaces`

Validated locally:

```bash
make test-dev
make fmt
make lint
```

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)
