### PR TITLE
docs: update rumdl version referred in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ mise ls-remote rumdl
 mise install rumdl
 
 # Use a specific version for the project
-mise use rumdl@0.1.62
+mise use rumdl@0.1.91
 ```
 
 ### Using Nix (macOS/Linux)
@@ -353,7 +353,7 @@ Add the following to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.62
+    rev: v0.1.91
     hooks:
       - id: rumdl      # Lint only (fails on issues)
       - id: rumdl-fmt  # Auto-format and fail if issues remain
@@ -375,7 +375,7 @@ However, for pre-commit workflows where you want to include all files, even when
 ```yaml
 repos:
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.62
+    rev: v0.1.91
     hooks:
       - id: rumdl
         args: [--no-exclude]  # Disable all exclude patterns


### PR DESCRIPTION
## What was done

Ideally, the version of `rumdl` referred in the README should be the same as the latest version of the package.

This makes it easier, for example, for users to select the latest pre-commit version.

It would be nice to find a way to automate this.