### PR TITLE
fix(code-block-tools): use yamlfmt lint mode for YAML

### DIFF
--- a/src/code_block_tools/registry.rs
+++ b/src/code_block_tools/registry.rs
@@ -615,6 +615,17 @@ mod tests {
     }
 
     #[test]
+    fn test_builtin_yamlfmt_lint_command_validates_stdin() {
+        let registry = ToolRegistry::default();
+
+        let tool = registry.get("yamlfmt").expect("Should find yamlfmt");
+        let mut argv = tool.command.clone();
+        argv.extend(tool.lint_args.clone());
+
+        assert_eq!(argv, vec!["yamlfmt", "-lint", "-"]);
+    }
+
+    #[test]
     fn test_get_user_tool_overrides_builtin() {
         let mut user_tools = HashMap::new();
         user_tools.insert(

--- a/src/code_block_tools/registry.rs
+++ b/src/code_block_tools/registry.rs
@@ -296,11 +296,11 @@ static BUILTIN_TOOLS: LazyLock<HashMap<&'static str, ToolDefinition>> = LazyLock
     m.insert(
         "yamlfmt",
         ToolDefinition {
-            command: vec!["yamlfmt".to_string(), "-".to_string()],
+            command: vec!["yamlfmt".to_string()],
             stdin: true,
             stdout: true,
-            lint_args: vec!["-dry".to_string()],
-            format_args: vec![],
+            lint_args: vec!["-lint".to_string(), "-".to_string()],
+            format_args: vec!["-".to_string()],
         },
     );
 


### PR DESCRIPTION
## Description

Fixes the built-in `yamlfmt` tool definition so linting uses `yamlfmt -lint -` for stdin validation, while formatting continues to pass stdin with `yamlfmt -`.

The regression test and bug fix were created in cooperation with Codex.

Fixes: #595

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [ ] Manual testing performed

Added regression test:

- `test_builtin_yamlfmt_lint_command_validates_stdin`

Validated locally:

```bash
make test-dev
make fmt
make lint
```

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)
