### PR TITLE
Add reference to 'sentence-per-line' mode description

### DIFF
--- a/docs/md013.md
+++ b/docs/md013.md
@@ -186,7 +186,7 @@ This mode is useful for standardizing documents with inconsistent line wrapping.
 
 #### `sentence-per-line` mode
 
-Enforces one sentence per line, making diffs cleaner and easier to review. This mode:
+Enforces one sentence per line, making diffs cleaner and easier to review, among [other advantages](https://nick.groenen.me/notes/one-sentence-per-line/). This mode:
 
 - Detects sentence boundaries (periods, exclamation marks, question marks)
 - Handles common abbreviations (e.g., i.e., Mr., Dr., Ph.D., Inc., etc.) without breaking sentences


### PR DESCRIPTION
I found this nice reference that lists the surpisingly many advantages of one sentence per line.