### PR TITLE
docs: add azure_devops to default list of available markdown dialects

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -782,7 +782,7 @@ exclude = [
 respect-gitignore = true
 
 # Markdown flavor/dialect (uncomment to enable)
-# Options: standard (default), gfm, commonmark, mkdocs, mdx, quarto
+# Options: standard (default), gfm, commonmark, mkdocs, mdx, quarto, azure_devops
 # flavor = "mkdocs"
 
 # Rule-specific configurations (uncomment and modify as needed)


### PR DESCRIPTION
## What was done

When running `rumdl init` a default config file is generated.

Updating the comment so it is consistent with: https://rumdl.dev/global-settings/#flavor