### PR TITLE
fix(MD049,MD037): Preserve inline code inside emphasis during auto-fix

### DIFF
--- a/src/rules/md037_spaces_around_emphasis.rs
+++ b/src/rules/md037_spaces_around_emphasis.rs
@@ -319,8 +319,14 @@ impl MD037NoSpaceInEmphasis {
                     format!("{marker_char}{marker_char}")
                 };
 
-                // Create the fixed version by trimming spaces from content
-                let trimmed_content = span.content.trim();
+                // Create the fixed version by trimming spaces from content.
+                // Slice the content from the *original* line, not from the
+                // code/math-masked copy: `span.content` would contain the 'X'/'M'
+                // placeholders, which must never leak into the generated fix.
+                // Masking is length-preserving, so the span byte offsets are
+                // valid in `content`.
+                let original_content = &content[span.opening.end_pos()..span.closing.start_pos];
+                let trimmed_content = original_content.trim();
                 let fixed_text = format!("{marker_str}{trimmed_content}{marker_str}");
 
                 // Truncate long emphasis spans for readable warning messages
@@ -398,6 +404,19 @@ mod tests {
             !result.is_empty(),
             "Expected warnings for spaces in emphasis outside code block"
         );
+    }
+
+    #[test]
+    fn test_inline_code_inside_spaced_emphasis_preserved_on_fix() {
+        // Regression test: inline code inside a spaced emphasis span must survive the
+        // space-trimming fix. Previously the 'X' masking placeholder leaked into
+        // the fix output, destroying the code span.
+        let rule = MD037NoSpaceInEmphasis;
+        let content = "Set * the `id` field * below.";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(fixed, "Set *the `id` field* below.");
+        assert!(!fixed.contains('X'), "masking placeholder leaked into fix: {fixed}");
     }
 
     #[test]

--- a/src/rules/md049_emphasis_style.rs
+++ b/src/rules/md049_emphasis_style.rs
@@ -47,7 +47,10 @@ impl MD049EmphasisStyle {
         line_start_pos: usize,
         emphasis_info: &mut Vec<(usize, usize, usize, char, String)>, // (line, col, abs_pos, marker, content)
     ) {
-        // Replace inline code to avoid false positives
+        // Replace inline code to avoid false positives. `replace_inline_code`
+        // substitutes each inline-code span with an equal-length run of 'X', so
+        // every byte offset (and thus every emphasis marker position) is
+        // identical between `line` and `line_no_code`.
         let line_no_code = replace_inline_code(line);
 
         // Find all emphasis markers
@@ -64,7 +67,16 @@ impl MD049EmphasisStyle {
             let col = span.opening.start_pos + 1; // Convert to 1-based
             let abs_pos = line_start_pos + span.opening.start_pos;
 
-            emphasis_info.push((line_num, col, abs_pos, marker_char, span.content.clone()));
+            // Use the content from the *original* line, not the code-masked copy.
+            // The span content from `line_no_code` would contain the 'X'
+            // placeholders, which must never leak into the generated fix.
+            // Marker positions are byte offsets that are valid in `line` because
+            // masking preserves byte length and span boundaries.
+            let content_start = span.opening.end_pos();
+            let content_end = span.closing.start_pos;
+            let original_content = line[content_start..content_end].to_string();
+
+            emphasis_info.push((line_num, col, abs_pos, marker_char, original_content));
         }
     }
 }
@@ -482,6 +494,34 @@ This should be _flagged_ since we're using asterisk style.
             "Only emphasis outside mkdocstrings should be flagged. Got: {result:?}"
         );
         assert_eq!(result[0].line, 6);
+    }
+
+    #[test]
+    fn test_inline_code_inside_emphasis_preserved_on_fix() {
+        // Regression test: inline code inside an emphasis span must survive the
+        // style conversion. Previously the 'X' masking placeholder leaked into
+        // the fix output, destroying the code span.
+        let rule = MD049EmphasisStyle::new(EmphasisStyle::Asterisk);
+        let content = "- _An item with `inline code` inside._ Trailing text.";
+        let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(fixed, "- *An item with `inline code` inside.* Trailing text.");
+        assert!(!fixed.contains('X'), "masking placeholder leaked into fix: {fixed}");
+
+        // Idempotent: fixing the already-fixed content changes nothing.
+        let ctx2 = crate::lint_context::LintContext::new(&fixed, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(rule.fix(&ctx2).unwrap(), fixed);
+    }
+
+    #[test]
+    fn test_inline_code_inside_emphasis_underscore_style() {
+        // Same bug in the opposite direction (* -> _).
+        let rule = MD049EmphasisStyle::new(EmphasisStyle::Underscore);
+        let content = "See *the `id` field* below.";
+        let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(fixed, "See _the `id` field_ below.");
     }
 
     #[test]


### PR DESCRIPTION
## Description

To detect emphasis markers reliably, `MD049` and `MD037` first build a throwaway copy of each line with every inline code span replaced by an equal-length sequence of `X` characters (and inline math by `M`). This prevents backtick or dollar contents from being misread as emphasis markers. The auto-fix, however, reused the emphasis text taken from that masked copy, so the `X`/`M` placeholders leaked into the written file and permanently replaced the original inline code.

The fix takes the replacement text from the original line at the span's byte offsets instead. Because masking replaces each span with a sequence of the same byte length, those offsets remain valid against the original line.

Example before this fix (`rumdl fmt` with MD049 `style = "asterisk"`):

- input: `- _An item with `inline code` inside._`
- output: `- *An item with XXXXXXXXXXXXX inside.*`

After the fix the inline code is preserved: `- *An item with `inline code` inside.*`. Only `fmt`/`--fix` was affected; `check` does not modify files. `MD050` (strong style) was not affected.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated (regression tests in both rules)
- [x] All tests passing: `cargo nextest` for md049/md037/emphasis/reflow/md013/formatter_idempotency, and full `cargo test --lib` (5810 passed)
- [x] Manual testing performed: `rumdl fmt` on the repro is now lossless and idempotent

## Checklist

- [x] Code follows project style (`cargo fmt --check` clean; CI clippy gate `-D warnings -D clippy::uninlined_format_args` clean)
- [x] Conventional commit messages used
- [ ] Documentation updated (not needed)
- [ ] CHANGELOG.md updated (maintainer-generated at release via git-cliff)

Closes #651
