### PR TITLE
feat(flavor): add support for MyST (Markedly Structured Text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ It offers:
 - 🛠️ **Automatic formatting** with `--fix` for files and stdin/stdout
 - 📦 **Zero dependencies** - single binary with no runtime requirements
 - 🔧 **Highly configurable** with TOML-based config files
-- 🎯 **Multiple Markdown flavors** - [GFM, MkDocs, MDX, Quarto](docs/flavors.md) support with auto-detection
+- 🎯 **Multiple Markdown flavors** - [GFM, MkDocs, MDX, Quarto, MyST](docs/flavors.md) support with auto-detection
 - 🌐 **Multiple installation options** - Rust, Python, standalone binaries
 - 🐍 **Installable via pip** for Python users
 - 📏 **Modern CLI** with detailed error reporting
@@ -519,6 +519,7 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 | [obsidian](docs/flavors/obsidian.md)         | Obsidian                     | Tag syntax (#tagname treated as tags, not headings) |
 | [kramdown](docs/flavors/kramdown.md)         | Jekyll / kramdown            | IALs, ALDs, extension blocks                        |
 | [azure_devops](docs/flavors/azure_devops.md) | Azure DevOps Wiki            | Colon code fences (:::lang ... :::)                 |
+| [myst](docs/flavors/myst.md)                 | MyST / Jupyter Book / Sphinx | Directives, roles, `%` comments                     |
 
 ### Configuring Flavors
 

--- a/docs/flavors.md
+++ b/docs/flavors.md
@@ -15,6 +15,7 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 | [quarto](flavors/quarto.md)             | Quarto / RMarkdown                   | MD022, MD029, MD031, MD032, MD034, MD037, MD038, MD040, MD042, MD049, MD050, MD051, MD052 |
 | [kramdown](flavors/kramdown.md)         | Jekyll / kramdown                    | MD022, MD041, MD051                                                                       |
 | [azure_devops](flavors/azure_devops.md) | Azure DevOps wikis                   | MD013, MD031, MD034, MD046, MD048                                                         |
+| [myst](flavors/myst.md)                 | MyST / Jupyter Book / Sphinx         | MD013, MD031, MD038, MD040, MD046, MD048                                                  |
 
 ## Configuration
 
@@ -66,6 +67,7 @@ The `standard` flavor includes CommonMark plus widely-adopted GFM extensions (ta
 - **[Quarto](flavors/quarto.md)** - Citations, shortcodes, div blocks, math blocks, executable code
 - **[Kramdown](flavors/kramdown.md)** - IALs, ALDs, extension blocks, kramdown anchor generation
 - **[Azure DevOps](flavors/azure_devops.md)** - Colon code fences (`:::mermaid … :::`) treated as opaque code blocks
+- **[MyST](flavors/myst.md)** - Directives (`:::{name}`, `` ```{name} ``), roles (`{role}`content``), `%` comments
 
 ## Adding Flavor Support
 

--- a/docs/flavors/myst.md
+++ b/docs/flavors/myst.md
@@ -1,0 +1,167 @@
+# MyST Flavor
+
+For projects using [MyST Markdown](https://mystmd.org/) (Markedly Structured Text) —
+the Markdown flavor used by Jupyter Book, Sphinx via MyST-Parser, and the MyST
+document engine.
+
+**Config name**: `myst`
+**Aliases**: `mystmd`
+
+## Supported Patterns
+
+### Colon Directives
+
+MyST uses `:::` (or more colons) as structural containers for directives:
+
+```markdown
+:::{note}
+This is a note admonition with **Markdown** content.
+:::
+```
+
+Nesting is supported by increasing the colon count:
+
+```markdown
+::::{warning}
+Outer directive.
+
+:::{tip}
+Inner directive.
+:::
+::::
+```
+
+The opener is 3+ colons immediately followed by `{name}` (e.g., `:::{note}`,
+`::::{warning}`). The closer is the same number of colons (or more) without a
+`{name}` suffix.
+
+**Treated as Markdown content**: The body of colon directives is linted as
+normal Markdown prose. Rules that check prose (MD013, MD034, link validation)
+still fire inside colon directives.
+
+### Backtick Directives
+
+MyST also uses backtick code fences with a `{name}` info string:
+
+````markdown
+```{note}
+This is also a note directive.
+```
+````
+
+For **content-bearing directives** (note, warning, tip, hint, important,
+caution, danger, admonition, seealso, topic, sidebar, margin, exercise,
+solution, dropdown, tab-item, grid, card, figure), the body is linted as
+Markdown — `in_code_block` is cleared.
+
+For **code-bearing directives** (code-cell, code-block, raw, eval-rst,
+literalinclude), the body remains treated as a code block and is not linted.
+
+### Directive Options
+
+Directives can have options specified as `:key: value` lines immediately after
+the opener:
+
+````markdown
+```{figure} image.png
+:alt: An image description
+:width: 80%
+
+Caption text with **Markdown** formatting.
+```
+````
+
+Option lines are part of the directive and are not linted as prose.
+
+### Roles (Inline Directives)
+
+MyST roles provide inline semantic markup:
+
+```markdown
+See {ref}`my-label` for details.
+The equation {math}`E=mc^2` is famous.
+```
+
+The pattern is `{rolename}` followed by backtick-delimited content. These are
+not flagged as malformed inline code.
+
+### Comments
+
+MyST uses `%` for single-line comments:
+
+```markdown
+% This is a comment that won't appear in output.
+Regular paragraph text.
+```
+
+Comment lines are excluded from line-length checks.
+
+## Rule Behavior Changes
+
+| Rule  | Standard Behavior                   | MyST Behavior                                                  |
+| ----- | ----------------------------------- | -------------------------------------------------------------- |
+| MD013 | Check line length everywhere        | Skip `%` comment lines                                         |
+| MD031 | Blanks around backtick/tilde fences | Also enforce blanks around colon directives (`:::{name}`)      |
+| MD038 | Flag spaces in inline code          | Skip role syntax (`{role}`content``)                           |
+| MD040 | Require language on code fences     | Accept `{name}` as valid directive info string                 |
+| MD046 | Detect code block style             | Skip colon directives from style detection                     |
+| MD048 | Detect fence style                  | Skip colon/backtick directives from fence style detection      |
+
+## Content vs Code Directives
+
+rumdl distinguishes between directives whose body contains Markdown and those
+whose body contains code:
+
+| Category | Directives                                                                                                     | Body linted? |
+| -------- | -------------------------------------------------------------------------------------------------------------- | ------------ |
+| Content  | note, warning, tip, hint, important, caution, danger, admonition, seealso, topic, sidebar, margin, exercise, solution, dropdown, tab-item, grid, card, figure | Yes          |
+| Code     | code-cell, code-block, raw, eval-rst, literalinclude                                                           | No           |
+
+Unrecognized directive names default to code-block behavior (body not linted).
+
+## Configuration
+
+```toml
+[global]
+flavor = "myst"
+```
+
+Or using the alias:
+
+```toml
+[global]
+flavor = "mystmd"
+```
+
+Or per-file:
+
+```toml
+[per-file-flavor]
+"docs/**/*.md" = "myst"
+```
+
+## CLI Usage
+
+```bash
+rumdl check --flavor myst docs/
+rumdl check --flavor mystmd docs/
+```
+
+## When to Use
+
+Use the MyST flavor when:
+
+- You write Markdown for Jupyter Book or Sphinx with MyST-Parser.
+- Your files contain `:::{directive}` or `` ```{directive} `` blocks.
+- You use role syntax like `{ref}`label`` or `{math}`expression``.
+- You are getting false positives from MD040 (missing language) on directive fences.
+
+Do **not** use this flavor for Pandoc projects — Pandoc uses `:::` with
+different semantics (fenced divs without `{name}`). Use
+[pandoc](pandoc.md) for Pandoc projects.
+
+## See Also
+
+- [Flavors Overview](../flavors.md) — compare all flavors
+- [Pandoc Flavor](pandoc.md) — Pandoc fenced divs (transparent `:::` blocks)
+- [MyST Markdown documentation](https://mystmd.org/guide)

--- a/rumdl.schema.json
+++ b/rumdl.schema.json
@@ -189,7 +189,7 @@
       "minimum": 0
     },
     "MarkdownFlavor": {
-      "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops.",
+      "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops, mystmd maps to myst.",
       "type": "string",
       "enum": [
         "standard",
@@ -208,7 +208,9 @@
         "jekyll",
         "azure_devops",
         "azure",
-        "ado"
+        "ado",
+        "myst",
+        "mystmd"
       ]
     },
     "CodeBlockToolsConfig": {

--- a/src/cli_types.rs
+++ b/src/cli_types.rs
@@ -167,7 +167,7 @@ pub struct CheckArgs {
     #[arg(
         long,
         value_enum,
-        help = "Markdown flavor to use: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, or azure_devops (also accepts azure/ado)"
+        help = "Markdown flavor to use: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops (also accepts azure/ado), or myst (also accepts mystmd)"
     )]
     pub flavor: Option<Flavor>,
 
@@ -415,6 +415,8 @@ pub enum Flavor {
     Kramdown,
     #[value(name = "azure_devops", aliases(["azure", "ado"]))]
     AzureDevOps,
+    #[value(name = "myst", alias("mystmd"))]
+    MyST,
 }
 
 impl From<Flavor> for rumdl_lib::config::MarkdownFlavor {
@@ -428,6 +430,7 @@ impl From<Flavor> for rumdl_lib::config::MarkdownFlavor {
             Flavor::Obsidian => Self::Obsidian,
             Flavor::Kramdown => Self::Kramdown,
             Flavor::AzureDevOps => Self::AzureDevOps,
+            Flavor::MyST => Self::MyST,
         }
     }
 }

--- a/src/config/flavor.rs
+++ b/src/config/flavor.rs
@@ -46,14 +46,17 @@ pub enum MarkdownFlavor {
     /// Azure DevOps flavor — treats `:::lang` blocks as opaque code fences
     #[serde(rename = "azure_devops", alias = "azure", alias = "ado")]
     AzureDevOps,
+    /// MyST (Markedly Structured Text) flavor — directives, roles, dollar math, % comments
+    #[serde(rename = "myst", alias = "mystmd")]
+    MyST,
 }
 
 /// Custom JSON schema for MarkdownFlavor that includes all accepted values and aliases
 fn markdown_flavor_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({
-        "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops.",
+        "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops, mystmd maps to myst.",
         "type": "string",
-        "enum": ["standard", "gfm", "github", "commonmark", "mkdocs", "mdx", "pandoc", "quarto", "qmd", "rmd", "rmarkdown", "obsidian", "kramdown", "jekyll", "azure_devops", "azure", "ado"]
+        "enum": ["standard", "gfm", "github", "commonmark", "mkdocs", "mdx", "pandoc", "quarto", "qmd", "rmd", "rmarkdown", "obsidian", "kramdown", "jekyll", "azure_devops", "azure", "ado", "myst", "mystmd"]
     })
 }
 
@@ -78,6 +81,7 @@ impl fmt::Display for MarkdownFlavor {
             MarkdownFlavor::Obsidian => write!(f, "obsidian"),
             MarkdownFlavor::Kramdown => write!(f, "kramdown"),
             MarkdownFlavor::AzureDevOps => write!(f, "azure_devops"),
+            MarkdownFlavor::MyST => write!(f, "myst"),
         }
     }
 }
@@ -95,6 +99,7 @@ impl FromStr for MarkdownFlavor {
             "obsidian" => Ok(MarkdownFlavor::Obsidian),
             "kramdown" | "jekyll" => Ok(MarkdownFlavor::Kramdown),
             "azure_devops" | "azure" | "ado" => Ok(MarkdownFlavor::AzureDevOps),
+            "myst" | "mystmd" => Ok(MarkdownFlavor::MyST),
             // GFM and CommonMark are aliases for Standard since the base parser
             // (pulldown-cmark) already supports GFM extensions (tables, task lists,
             // strikethrough, autolinks, etc.) which are a superset of CommonMark
@@ -174,12 +179,28 @@ impl MarkdownFlavor {
             Self::Obsidian => "Obsidian",
             Self::Kramdown => "Kramdown",
             Self::AzureDevOps => "AzureDevOps",
+            Self::MyST => "MyST",
         }
     }
 
     /// True only for Azure DevOps flavor, which uses `:::lang` as a code fence.
     pub fn supports_colon_code_fences(self) -> bool {
         matches!(self, Self::AzureDevOps)
+    }
+
+    /// True for MyST flavor — supports directive syntax (backtick and colon fences with `{name}`)
+    pub fn supports_myst_directives(self) -> bool {
+        matches!(self, Self::MyST)
+    }
+
+    /// True for MyST flavor — supports role syntax (`{role}`content``)
+    pub fn supports_myst_roles(self) -> bool {
+        matches!(self, Self::MyST)
+    }
+
+    /// True for MyST flavor — supports `%` line comments
+    pub fn supports_myst_comments(self) -> bool {
+        matches!(self, Self::MyST)
     }
 }
 
@@ -222,6 +243,7 @@ mod tests {
             (MarkdownFlavor::Obsidian, "obsidian"),
             (MarkdownFlavor::Kramdown, "kramdown"),
             (MarkdownFlavor::AzureDevOps, "azure_devops"),
+            (MarkdownFlavor::MyST, "myst"),
         ];
         for (variant, expected) in cases {
             let displayed = variant.to_string();
@@ -250,6 +272,7 @@ mod tests {
             MarkdownFlavor::Obsidian,
             MarkdownFlavor::Kramdown,
             MarkdownFlavor::AzureDevOps,
+            MarkdownFlavor::MyST,
         ];
         for variant in variants {
             let displayed = variant.to_string();
@@ -325,6 +348,7 @@ mod tests {
         assert!(!MarkdownFlavor::Quarto.supports_colon_code_fences());
         assert!(!MarkdownFlavor::Obsidian.supports_colon_code_fences());
         assert!(!MarkdownFlavor::Kramdown.supports_colon_code_fences());
+        assert!(!MarkdownFlavor::MyST.supports_colon_code_fences());
     }
 
     #[test]
@@ -336,5 +360,38 @@ mod tests {
     fn test_display_all_variants_covers_azure_devops() {
         let displayed = MarkdownFlavor::AzureDevOps.to_string();
         assert!(displayed.chars().all(|c| !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn test_myst_from_str() {
+        assert_eq!("myst".parse::<MarkdownFlavor>().unwrap(), MarkdownFlavor::MyST);
+        assert_eq!("MYST".parse::<MarkdownFlavor>().unwrap(), MarkdownFlavor::MyST);
+        assert_eq!("mystmd".parse::<MarkdownFlavor>().unwrap(), MarkdownFlavor::MyST);
+    }
+
+    #[test]
+    fn test_myst_display_and_round_trip() {
+        assert_eq!(MarkdownFlavor::MyST.to_string(), "myst");
+        let parsed: MarkdownFlavor = "myst".parse().unwrap();
+        assert_eq!(parsed, MarkdownFlavor::MyST);
+    }
+
+    #[test]
+    fn test_myst_capabilities() {
+        assert!(MarkdownFlavor::MyST.supports_myst_directives());
+        assert!(MarkdownFlavor::MyST.supports_myst_roles());
+        assert!(MarkdownFlavor::MyST.supports_myst_comments());
+        assert!(!MarkdownFlavor::MyST.is_pandoc_compatible());
+        assert!(!MarkdownFlavor::MyST.supports_colon_code_fences());
+        assert!(!MarkdownFlavor::MyST.supports_jsx());
+
+        assert!(!MarkdownFlavor::Standard.supports_myst_directives());
+        assert!(!MarkdownFlavor::Standard.supports_myst_roles());
+        assert!(!MarkdownFlavor::Standard.supports_myst_comments());
+    }
+
+    #[test]
+    fn test_myst_name() {
+        assert_eq!(MarkdownFlavor::MyST.name(), "MyST");
     }
 }

--- a/src/config/parsers.rs
+++ b/src/config/parsers.rs
@@ -264,7 +264,7 @@ pub(super) fn parse_pyproject_toml(
                     per_file_map.insert(pattern.clone(), flavor);
                 } else {
                     log::warn!(
-                        "[WARN] Invalid flavor for per-file-flavor pattern '{pattern}' in {display_path}, found {flavor_value:?}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops"
+                        "[WARN] Invalid flavor for per-file-flavor pattern '{pattern}' in {display_path}, found {flavor_value:?}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst"
                     );
                 }
             }
@@ -859,7 +859,7 @@ pub(super) fn parse_rumdl_toml(
                     }
                     Err(_) => {
                         log::warn!(
-                            "[WARN] Invalid flavor '{flavor_str}' for pattern '{pattern}' in {display_path}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops"
+                            "[WARN] Invalid flavor '{flavor_str}' for pattern '{pattern}' in {display_path}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst"
                         );
                     }
                 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -782,7 +782,7 @@ exclude = [
 respect-gitignore = true
 
 # Markdown flavor/dialect (uncomment to enable)
-# Options: standard (default), gfm, commonmark, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops
+# Options: standard (default), gfm, commonmark, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst
 # flavor = "mkdocs"
 
 # Rule-specific configurations (uncomment and modify as needed)

--- a/src/lint_context/flavor_detection.rs
+++ b/src/lint_context/flavor_detection.rs
@@ -1032,11 +1032,7 @@ fn myst_colon_directive_opener(line: &str) -> Option<usize> {
     }
     let after_colons = &rest[colon_count..];
     if after_colons.starts_with('{') && after_colons.contains('}') {
-        let name = after_colons
-            .trim_start_matches('{')
-            .split('}')
-            .next()
-            .unwrap_or("");
+        let name = after_colons.trim_start_matches('{').split('}').next().unwrap_or("");
         if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_') {
             return Some(colon_count);
         }
@@ -1145,14 +1141,47 @@ pub(super) fn detect_myst_comments(
 
 /// Known MyST content-bearing directives whose body should be linted as markdown.
 const MYST_CONTENT_DIRECTIVES: &[&str] = &[
-    "note", "warning", "tip", "hint", "important", "caution", "danger",
-    "admonition", "attention", "error", "seealso", "topic", "sidebar",
-    "margin", "exercise", "solution", "dropdown", "tab-item", "grid",
-    "card", "tab-set", "toggle", "proof", "prf:proof", "prf:theorem",
-    "prf:lemma", "prf:definition", "prf:criterion", "prf:remark",
-    "prf:conjecture", "prf:corollary", "prf:algorithm", "prf:example",
-    "prf:property", "prf:observation", "prf:proposition", "prf:assumption",
-    "figure", "table", "list-table", "csv-table",
+    "note",
+    "warning",
+    "tip",
+    "hint",
+    "important",
+    "caution",
+    "danger",
+    "admonition",
+    "attention",
+    "error",
+    "seealso",
+    "topic",
+    "sidebar",
+    "margin",
+    "exercise",
+    "solution",
+    "dropdown",
+    "tab-item",
+    "grid",
+    "card",
+    "tab-set",
+    "toggle",
+    "proof",
+    "prf:proof",
+    "prf:theorem",
+    "prf:lemma",
+    "prf:definition",
+    "prf:criterion",
+    "prf:remark",
+    "prf:conjecture",
+    "prf:corollary",
+    "prf:algorithm",
+    "prf:example",
+    "prf:property",
+    "prf:observation",
+    "prf:proposition",
+    "prf:assumption",
+    "figure",
+    "table",
+    "list-table",
+    "csv-table",
 ];
 
 /// Check if a MyST directive name is content-bearing (body is markdown, not code).
@@ -1218,8 +1247,8 @@ pub(super) fn detect_myst_backtick_directives(
                 let trimmed = line_content.trim();
 
                 // Check if this is the closing fence line
-                let is_closer = trimmed.starts_with("```")
-                    && trimmed.chars().skip(3).all(|c| c == '`' || c.is_whitespace());
+                let is_closer =
+                    trimmed.starts_with("```") && trimmed.chars().skip(3).all(|c| c == '`' || c.is_whitespace());
                 if is_closer {
                     lines[i].in_myst_directive = true;
                     lines[i].in_code_block = false;
@@ -1250,11 +1279,10 @@ pub(super) fn detect_myst_backtick_directives(
             }
         } else {
             // Code-bearing directive: mark opener/closer as directive but keep in_code_block
-            if end_line_idx > 0 {
-                if let Some(closer_line) = lines.get_mut(end_line_idx - 1) {
+            if end_line_idx > 0
+                && let Some(closer_line) = lines.get_mut(end_line_idx - 1) {
                     closer_line.in_myst_directive = true;
                 }
-            }
         }
     }
 }
@@ -1413,7 +1441,10 @@ mod myst_tests {
         let ctx = myst_ctx(content);
         assert!(ctx.lines[0].in_myst_directive);
         assert!(ctx.lines[1].in_myst_directive);
-        assert!(!ctx.lines[1].in_code_block, "content directive body should not be in_code_block");
+        assert!(
+            !ctx.lines[1].in_code_block,
+            "content directive body should not be in_code_block"
+        );
     }
 
     #[test]
@@ -1421,7 +1452,10 @@ mod myst_tests {
         let content = "```{code-cell} python\nprint('hello')\n```\n";
         let ctx = myst_ctx(content);
         assert!(ctx.lines[0].in_myst_directive);
-        assert!(ctx.lines[1].in_code_block, "code directive body should remain in_code_block");
+        assert!(
+            ctx.lines[1].in_code_block,
+            "code directive body should remain in_code_block"
+        );
     }
 
     #[test]

--- a/src/lint_context/flavor_detection.rs
+++ b/src/lint_context/flavor_detection.rs
@@ -1009,3 +1009,433 @@ mod colon_fence_tests {
         );
     }
 }
+
+// ============================================================================
+// MyST Markdown Detection
+// ============================================================================
+
+/// Check if a line is a MyST colon directive opener.
+/// Pattern: 0-3 leading spaces, 3+ colons, immediately followed by `{name}`.
+/// Returns the colon count if it's an opener, None otherwise.
+fn myst_colon_directive_opener(line: &str) -> Option<usize> {
+    let spaces = count_leading_spaces(line);
+    if spaces > 3 {
+        return None;
+    }
+    let rest = &line[spaces..];
+    if rest.starts_with('\t') {
+        return None;
+    }
+    let colon_count = rest.bytes().take_while(|&b| b == b':').count();
+    if colon_count < 3 {
+        return None;
+    }
+    let after_colons = &rest[colon_count..];
+    if after_colons.starts_with('{') && after_colons.contains('}') {
+        let name = after_colons
+            .trim_start_matches('{')
+            .split('}')
+            .next()
+            .unwrap_or("");
+        if !name.is_empty() && name.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_') {
+            return Some(colon_count);
+        }
+    }
+    None
+}
+
+/// Detect MyST colon fence directives (`:::{name} ... :::`) and mark their
+/// lines as `in_myst_directive`. Returns byte ranges for each detected directive.
+///
+/// Supports nesting: outer directives use more colons than inner ones.
+pub(super) fn detect_myst_colon_directives(
+    content: &str,
+    lines: &mut [LineInfo],
+    flavor: MarkdownFlavor,
+) -> Vec<(usize, usize)> {
+    if !flavor.supports_myst_directives() {
+        return Vec::new();
+    }
+
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    // Stack of (colon_count, byte_start) for nested directives
+    let mut stack: Vec<(usize, usize)> = Vec::new();
+
+    for line in lines.iter_mut() {
+        if line.in_front_matter || line.in_html_comment || line.in_code_block {
+            continue;
+        }
+
+        let line_content = line.content(content);
+
+        if let Some(colon_count) = myst_colon_directive_opener(line_content) {
+            stack.push((colon_count, line.byte_offset));
+            line.in_myst_directive = true;
+        } else if !stack.is_empty() {
+            // Check if this is a closer for any level in the stack
+            // Closers match the innermost directive with <= colon count
+            let spaces = count_leading_spaces(line_content);
+            let rest = if spaces <= 3 { &line_content[spaces..] } else { "" };
+            let colon_count = rest.bytes().take_while(|&b| b == b':').count();
+            let is_bare_colons = colon_count >= 3 && rest[colon_count..].trim().is_empty();
+
+            if is_bare_colons {
+                // Find the innermost directive this closer matches
+                // A closer with N colons closes the innermost directive with <= N colons
+                if let Some(pos) = stack.iter().rposition(|&(c, _)| c <= colon_count) {
+                    let (_, start) = stack.remove(pos);
+                    // Also remove any inner directives that were opened after this one
+                    stack.truncate(pos);
+                    let end = (line.byte_offset + line.byte_len + 1).min(content.len());
+                    ranges.push((start, end));
+                    line.in_myst_directive = true;
+                } else {
+                    // Not a valid closer, mark as directive content if inside one
+                    line.in_myst_directive = true;
+                }
+            } else {
+                // Regular content inside a directive
+                line.in_myst_directive = true;
+            }
+        }
+    }
+
+    // Unclosed directives extend to end of document
+    for (_, start) in stack {
+        ranges.push((start, content.len()));
+    }
+
+    ranges.sort_by_key(|&(s, _)| s);
+    ranges
+}
+
+/// Detect MyST `%` comments and mark their lines.
+/// Pattern: 0-3 leading spaces followed by `%` then space or end of line.
+pub(super) fn detect_myst_comments(
+    content: &str,
+    lines: &mut [LineInfo],
+    flavor: MarkdownFlavor,
+) -> Vec<(usize, usize)> {
+    if !flavor.supports_myst_comments() {
+        return Vec::new();
+    }
+
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+
+    for line in lines.iter_mut() {
+        if line.in_code_block || line.in_front_matter || line.in_html_comment || line.in_myst_directive {
+            continue;
+        }
+
+        let line_content = line.content(content);
+        let spaces = count_leading_spaces(line_content);
+        if spaces > 3 {
+            continue;
+        }
+        let rest = &line_content[spaces..];
+        if rest.starts_with('%') && (rest.len() == 1 || rest.as_bytes().get(1) == Some(&b' ')) {
+            line.is_myst_comment = true;
+            let end = (line.byte_offset + line.byte_len + 1).min(content.len());
+            ranges.push((line.byte_offset, end));
+        }
+    }
+
+    ranges
+}
+
+/// Known MyST content-bearing directives whose body should be linted as markdown.
+const MYST_CONTENT_DIRECTIVES: &[&str] = &[
+    "note", "warning", "tip", "hint", "important", "caution", "danger",
+    "admonition", "attention", "error", "seealso", "topic", "sidebar",
+    "margin", "exercise", "solution", "dropdown", "tab-item", "grid",
+    "card", "tab-set", "toggle", "proof", "prf:proof", "prf:theorem",
+    "prf:lemma", "prf:definition", "prf:criterion", "prf:remark",
+    "prf:conjecture", "prf:corollary", "prf:algorithm", "prf:example",
+    "prf:property", "prf:observation", "prf:proposition", "prf:assumption",
+    "figure", "table", "list-table", "csv-table",
+];
+
+/// Check if a MyST directive name is content-bearing (body is markdown, not code).
+fn is_myst_content_directive(name: &str) -> bool {
+    MYST_CONTENT_DIRECTIVES.contains(&name)
+}
+
+/// Detect MyST backtick directives (` ```{name} `) and clear `in_code_block` for
+/// content-bearing directives so their body is linted as markdown.
+///
+/// Code-bearing directives ({code-cell}, {code-block}, {raw}, etc.) keep `in_code_block = true`.
+pub(super) fn detect_myst_backtick_directives(
+    content: &str,
+    lines: &mut [LineInfo],
+    flavor: MarkdownFlavor,
+    code_block_details: &[crate::utils::code_block_utils::CodeBlockDetail],
+    line_offsets: &[usize],
+) {
+    if !flavor.supports_myst_directives() {
+        return;
+    }
+
+    for block in code_block_details {
+        if !block.is_fenced {
+            continue;
+        }
+
+        // Check if info string matches MyST directive pattern: {name} or {name} args
+        let info = block.info_string.trim();
+        if !info.starts_with('{') || !info.contains('}') {
+            continue;
+        }
+
+        let name = info.trim_start_matches('{').split('}').next().unwrap_or("");
+        if name.is_empty() || !name.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_') {
+            continue;
+        }
+
+        // Find the line index for this block's start byte offset
+        let start_line_idx = line_offsets
+            .partition_point(|&offset| offset <= block.start)
+            .saturating_sub(1);
+        let end_line_idx = line_offsets
+            .partition_point(|&offset| offset < block.end)
+            .min(lines.len());
+
+        // Mark the opener line as a directive
+        if let Some(line) = lines.get_mut(start_line_idx) {
+            line.in_myst_directive = true;
+        }
+
+        // For content-bearing directives, clear in_code_block for body lines
+        if is_myst_content_directive(name) {
+            let mut past_options = false;
+            let mut fence_tracker = FencedCodeTracker::new();
+
+            for i in (start_line_idx + 1)..end_line_idx {
+                if i >= lines.len() {
+                    break;
+                }
+
+                let line_content = lines[i].content(content);
+                let trimmed = line_content.trim();
+
+                // Check if this is the closing fence line
+                let is_closer = trimmed.starts_with("```")
+                    && trimmed.chars().skip(3).all(|c| c == '`' || c.is_whitespace());
+                if is_closer {
+                    lines[i].in_myst_directive = true;
+                    lines[i].in_code_block = false;
+                    break;
+                }
+
+                // Detect option lines (:key: value) at the start of the body
+                if !past_options {
+                    if trimmed.starts_with(':') && trimmed.len() > 1 && trimmed[1..].contains(':') {
+                        lines[i].in_myst_directive = true;
+                        lines[i].in_code_block = false;
+                        continue;
+                    } else if trimmed.starts_with("---") {
+                        // YAML options block delimiter
+                        lines[i].in_myst_directive = true;
+                        lines[i].in_code_block = false;
+                        continue;
+                    }
+                    past_options = true;
+                }
+
+                // Track nested fenced code blocks within the directive body
+                let in_nested_fence = fence_tracker.process_line(trimmed);
+                lines[i].in_myst_directive = true;
+                if !in_nested_fence {
+                    lines[i].in_code_block = false;
+                }
+            }
+        } else {
+            // Code-bearing directive: mark opener/closer as directive but keep in_code_block
+            if end_line_idx > 0 {
+                if let Some(closer_line) = lines.get_mut(end_line_idx - 1) {
+                    closer_line.in_myst_directive = true;
+                }
+            }
+        }
+    }
+}
+
+/// Detect MyST role syntax (`{rolename}`content``) and return byte ranges.
+/// Roles look like `{name}`content`` where name is alphanumeric with hyphens/underscores.
+pub(super) fn detect_myst_role_ranges(
+    content: &str,
+    lines: &[LineInfo],
+    flavor: MarkdownFlavor,
+    code_blocks: &[(usize, usize)],
+) -> Vec<(usize, usize)> {
+    if !flavor.supports_myst_roles() {
+        return Vec::new();
+    }
+
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let bytes = content.as_bytes();
+
+    for line in lines {
+        if line.in_code_block || line.in_front_matter || line.in_html_comment {
+            continue;
+        }
+
+        let line_start = line.byte_offset;
+        let line_end = line.byte_offset + line.byte_len;
+        let line_bytes = &bytes[line_start..line_end];
+
+        let mut i = 0;
+        while i < line_bytes.len() {
+            // Look for `{` that starts a role
+            if line_bytes[i] != b'{' {
+                i += 1;
+                continue;
+            }
+
+            let role_start = line_start + i;
+
+            // Check if inside a code block (byte-range check)
+            if code_blocks.iter().any(|&(s, e)| role_start >= s && role_start < e) {
+                i += 1;
+                continue;
+            }
+
+            // Parse role name: {name}
+            let mut j = i + 1;
+            if j >= line_bytes.len() || !(line_bytes[j].is_ascii_alphabetic() || line_bytes[j] == b'_') {
+                i += 1;
+                continue;
+            }
+            while j < line_bytes.len()
+                && (line_bytes[j].is_ascii_alphanumeric()
+                    || line_bytes[j] == b'-'
+                    || line_bytes[j] == b'_'
+                    || line_bytes[j] == b':'
+                    || line_bytes[j] == b'.')
+            {
+                j += 1;
+            }
+            if j >= line_bytes.len() || line_bytes[j] != b'}' {
+                i += 1;
+                continue;
+            }
+            j += 1; // past '}'
+
+            // Must be immediately followed by backtick(s)
+            if j >= line_bytes.len() || line_bytes[j] != b'`' {
+                i += 1;
+                continue;
+            }
+
+            // Count opening backticks
+            let backtick_start = j;
+            while j < line_bytes.len() && line_bytes[j] == b'`' {
+                j += 1;
+            }
+            let backtick_count = j - backtick_start;
+
+            // Find matching closing backticks
+            let mut found_close = false;
+            while j + backtick_count <= line_bytes.len() {
+                if line_bytes[j] == b'`' {
+                    let close_count = line_bytes[j..].iter().take_while(|&&b| b == b'`').count();
+                    if close_count == backtick_count {
+                        j += close_count;
+                        found_close = true;
+                        break;
+                    }
+                    j += close_count;
+                } else {
+                    j += 1;
+                }
+            }
+
+            if found_close {
+                let role_end = line_start + j;
+                ranges.push((role_start, role_end));
+                i = j;
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    ranges.sort_by_key(|&(s, _)| s);
+    ranges
+}
+
+#[cfg(test)]
+mod myst_tests {
+    use crate::config::MarkdownFlavor;
+    use crate::lint_context::LintContext;
+
+    fn myst_ctx(content: &str) -> LintContext<'_> {
+        LintContext::new(content, MarkdownFlavor::MyST, None)
+    }
+
+    #[test]
+    fn test_myst_colon_directive_basic() {
+        let content = ":::{note}\nThis is a note.\n:::\n";
+        let ctx = myst_ctx(content);
+        assert!(ctx.lines[0].in_myst_directive);
+        assert!(ctx.lines[1].in_myst_directive);
+        assert!(ctx.lines[2].in_myst_directive);
+        assert!(!ctx.lines[0].in_code_block);
+        assert!(!ctx.lines[1].in_code_block);
+    }
+
+    #[test]
+    fn test_myst_colon_directive_nested() {
+        let content = "::::{note}\n:::{warning}\nInner content\n:::\nOuter content\n::::\n";
+        let ctx = myst_ctx(content);
+        for i in 0..6 {
+            assert!(ctx.lines[i].in_myst_directive, "line {i} should be in_myst_directive");
+        }
+    }
+
+    #[test]
+    fn test_myst_comment() {
+        let content = "% This is a comment\nRegular text\n";
+        let ctx = myst_ctx(content);
+        assert!(ctx.lines[0].is_myst_comment);
+        assert!(!ctx.lines[1].is_myst_comment);
+    }
+
+    #[test]
+    fn test_myst_comment_not_in_standard_flavor() {
+        let content = "% This is a comment\n";
+        let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+        assert!(!ctx.lines[0].is_myst_comment);
+    }
+
+    #[test]
+    fn test_myst_backtick_content_directive() {
+        let content = "```{note}\nThis is **markdown** content.\n```\n";
+        let ctx = myst_ctx(content);
+        assert!(ctx.lines[0].in_myst_directive);
+        assert!(ctx.lines[1].in_myst_directive);
+        assert!(!ctx.lines[1].in_code_block, "content directive body should not be in_code_block");
+    }
+
+    #[test]
+    fn test_myst_backtick_code_directive() {
+        let content = "```{code-cell} python\nprint('hello')\n```\n";
+        let ctx = myst_ctx(content);
+        assert!(ctx.lines[0].in_myst_directive);
+        assert!(ctx.lines[1].in_code_block, "code directive body should remain in_code_block");
+    }
+
+    #[test]
+    fn test_myst_role_detection() {
+        let content = "See {ref}`my-label` for details.\n";
+        let ctx = myst_ctx(content);
+        // The role should be detected
+        assert!(ctx.is_in_myst_role(4)); // byte position of `{ref}`
+    }
+
+    #[test]
+    fn test_myst_role_not_in_standard_flavor() {
+        let content = "See {ref}`my-label` for details.\n";
+        let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+        assert!(!ctx.is_in_myst_role(4));
+    }
+}

--- a/src/lint_context/line_computation.rs
+++ b/src/lint_context/line_computation.rs
@@ -159,6 +159,8 @@ pub(super) fn compute_basic_line_info(
             is_kramdown_block_ial: false,
             in_jsx_block: false,
             in_footnote_definition: false,
+            in_myst_directive: false,
+            is_myst_comment: false,
         });
     }
 

--- a/src/lint_context/mod.rs
+++ b/src/lint_context/mod.rs
@@ -106,6 +106,9 @@ pub struct LintContext<'a> {
     inline_config: InlineConfig,           // Parsed inline configuration comments for rule disabling
     obsidian_comment_ranges: Vec<(usize, usize)>, // Pre-computed Obsidian comment ranges (%%...%%)
     lazy_cont_lines_cache: OnceLock<Arc<Vec<LazyContLine>>>, // Lazy-loaded lazy continuation lines
+    myst_directive_ranges: Vec<(usize, usize)>, // Pre-computed MyST colon directive byte ranges (:::{name} ... :::)
+    myst_comment_ranges: Vec<(usize, usize)>,   // Pre-computed MyST comment byte ranges (% comment)
+    myst_role_ranges: Vec<(usize, usize)>,      // Pre-computed MyST role byte ranges ({role}`content`)
 }
 
 impl<'a> LintContext<'a> {
@@ -153,7 +156,7 @@ impl<'a> LintContext<'a> {
         // Detected for all flavors except AzureDevOps, where `:::` denotes code fences
         // rather than autodoc directives.
         let autodoc_ranges = profile_section!("Autodoc block ranges", profile, {
-            if flavor.supports_colon_code_fences() {
+            if flavor.supports_colon_code_fences() || flavor.supports_myst_directives() {
                 Vec::new()
             } else {
                 crate::utils::mkdocstrings_refs::detect_autodoc_block_ranges(content)
@@ -371,6 +374,63 @@ impl<'a> LintContext<'a> {
             code_blocks.sort_by_key(|&(start, _)| start);
         }
 
+        // Detect MyST colon directives (:::{name} ... :::) — these are structural
+        // containers, NOT code blocks. Content inside is linted as markdown.
+        let myst_directive_ranges = profile_section!(
+            "MyST colon directives",
+            profile,
+            flavor_detection::detect_myst_colon_directives(content, &mut lines, flavor)
+        );
+
+        // Detect MyST % comments
+        let myst_comment_ranges = profile_section!(
+            "MyST comments",
+            profile,
+            flavor_detection::detect_myst_comments(content, &mut lines, flavor)
+        );
+
+        // Detect MyST backtick directives (```{name}) and clear in_code_block for
+        // content-bearing directives so their body is linted as markdown.
+        profile_section!(
+            "MyST backtick directives",
+            profile,
+            flavor_detection::detect_myst_backtick_directives(
+                content, &mut lines, flavor, &code_block_details, &line_offsets
+            )
+        );
+
+        // Filter code_blocks to remove false positives from MyST content-bearing directives.
+        // Same pattern as MkDocs admonition filtering.
+        if flavor.supports_myst_directives() {
+            let mut new_code_blocks = Vec::with_capacity(code_blocks.len());
+            for &(start, end) in &code_blocks {
+                let start_line = line_offsets
+                    .partition_point(|&offset| offset <= start)
+                    .saturating_sub(1);
+                let end_line = line_offsets.partition_point(|&offset| offset < end).min(lines.len());
+
+                let mut sub_start: Option<usize> = None;
+                for (i, &offset) in line_offsets[start_line..end_line]
+                    .iter()
+                    .enumerate()
+                    .map(|(j, o)| (j + start_line, o))
+                {
+                    let is_real_code = lines.get(i).is_some_and(|info| info.in_code_block);
+                    if is_real_code && sub_start.is_none() {
+                        let byte_start = if i == start_line { start } else { offset };
+                        sub_start = Some(byte_start);
+                    } else if !is_real_code && sub_start.is_some() {
+                        new_code_blocks.push((sub_start.unwrap(), offset));
+                        sub_start = None;
+                    }
+                }
+                if let Some(s) = sub_start {
+                    new_code_blocks.push((s, end));
+                }
+            }
+            code_blocks = new_code_blocks;
+        }
+
         // Detect kramdown constructs (extension blocks, IALs, ALDs) in kramdown flavor
         profile_section!(
             "Kramdown constructs",
@@ -396,6 +456,13 @@ impl<'a> LintContext<'a> {
             "Obsidian comments",
             profile,
             flavor_detection::detect_obsidian_comments(content, &mut lines, flavor, &code_span_ranges)
+        );
+
+        // Detect MyST role syntax ({role}`content`)
+        let myst_role_ranges = profile_section!(
+            "MyST roles",
+            profile,
+            flavor_detection::detect_myst_role_ranges(content, &lines, flavor, &code_blocks)
         );
 
         // Run pulldown-cmark parse for links, images, and link byte ranges in a single pass.
@@ -788,6 +855,9 @@ impl<'a> LintContext<'a> {
             inline_config,
             obsidian_comment_ranges,
             lazy_cont_lines_cache: OnceLock::new(),
+            myst_directive_ranges,
+            myst_comment_ranges,
+            myst_role_ranges,
         }
     }
 
@@ -893,6 +963,21 @@ impl<'a> LintContext<'a> {
         // Convert line/column (1-indexed, char-based) to byte position
         let byte_pos = self.line_index.line_col_to_byte_range(line_num, col).start;
         self.is_in_obsidian_comment(byte_pos)
+    }
+
+    /// Get byte ranges of MyST colon directive blocks
+    pub fn myst_directive_ranges(&self) -> &[(usize, usize)] {
+        &self.myst_directive_ranges
+    }
+
+    /// Check if a byte position is inside a MyST role (`{role}`content``)
+    pub fn is_in_myst_role(&self, byte_pos: usize) -> bool {
+        Self::binary_search_ranges(&self.myst_role_ranges, byte_pos)
+    }
+
+    /// Check if a byte position is inside a MyST comment (`% comment`)
+    pub fn is_in_myst_comment(&self, byte_pos: usize) -> bool {
+        Self::binary_search_ranges(&self.myst_comment_ranges, byte_pos)
     }
 
     /// Get HTML tags - computed lazily on first access

--- a/src/lint_context/mod.rs
+++ b/src/lint_context/mod.rs
@@ -107,8 +107,8 @@ pub struct LintContext<'a> {
     obsidian_comment_ranges: Vec<(usize, usize)>, // Pre-computed Obsidian comment ranges (%%...%%)
     lazy_cont_lines_cache: OnceLock<Arc<Vec<LazyContLine>>>, // Lazy-loaded lazy continuation lines
     myst_directive_ranges: Vec<(usize, usize)>, // Pre-computed MyST colon directive byte ranges (:::{name} ... :::)
-    myst_comment_ranges: Vec<(usize, usize)>,   // Pre-computed MyST comment byte ranges (% comment)
-    myst_role_ranges: Vec<(usize, usize)>,      // Pre-computed MyST role byte ranges ({role}`content`)
+    myst_comment_ranges: Vec<(usize, usize)>, // Pre-computed MyST comment byte ranges (% comment)
+    myst_role_ranges: Vec<(usize, usize)>, // Pre-computed MyST role byte ranges ({role}`content`)
 }
 
 impl<'a> LintContext<'a> {
@@ -395,7 +395,11 @@ impl<'a> LintContext<'a> {
             "MyST backtick directives",
             profile,
             flavor_detection::detect_myst_backtick_directives(
-                content, &mut lines, flavor, &code_block_details, &line_offsets
+                content,
+                &mut lines,
+                flavor,
+                &code_block_details,
+                &line_offsets
             )
         );
 

--- a/src/lint_context/types.rs
+++ b/src/lint_context/types.rs
@@ -73,6 +73,10 @@ pub struct LineInfo {
     pub in_jsx_block: bool,
     /// Whether this line is inside a footnote definition body (continuation lines)
     pub in_footnote_definition: bool,
+    /// Whether this line is inside a MyST directive block (colon or backtick fence with `{name}`)
+    pub in_myst_directive: bool,
+    /// Whether this line is a MyST comment (`% comment`)
+    pub is_myst_comment: bool,
 }
 
 impl LineInfo {
@@ -111,6 +115,7 @@ impl LineInfo {
             && !self.in_pymdown_block
             && !self.in_kramdown_extension_block
             && !self.is_kramdown_block_ial
+            && !self.is_myst_comment
             && self.heading.is_none()
     }
 }

--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -380,6 +380,11 @@ impl Rule for MD013LineLength {
                 continue;
             }
 
+            // Skip MyST comments (% comment) — structural lines, not prose
+            if ctx.lines[line_idx].is_myst_comment {
+                continue;
+            }
+
             // Link reference definitions are always exempt, even in strict mode.
             // There's no way to shorten them without breaking the URL.
             // Also check after stripping list markers, since list items may

--- a/src/rules/md031_blanks_around_fences.rs
+++ b/src/rules/md031_blanks_around_fences.rs
@@ -195,6 +195,22 @@ impl MD031BlanksAroundFences {
             })
             .collect()
     }
+
+    /// Convert MyST directive byte ranges from LintContext into (opener_line, closer_line) pairs.
+    fn myst_directive_line_ranges(ctx: &crate::lint_context::LintContext) -> Vec<(usize, usize)> {
+        ctx.myst_directive_ranges()
+            .iter()
+            .map(|&(start, end)| {
+                let start_line = ctx.line_offsets.partition_point(|&off| off <= start).saturating_sub(1);
+                let end_byte = if end > 0 { end - 1 } else { 0 };
+                let end_line = ctx
+                    .line_offsets
+                    .partition_point(|&off| off <= end_byte)
+                    .saturating_sub(1);
+                (start_line, end_line)
+            })
+            .collect()
+    }
 }
 
 impl Rule for MD031BlanksAroundFences {
@@ -346,6 +362,59 @@ impl Rule for MD031BlanksAroundFences {
             }
         }
 
+        // Enforce blank lines around MyST colon directives (:::{name} ... :::)
+        if ctx.flavor.supports_myst_directives() {
+            let myst_blocks = Self::myst_directive_line_ranges(ctx);
+            for (opening_line, closing_line) in &myst_blocks {
+                // Check for blank line before opener
+                if *opening_line > 0
+                    && !Self::is_effectively_empty_line(*opening_line - 1, lines, ctx)
+                    && !Self::is_right_after_frontmatter(*opening_line, ctx)
+                    && self.should_require_blank_line(*opening_line, lines)
+                {
+                    let (start_line, start_col, end_line, end_col) =
+                        calculate_line_range(*opening_line + 1, lines[*opening_line]);
+                    let bq_prefix = ctx.blockquote_prefix_for_blank_line(*opening_line);
+                    warnings.push(LintWarning {
+                        rule_name: Some(self.name().to_string()),
+                        line: start_line,
+                        column: start_col,
+                        end_line,
+                        end_column: end_col,
+                        message: "No blank line before MyST directive".to_string(),
+                        severity: Severity::Warning,
+                        fix: Some(Fix::new(
+                            line_index.line_col_to_byte_range_with_length(*opening_line + 1, 1, 0),
+                            format!("{bq_prefix}\n"),
+                        )),
+                    });
+                }
+
+                // Check for blank line after closer
+                if *closing_line + 1 < lines.len()
+                    && !Self::is_effectively_empty_line(*closing_line + 1, lines, ctx)
+                    && self.should_require_blank_line(*closing_line, lines)
+                {
+                    let (start_line, start_col, end_line, end_col) =
+                        calculate_line_range(*closing_line + 1, lines[*closing_line]);
+                    let bq_prefix = ctx.blockquote_prefix_for_blank_line(*closing_line);
+                    warnings.push(LintWarning {
+                        rule_name: Some(self.name().to_string()),
+                        line: start_line,
+                        column: start_col,
+                        end_line,
+                        end_column: end_col,
+                        message: "No blank line after MyST directive".to_string(),
+                        severity: Severity::Warning,
+                        fix: Some(Fix::new(
+                            line_index.line_col_to_byte_range_with_length(*closing_line + 2, 1, 0),
+                            format!("{bq_prefix}\n"),
+                        )),
+                    });
+                }
+            }
+        }
+
         // Handle MkDocs admonitions separately
         if is_mkdocs {
             let mut in_admonition = false;
@@ -469,7 +538,8 @@ impl Rule for MD031BlanksAroundFences {
         let has_fences = ctx.likely_has_code() || ctx.has_char('~');
         let has_mkdocs_admonitions = ctx.flavor == crate::config::MarkdownFlavor::MkDocs && ctx.content.contains("!!!");
         let has_colon_fences = ctx.flavor.supports_colon_code_fences() && ctx.content.contains(":::");
-        !has_fences && !has_mkdocs_admonitions && !has_colon_fences
+        let has_myst_directives = ctx.flavor.supports_myst_directives() && ctx.content.contains(":::");
+        !has_fences && !has_mkdocs_admonitions && !has_colon_fences && !has_myst_directives
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/src/rules/md038_no_space_in_code.rs
+++ b/src/rules/md038_no_space_in_code.rs
@@ -341,6 +341,12 @@ impl Rule for MD038NoSpaceInCode {
                     continue;
                 }
 
+                // Skip MyST role syntax: {role}`content` — the backtick content is part
+                // of the role's semantics, not a regular code span.
+                if ctx.flavor.supports_myst_roles() && ctx.is_in_myst_role(code_span.byte_offset) {
+                    continue;
+                }
+
                 // Check if this is part of Hugo template syntax (e.g., {{raw `...`}})
                 // Hugo uses backticks as part of template delimiters, not markdown code spans
                 if self.is_hugo_template_syntax(ctx, code_span) {

--- a/src/rules/md040_fenced_code_language.rs
+++ b/src/rules/md040_fenced_code_language.rs
@@ -267,10 +267,8 @@ impl Rule for MD040FencedCodeLanguage {
 
             // MyST directives use {name} as the info string (e.g., {note}, {code-cell} python).
             // These are valid MyST syntax and should not trigger missing-language warnings.
-            let is_myst_directive = ctx.flavor.supports_myst_directives()
-                && after_fence.starts_with('{')
-                && after_fence.contains('}')
-                && {
+            let is_myst_directive =
+                ctx.flavor.supports_myst_directives() && after_fence.starts_with('{') && after_fence.contains('}') && {
                     let name = after_fence.trim_start_matches('{').split('}').next().unwrap_or("");
                     !name.is_empty() && name.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_')
                 };
@@ -295,8 +293,10 @@ impl Rule for MD040FencedCodeLanguage {
                 && !is_pandoc_raw
                 && !is_pandoc_class_attr;
             let has_pandoc_or_quarto_syntax = is_pandoc_raw || is_pandoc_class_attr || is_quarto_exec;
-            let is_unrecognized_brace_syntax =
-                after_fence.starts_with('{') && after_fence.ends_with('}') && !has_pandoc_or_quarto_syntax && !is_myst_directive;
+            let is_unrecognized_brace_syntax = after_fence.starts_with('{')
+                && after_fence.ends_with('}')
+                && !has_pandoc_or_quarto_syntax
+                && !is_myst_directive;
 
             let needs_language = !has_mkdocs_attrs_only
                 && !is_myst_directive

--- a/src/rules/md040_fenced_code_language.rs
+++ b/src/rules/md040_fenced_code_language.rs
@@ -265,6 +265,16 @@ impl Rule for MD040FencedCodeLanguage {
             let has_mkdocs_attrs_only =
                 ctx.flavor == crate::config::MarkdownFlavor::MkDocs && is_superfences_attribute(after_fence);
 
+            // MyST directives use {name} as the info string (e.g., {note}, {code-cell} python).
+            // These are valid MyST syntax and should not trigger missing-language warnings.
+            let is_myst_directive = ctx.flavor.supports_myst_directives()
+                && after_fence.starts_with('{')
+                && after_fence.contains('}')
+                && {
+                    let name = after_fence.trim_start_matches('{').split('}').next().unwrap_or("");
+                    !name.is_empty() && name.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_')
+                };
+
             // Pandoc/Quarto brace-syntax code chunks fall into three forms:
             //   1. `{=html}` raw blocks — accepted under any Pandoc-compatible flavor.
             //      Validated by `is_pandoc_raw_block_lang` (non-empty ASCII format name).
@@ -286,9 +296,10 @@ impl Rule for MD040FencedCodeLanguage {
                 && !is_pandoc_class_attr;
             let has_pandoc_or_quarto_syntax = is_pandoc_raw || is_pandoc_class_attr || is_quarto_exec;
             let is_unrecognized_brace_syntax =
-                after_fence.starts_with('{') && after_fence.ends_with('}') && !has_pandoc_or_quarto_syntax;
+                after_fence.starts_with('{') && after_fence.ends_with('}') && !has_pandoc_or_quarto_syntax && !is_myst_directive;
 
             let needs_language = !has_mkdocs_attrs_only
+                && !is_myst_directive
                 && (block.language.is_empty()
                     || is_superfences_attribute(&block.language)
                     || is_unrecognized_brace_syntax);

--- a/src/rules/md046_code_block_style.rs
+++ b/src/rules/md046_code_block_style.rs
@@ -749,6 +749,12 @@ impl MD046CodeBlockStyle {
                 continue;
             }
 
+            // Lines inside MyST colon directives are structural containers, not code blocks.
+            if ctx.flavor.supports_myst_directives() && ctx.lines.get(i).is_some_and(|l| l.in_myst_directive) {
+                prev_was_indented = false;
+                continue;
+            }
+
             if self.is_fenced_code_block_start(line) {
                 if in_container {
                     // Fence marker inside a container — not a real fence,

--- a/src/rules/md048_code_fence_style.rs
+++ b/src/rules/md048_code_fence_style.rs
@@ -98,9 +98,20 @@ impl MD048CodeFenceStyle {
                 continue;
             }
 
+            // Skip lines inside MyST colon directives — they are structural
+            // containers, not code fences.
+            if ctx.flavor.supports_myst_directives() && ctx.lines.get(i).is_some_and(|li| li.in_myst_directive) {
+                continue;
+            }
+
             let Some(marker) = parse_fence_marker(line) else {
                 continue;
             };
+
+            // Skip MyST backtick directives (info string starts with {name})
+            if ctx.flavor.supports_myst_directives() && marker.fence_char == '`' && marker.rest.trim_start().starts_with('{') {
+                continue;
+            }
 
             if !in_code_block {
                 // Opening fence - count it
@@ -216,9 +227,19 @@ impl Rule for MD048CodeFenceStyle {
                 continue;
             }
 
+            // Skip lines inside MyST colon directives.
+            if ctx.flavor.supports_myst_directives() && ctx.lines.get(line_num).is_some_and(|li| li.in_myst_directive) {
+                continue;
+            }
+
             let Some(marker) = parse_fence_marker(line) else {
                 continue;
             };
+
+            // Skip MyST backtick directives (info string starts with {name})
+            if ctx.flavor.supports_myst_directives() && !in_code_block && marker.fence_char == '`' && marker.rest.trim_start().starts_with('{') {
+                continue;
+            }
             let fence_char = marker.fence_char;
             let fence_len = marker.fence_len;
 

--- a/src/rules/md048_code_fence_style.rs
+++ b/src/rules/md048_code_fence_style.rs
@@ -109,7 +109,10 @@ impl MD048CodeFenceStyle {
             };
 
             // Skip MyST backtick directives (info string starts with {name})
-            if ctx.flavor.supports_myst_directives() && marker.fence_char == '`' && marker.rest.trim_start().starts_with('{') {
+            if ctx.flavor.supports_myst_directives()
+                && marker.fence_char == '`'
+                && marker.rest.trim_start().starts_with('{')
+            {
                 continue;
             }
 
@@ -237,7 +240,11 @@ impl Rule for MD048CodeFenceStyle {
             };
 
             // Skip MyST backtick directives (info string starts with {name})
-            if ctx.flavor.supports_myst_directives() && !in_code_block && marker.fence_char == '`' && marker.rest.trim_start().starts_with('{') {
+            if ctx.flavor.supports_myst_directives()
+                && !in_code_block
+                && marker.fence_char == '`'
+                && marker.rest.trim_start().starts_with('{')
+            {
                 continue;
             }
             let fence_char = marker.fence_char;

--- a/tests/formats/mod.rs
+++ b/tests/formats/mod.rs
@@ -9,5 +9,6 @@ mod md013_reflow_nested_lists_test;
 mod mkdocs_anchor_edge_cases_test;
 mod mkdocs_anchor_test;
 mod mkdocs_extensions_test;
+mod myst_integration_test;
 mod quarto_comprehensive_test;
 mod sentence_per_line_test;

--- a/tests/formats/myst_integration_test.rs
+++ b/tests/formats/myst_integration_test.rs
@@ -22,7 +22,10 @@ fn test_md040_myst_backtick_directive_no_warning() {
     let ctx = myst_ctx(content);
     let rule = MD040FencedCodeLanguage::default();
     let warnings = rule.check(&ctx).unwrap();
-    assert!(warnings.is_empty(), "MyST directive should not trigger MD040: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "MyST directive should not trigger MD040: {warnings:?}"
+    );
 }
 
 #[test]
@@ -31,7 +34,10 @@ fn test_md040_myst_directive_with_argument() {
     let ctx = myst_ctx(content);
     let rule = MD040FencedCodeLanguage::default();
     let warnings = rule.check(&ctx).unwrap();
-    assert!(warnings.is_empty(), "MyST directive with argument should not trigger MD040: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "MyST directive with argument should not trigger MD040: {warnings:?}"
+    );
 }
 
 #[test]
@@ -49,7 +55,10 @@ fn test_md040_standard_flavor_flags_myst_directive() {
     let ctx = standard_ctx(content);
     let rule = MD040FencedCodeLanguage::default();
     let warnings = rule.check(&ctx).unwrap();
-    assert!(!warnings.is_empty(), "Standard flavor should flag {{note}} as missing language");
+    assert!(
+        !warnings.is_empty(),
+        "Standard flavor should flag {{note}} as missing language"
+    );
 }
 
 // ==================== MD048: Code Fence Style ====================
@@ -61,7 +70,10 @@ fn test_md048_myst_colon_directive_not_counted() {
     let ctx = myst_ctx(content);
     let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Consistent);
     let warnings = rule.check(&ctx).unwrap();
-    assert!(warnings.is_empty(), "MyST colon directive should not trigger MD048: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "MyST colon directive should not trigger MD048: {warnings:?}"
+    );
 }
 
 #[test]
@@ -72,7 +84,10 @@ fn test_md048_myst_backtick_directive_not_counted() {
     let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Consistent);
     let warnings = rule.check(&ctx).unwrap();
     // Only the tilde fence should be counted; the backtick directive is skipped
-    assert!(warnings.is_empty(), "MyST backtick directive should not trigger MD048: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "MyST backtick directive should not trigger MD048: {warnings:?}"
+    );
 }
 
 // ==================== MD031: Blanks Around Fences ====================
@@ -83,7 +98,11 @@ fn test_md031_myst_colon_directive_needs_blanks() {
     let ctx = myst_ctx(content);
     let rule = MD031BlanksAroundFences::new(true);
     let warnings = rule.check(&ctx).unwrap();
-    assert_eq!(warnings.len(), 2, "Should warn about missing blanks before and after: {warnings:?}");
+    assert_eq!(
+        warnings.len(),
+        2,
+        "Should warn about missing blanks before and after: {warnings:?}"
+    );
 }
 
 #[test]
@@ -92,7 +111,10 @@ fn test_md031_myst_colon_directive_with_blanks_ok() {
     let ctx = myst_ctx(content);
     let rule = MD031BlanksAroundFences::new(true);
     let warnings = rule.check(&ctx).unwrap();
-    assert!(warnings.is_empty(), "Properly spaced MyST directive should not warn: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "Properly spaced MyST directive should not warn: {warnings:?}"
+    );
 }
 
 #[test]
@@ -113,7 +135,10 @@ fn test_md046_myst_colon_directive_not_counted_as_code_block() {
     let ctx = myst_ctx(content);
     let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Fenced);
     let warnings = rule.check(&ctx).unwrap();
-    assert!(warnings.is_empty(), "MyST directive should not affect code block style: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "MyST directive should not affect code block style: {warnings:?}"
+    );
 }
 
 // ==================== MD038: No Space in Code ====================
@@ -137,7 +162,10 @@ fn test_md013_myst_comment_not_flagged() {
     let ctx = myst_ctx(content);
     let rule = MD013LineLength::default();
     let warnings = rule.check(&ctx).unwrap();
-    assert!(warnings.is_empty(), "MyST comment should not trigger MD013: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "MyST comment should not trigger MD013: {warnings:?}"
+    );
 }
 
 #[test]
@@ -157,8 +185,14 @@ fn test_myst_content_directive_body_not_in_code_block() {
     let content = "```{note}\nThis is **markdown** content with a [link](url).\n```\n";
     let ctx = myst_ctx(content);
     // Line 1 (body) should NOT be in_code_block
-    assert!(!ctx.lines[1].in_code_block, "Content directive body should not be in_code_block");
-    assert!(ctx.lines[1].in_myst_directive, "Content directive body should be in_myst_directive");
+    assert!(
+        !ctx.lines[1].in_code_block,
+        "Content directive body should not be in_code_block"
+    );
+    assert!(
+        ctx.lines[1].in_myst_directive,
+        "Content directive body should be in_myst_directive"
+    );
 }
 
 #[test]
@@ -166,7 +200,10 @@ fn test_myst_code_directive_body_stays_in_code_block() {
     let content = "```{code-cell} python\nprint('hello')\n```\n";
     let ctx = myst_ctx(content);
     // Line 1 (body) SHOULD be in_code_block
-    assert!(ctx.lines[1].in_code_block, "Code directive body should remain in_code_block");
+    assert!(
+        ctx.lines[1].in_code_block,
+        "Code directive body should remain in_code_block"
+    );
 }
 
 // ==================== Nested directives ====================

--- a/tests/formats/myst_integration_test.rs
+++ b/tests/formats/myst_integration_test.rs
@@ -1,0 +1,195 @@
+use rumdl_lib::config::MarkdownFlavor;
+use rumdl_lib::lint_context::LintContext;
+use rumdl_lib::rule::Rule;
+use rumdl_lib::rules::{
+    CodeBlockStyle, CodeFenceStyle, MD013LineLength, MD031BlanksAroundFences, MD038NoSpaceInCode,
+    MD040FencedCodeLanguage, MD046CodeBlockStyle, MD048CodeFenceStyle,
+};
+
+fn myst_ctx(content: &str) -> LintContext<'_> {
+    LintContext::new(content, MarkdownFlavor::MyST, None)
+}
+
+fn standard_ctx(content: &str) -> LintContext<'_> {
+    LintContext::new(content, MarkdownFlavor::Standard, None)
+}
+
+// ==================== MD040: Fenced Code Language ====================
+
+#[test]
+fn test_md040_myst_backtick_directive_no_warning() {
+    let content = "```{note}\nThis is a note.\n```\n";
+    let ctx = myst_ctx(content);
+    let rule = MD040FencedCodeLanguage::default();
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(warnings.is_empty(), "MyST directive should not trigger MD040: {warnings:?}");
+}
+
+#[test]
+fn test_md040_myst_directive_with_argument() {
+    let content = "```{code-cell} python\nprint('hello')\n```\n";
+    let ctx = myst_ctx(content);
+    let rule = MD040FencedCodeLanguage::default();
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(warnings.is_empty(), "MyST directive with argument should not trigger MD040: {warnings:?}");
+}
+
+#[test]
+fn test_md040_myst_empty_braces_still_warns() {
+    let content = "```{}\ncode\n```\n";
+    let ctx = myst_ctx(content);
+    let rule = MD040FencedCodeLanguage::default();
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(!warnings.is_empty(), "Empty braces should still trigger MD040");
+}
+
+#[test]
+fn test_md040_standard_flavor_flags_myst_directive() {
+    let content = "```{note}\nThis is a note.\n```\n";
+    let ctx = standard_ctx(content);
+    let rule = MD040FencedCodeLanguage::default();
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(!warnings.is_empty(), "Standard flavor should flag {{note}} as missing language");
+}
+
+// ==================== MD048: Code Fence Style ====================
+
+#[test]
+fn test_md048_myst_colon_directive_not_counted() {
+    // MyST colon directives should not influence fence style detection
+    let content = ":::{note}\nContent\n:::\n\n```python\ncode\n```\n";
+    let ctx = myst_ctx(content);
+    let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Consistent);
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(warnings.is_empty(), "MyST colon directive should not trigger MD048: {warnings:?}");
+}
+
+#[test]
+fn test_md048_myst_backtick_directive_not_counted() {
+    // MyST backtick directives should not influence fence style detection
+    let content = "```{note}\nContent\n```\n\n~~~python\ncode\n~~~\n";
+    let ctx = myst_ctx(content);
+    let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Consistent);
+    let warnings = rule.check(&ctx).unwrap();
+    // Only the tilde fence should be counted; the backtick directive is skipped
+    assert!(warnings.is_empty(), "MyST backtick directive should not trigger MD048: {warnings:?}");
+}
+
+// ==================== MD031: Blanks Around Fences ====================
+
+#[test]
+fn test_md031_myst_colon_directive_needs_blanks() {
+    let content = "Some text\n:::{note}\nContent\n:::\nMore text\n";
+    let ctx = myst_ctx(content);
+    let rule = MD031BlanksAroundFences::new(true);
+    let warnings = rule.check(&ctx).unwrap();
+    assert_eq!(warnings.len(), 2, "Should warn about missing blanks before and after: {warnings:?}");
+}
+
+#[test]
+fn test_md031_myst_colon_directive_with_blanks_ok() {
+    let content = "Some text\n\n:::{note}\nContent\n:::\n\nMore text\n";
+    let ctx = myst_ctx(content);
+    let rule = MD031BlanksAroundFences::new(true);
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(warnings.is_empty(), "Properly spaced MyST directive should not warn: {warnings:?}");
+}
+
+#[test]
+fn test_md031_myst_fix_inserts_blanks() {
+    let content = "Some text\n:::{note}\nContent\n:::\nMore text\n";
+    let ctx = myst_ctx(content);
+    let rule = MD031BlanksAroundFences::new(true);
+    let fixed = rule.fix(&ctx).unwrap();
+    assert_eq!(fixed, "Some text\n\n:::{note}\nContent\n:::\n\nMore text\n");
+}
+
+// ==================== MD046: Code Block Style ====================
+
+#[test]
+fn test_md046_myst_colon_directive_not_counted_as_code_block() {
+    // MyST colon directives should not be counted as code blocks for style detection
+    let content = ":::{note}\nContent\n:::\n\n```python\ncode\n```\n";
+    let ctx = myst_ctx(content);
+    let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Fenced);
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(warnings.is_empty(), "MyST directive should not affect code block style: {warnings:?}");
+}
+
+// ==================== MD038: No Space in Code ====================
+
+#[test]
+fn test_md038_myst_role_not_flagged() {
+    // MyST role with content that has leading space — should not be flagged in MyST
+    let content = "See {ref}` my-label` for details.\n";
+    let ctx = myst_ctx(content);
+    let rule = MD038NoSpaceInCode::default();
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(warnings.is_empty(), "MyST role should not trigger MD038: {warnings:?}");
+}
+
+// ==================== MD013: Line Length ====================
+
+#[test]
+fn test_md013_myst_comment_not_flagged() {
+    // A long MyST comment with spaces (so trailing-token forgiveness doesn't apply)
+    let content = "% This is a very long comment that exceeds the default line length limit of eighty characters and should be skipped by the linter\n";
+    let ctx = myst_ctx(content);
+    let rule = MD013LineLength::default();
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(warnings.is_empty(), "MyST comment should not trigger MD013: {warnings:?}");
+}
+
+#[test]
+fn test_md013_standard_flavor_flags_percent_line() {
+    // Same long line but in standard flavor — should be flagged
+    let content = "% This is a very long comment that exceeds the default line length limit of eighty characters and should be flagged by the linter\n";
+    let ctx = standard_ctx(content);
+    let rule = MD013LineLength::default();
+    let warnings = rule.check(&ctx).unwrap();
+    assert!(!warnings.is_empty(), "Standard flavor should flag long % line");
+}
+
+// ==================== Content-bearing directive body linting ====================
+
+#[test]
+fn test_myst_content_directive_body_not_in_code_block() {
+    let content = "```{note}\nThis is **markdown** content with a [link](url).\n```\n";
+    let ctx = myst_ctx(content);
+    // Line 1 (body) should NOT be in_code_block
+    assert!(!ctx.lines[1].in_code_block, "Content directive body should not be in_code_block");
+    assert!(ctx.lines[1].in_myst_directive, "Content directive body should be in_myst_directive");
+}
+
+#[test]
+fn test_myst_code_directive_body_stays_in_code_block() {
+    let content = "```{code-cell} python\nprint('hello')\n```\n";
+    let ctx = myst_ctx(content);
+    // Line 1 (body) SHOULD be in_code_block
+    assert!(ctx.lines[1].in_code_block, "Code directive body should remain in_code_block");
+}
+
+// ==================== Nested directives ====================
+
+#[test]
+fn test_myst_nested_colon_directives() {
+    let content = "::::{note}\n:::{warning}\nInner content\n:::\nOuter content\n::::\n";
+    let ctx = myst_ctx(content);
+    for i in 0..6 {
+        assert!(ctx.lines[i].in_myst_directive, "line {i} should be in_myst_directive");
+        assert!(!ctx.lines[i].in_code_block, "line {i} should not be in_code_block");
+    }
+}
+
+// ==================== Directive options ====================
+
+#[test]
+fn test_myst_directive_options_not_in_code_block() {
+    let content = "```{figure} image.png\n:alt: An image\n:width: 80%\n\nCaption text\n```\n";
+    let ctx = myst_ctx(content);
+    // Option lines should be in_myst_directive but not in_code_block
+    assert!(ctx.lines[1].in_myst_directive);
+    assert!(!ctx.lines[1].in_code_block);
+    assert!(ctx.lines[2].in_myst_directive);
+    assert!(!ctx.lines[2].in_code_block);
+}


### PR DESCRIPTION
## Description

Add support for [MyST (Markedly Structured Text)](https://mystmd.org/), which used by [Sphinx](https://www.sphinx-doc.org/en/master/) and [Jupyterbook](https://jupyterbook.org/).

The syntax is on top of CommonMark, and is described in 
- https://mystmd.org/guide/syntax-overview
- https://mystmd.org/guide/directives
- https://mystmd.org/guide/roles

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [x] Manual testing performed

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used
- [x] Documentation updated (if needed)
- [ ] CHANGELOG.md updated (if user-facing)