### PR TITLE
fix(md030): keep nested content attached when a marker widens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,6 +2302,7 @@ dependencies = [
  "globset",
  "ignore",
  "indexmap",
+ "indoc",
  "jsonschema",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ wasm = ["wasm-bindgen", "console_error_panic_hook", "serde-wasm-bindgen"]
 
 [dev-dependencies]
 assert_cmd = "2.1.1"
+indoc = "2"
 predicates = "3.1.3"
 tempfile = "3.23"
 proptest = "1.9"

--- a/src/rules/md030_list_marker_space.rs
+++ b/src/rules/md030_list_marker_space.rs
@@ -19,6 +19,17 @@ enum ListType {
     Ordered,
 }
 
+/// How a following line relates to the list item being scanned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Continuation {
+    /// Part of the item (a continuation line or nested content).
+    Belongs,
+    /// A blank line, which neither continues nor ends the item.
+    Skip,
+    /// The item is over (a sibling/ancestor marker or under-indented content).
+    Ends,
+}
+
 #[derive(Clone, Default)]
 pub struct MD030ListMarkerSpace {
     config: MD030Config,
@@ -259,65 +270,69 @@ impl MD030ListMarkerSpace {
         !line[marker_end..].trim().is_empty()
     }
 
-    /// Check if a list item is multi-line (spans multiple lines or contains nested content)
-    fn is_multi_line_list_item(&self, ctx: &crate::lint_context::LintContext, line_num: usize, lines: &[&str]) -> bool {
-        // Get the current list item info
-        let current_line_info = match ctx.line_info(line_num) {
-            Some(info) if info.list_item.is_some() => info,
-            _ => return false,
+    /// The marker column, blockquote nesting level, and minimum (blockquote-aware)
+    /// indent a following line needs to continue the list item on `line_num`. These
+    /// are the inputs shared by every continuation scan. `None` if the line isn't a
+    /// list item. Inside a blockquote the indent excludes the prefix so it stays in
+    /// the coordinate system of [`effective_indent_in_blockquote`].
+    fn continuation_params(ctx: &crate::lint_context::LintContext, line_num: usize) -> Option<(usize, usize, usize)> {
+        let info = ctx.line_info(line_num)?;
+        let list = info.list_item.as_ref()?;
+        let (bq_level, min_indent) = match &info.blockquote {
+            Some(bq) if bq.nesting_level > 0 => (bq.nesting_level, list.content_column.saturating_sub(bq.prefix.len())),
+            _ => (0, list.content_column),
         };
+        Some((list.marker_column, bq_level, min_indent))
+    }
 
-        let current_list = current_line_info.list_item.as_ref().unwrap();
+    /// Classify the line at `next_line_num` (1-based) relative to a list item whose
+    /// marker is at `marker_column` with continuation threshold (`bq_level`,
+    /// `min_indent`). The single source of truth for what belongs to a list item.
+    fn classify_continuation(
+        ctx: &crate::lint_context::LintContext,
+        next_line_num: usize,
+        lines: &[&str],
+        marker_column: usize,
+        bq_level: usize,
+        min_indent: usize,
+    ) -> Continuation {
+        let Some(info) = ctx.line_info(next_line_num) else {
+            return Continuation::Skip;
+        };
+        // A deeper marker is nested content; one at the same or a shallower column
+        // ends the item.
+        if let Some(next_list) = &info.list_item {
+            return if next_list.marker_column <= marker_column {
+                Continuation::Ends
+            } else {
+                Continuation::Belongs
+            };
+        }
+        let content = lines.get(next_line_num - 1).copied().unwrap_or("");
+        if content.trim().is_empty() {
+            return Continuation::Skip; // Blank lines don't decide on their own.
+        }
+        let raw_indent = content.len() - content.trim_start().len();
+        if effective_indent_in_blockquote(content, bq_level, raw_indent) < min_indent {
+            Continuation::Ends
+        } else {
+            Continuation::Belongs
+        }
+    }
 
-        // Check subsequent lines to see if they are continuation of this list item
-        for next_line_num in (line_num + 1)..=lines.len() {
-            if let Some(next_line_info) = ctx.line_info(next_line_num) {
-                // If we encounter another list item at the same or higher level, this item is done
-                if let Some(next_list) = &next_line_info.list_item {
-                    if next_list.marker_column <= current_list.marker_column {
-                        break; // Found the next list item at same/higher level
-                    }
-                    // If there's a nested list item, this is multi-line
-                    return true;
-                }
-
-                // If we encounter a non-empty line that's not indented enough to be part of this list item,
-                // this list item is done
-                let line_content = lines.get(next_line_num - 1).unwrap_or(&"");
-                if !line_content.trim().is_empty() {
-                    // Get blockquote level from the current list item's line
-                    let bq_level = current_line_info.blockquote.as_ref().map_or(0, |bq| bq.nesting_level);
-
-                    // For blockquote lists, min continuation indent is just the marker width
-                    // (not the full content_column which includes blockquote prefix)
-                    let min_continuation_indent = if bq_level > 0 {
-                        // For lists in blockquotes, use marker width (2 for "* " or "- ")
-                        // content_column includes blockquote prefix, so subtract that
-                        current_list
-                            .content_column
-                            .saturating_sub(current_line_info.blockquote.as_ref().map_or(0, |bq| bq.prefix.len()))
-                    } else {
-                        current_list.content_column
-                    };
-
-                    // Calculate effective indent (blockquote-aware)
-                    let raw_indent = line_content.len() - line_content.trim_start().len();
-                    let actual_indent = effective_indent_in_blockquote(line_content, bq_level, raw_indent);
-
-                    if actual_indent < min_continuation_indent {
-                        break; // Line is not indented enough to be part of this list item
-                    }
-
-                    // If we find a continuation line, this is multi-line
-                    if actual_indent >= min_continuation_indent {
-                        return true;
-                    }
-                }
-
-                // Empty lines don't affect the multi-line status by themselves
+    /// Whether the list item on `line_num` spans multiple lines (has continuation or
+    /// nested content). Stops at the first line that belongs to it.
+    fn is_multi_line_list_item(&self, ctx: &crate::lint_context::LintContext, line_num: usize, lines: &[&str]) -> bool {
+        let Some((marker_column, bq_level, min_indent)) = Self::continuation_params(ctx, line_num) else {
+            return false;
+        };
+        for next in (line_num + 1)..=lines.len() {
+            match Self::classify_continuation(ctx, next, lines, marker_column, bq_level, min_indent) {
+                Continuation::Belongs => return true,
+                Continuation::Ends => break,
+                Continuation::Skip => {}
             }
         }
-
         false
     }
 

--- a/src/rules/md030_list_marker_space.rs
+++ b/src/rules/md030_list_marker_space.rs
@@ -30,6 +30,17 @@ enum Continuation {
     Ends,
 }
 
+/// An open list item (or inline bullet) whose content the current line may
+/// continue, tracked on a stack. `shift` is its cumulative indent shift (its own
+/// marker re-spacing plus every ancestor's), applied to the continuation lines it
+/// owns.
+struct AlignFrame {
+    marker_column: usize,
+    bq_level: usize,
+    min_indent: usize,
+    shift: isize,
+}
+
 #[derive(Clone, Default)]
 pub struct MD030ListMarkerSpace {
     config: MD030Config,
@@ -87,74 +98,139 @@ impl Rule for MD030ListMarkerSpace {
         // Track which lines we've already processed (to avoid duplicates)
         let mut processed_lines = std::collections::HashSet::new();
 
-        // First pass: Check parser-recognized list items
+        // Content only needs re-indenting when a marker can *widen*, pushing content
+        // right, which otherwise detaches nested lists (a multi-line `1.` marker that
+        // grows leaves its `   1. inner` child under-indented and flattened). Narrowing
+        // leaves content over-indented but attached, which MD077 tightens, so we skip
+        // the whole mechanism unless some configured spacing exceeds 1. Widening needs
+        // an expected width above the 1 that recognized markers already have.
+        let may_widen = self.config.ul_single.get() > 1
+            || self.config.ul_multi.get() > 1
+            || self.config.ol_single.get() > 1
+            || self.config.ol_multi.get() > 1;
+
+        // Active list items (and inline bullets) whose content the current line may
+        // continue. Each frame carries the item's cumulative indent shift (its own
+        // marker re-spacing plus every ancestor's), so a continuation line is
+        // re-indented by the shift of the innermost frame that still owns it. Because
+        // the loop walks top to bottom, every owning item is already on the stack by
+        // the time we reach its content, so the shift is known on the spot.
+        let mut stack: Vec<AlignFrame> = Vec::new();
+
+        // Main pass: re-indent each continuation/nested line as the loop reaches it,
+        // and check parser-recognized list items.
         for (line_num, line_info) in ctx.lines.iter().enumerate() {
+            let line_num_1based = line_num + 1;
+            let line = lines[line_num];
+
+            // Drop frames whose item has ended, then read the shift and blockquote
+            // level of the innermost item that still owns this line.
+            let (owner_shift, owner_bq_level) = if may_widen {
+                while let Some(&AlignFrame {
+                    marker_column,
+                    bq_level,
+                    min_indent,
+                    ..
+                }) = stack.last()
+                {
+                    if Self::classify_continuation(ctx, line_num_1based, lines, marker_column, bq_level, min_indent)
+                        == Continuation::Ends
+                    {
+                        stack.pop();
+                    } else {
+                        break;
+                    }
+                }
+                stack.last().map_or((0, 0), |f| (f.shift, f.bq_level))
+            } else {
+                (0, 0)
+            };
+
             // Skip code blocks, math blocks, PyMdown blocks, and MkDocs markdown HTML divs (grid cards use custom spacing)
-            if line_info.list_item.is_some()
+            let is_list_item = line_info.list_item.is_some()
                 && !line_info.in_code_block
                 && !line_info.in_math_block
                 && !line_info.in_pymdown_block
                 && !line_info.in_mkdocs_html_markdown
-                && !line_info.in_footnote_definition
+                && !line_info.in_footnote_definition;
+
+            if !is_list_item {
+                // A continuation/nested line follows its owning item's shift.
+                if owner_shift > 0
+                    && !line.trim().is_empty()
+                    && let Some(warning) = self.indent_shift_warning(ctx, line, line_num, owner_bq_level, owner_shift)
+                {
+                    processed_lines.insert(line_num_1based);
+                    warnings.push(warning);
+                }
+                continue;
+            }
+
+            processed_lines.insert(line_num_1based);
+            let Some(list_info) = &line_info.list_item else {
+                continue;
+            };
+
+            // The item is content of its parent, so its leading indent follows too.
+            if may_widen
+                && let Some(warning) = self.indent_shift_warning(ctx, line, line_num, owner_bq_level, owner_shift)
             {
-                let line_num_1based = line_num + 1;
-                processed_lines.insert(line_num_1based);
+                warnings.push(warning);
+            }
 
-                let line = lines[line_num];
+            let list_type = if list_info.is_ordered {
+                ListType::Ordered
+            } else {
+                ListType::Unordered
+            };
+            let marker_end = list_info.marker_column + list_info.marker.len();
 
-                if let Some(list_info) = &line_info.list_item {
-                    let list_type = if list_info.is_ordered {
-                        ListType::Ordered
-                    } else {
-                        ListType::Unordered
-                    };
+            // MD030 only applies when there is content after the marker.
+            if !Self::has_content_after_marker(line, marker_end) {
+                continue;
+            }
 
-                    // Calculate actual spacing after marker
-                    let marker_end = list_info.marker_column + list_info.marker.len();
+            let actual_spaces = list_info.content_column.saturating_sub(marker_end);
 
-                    // Skip if there's no content on this line after the marker
-                    // MD030 only applies when there IS content after the marker
-                    if !Self::has_content_after_marker(line, marker_end) {
-                        continue;
-                    }
+            // A fixed number of spaces by list type and whether the item is single- or
+            // multi-line.
+            let is_multi_line = self.is_multi_line_list_item(ctx, line_num_1based, lines);
+            let expected_spaces = self.get_expected_spaces(list_type, is_multi_line);
 
-                    let actual_spaces = list_info.content_column.saturating_sub(marker_end);
+            if actual_spaces != expected_spaces {
+                warnings.push(self.spacing_fix_warning(
+                    ctx,
+                    line,
+                    line_num,
+                    marker_end..marker_end + actual_spaces,
+                    expected_spaces,
+                    format!("Spaces after list markers (Expected: {expected_spaces}; Actual: {actual_spaces})"),
+                ));
+            }
 
-                    // Determine if this is a multi-line list item
-                    let is_multi_line = self.is_multi_line_list_item(ctx, line_num_1based, lines);
-                    let expected_spaces = self.get_expected_spaces(list_type, is_multi_line);
-
-                    if actual_spaces != expected_spaces {
-                        let whitespace_start_pos = marker_end;
-                        let whitespace_len = actual_spaces;
-
-                        let (start_line, start_col, end_line, end_col) =
-                            calculate_match_range(line_num_1based, line, whitespace_start_pos, whitespace_len);
-
-                        let correct_spaces = " ".repeat(expected_spaces);
-                        let line_start_byte = ctx.line_offsets.get(line_num).copied().unwrap_or(0);
-                        let whitespace_start_byte = line_start_byte + whitespace_start_pos;
-                        let whitespace_end_byte = whitespace_start_byte + whitespace_len;
-
-                        let fix = Some(crate::rule::Fix::new(
-                            whitespace_start_byte..whitespace_end_byte,
-                            correct_spaces,
-                        ));
-
-                        let message =
-                            format!("Spaces after list markers (Expected: {expected_spaces}; Actual: {actual_spaces})");
-
-                        warnings.push(LintWarning {
-                            rule_name: Some(self.name().to_string()),
-                            severity: Severity::Warning,
-                            line: start_line,
-                            column: start_col,
-                            end_line,
-                            end_column: end_col,
-                            message,
-                            fix,
-                        });
-                    }
+            // Push this item's frame so its continuation lines follow it, and space any
+            // inline nested bullet (`1. - x`), which gets its own frame.
+            if may_widen
+                && let Some((marker_column, bq_level, min_indent)) = Self::continuation_params(ctx, line_num_1based)
+            {
+                let item_shift = owner_shift + (expected_spaces as isize - actual_spaces as isize);
+                stack.push(AlignFrame {
+                    marker_column,
+                    bq_level,
+                    min_indent,
+                    shift: item_shift,
+                });
+                if list_info.is_ordered
+                    && let Some(warning) = self.align_inline_bullet(
+                        ctx,
+                        line_num_1based,
+                        lines,
+                        list_info.content_column,
+                        item_shift,
+                        &mut stack,
+                    )
+                {
+                    warnings.push(warning);
                 }
             }
         }
@@ -270,6 +346,53 @@ impl MD030ListMarkerSpace {
         !line[marker_end..].trim().is_empty()
     }
 
+    /// Build a warning that replaces the whitespace run at byte range `span` within
+    /// the line at `line_idx` (0-based) with `want` spaces. Shared by the marker-
+    /// spacing checks and the nested-content re-indentation.
+    fn spacing_fix_warning(
+        &self,
+        ctx: &crate::lint_context::LintContext,
+        line: &str,
+        line_idx: usize,
+        span: std::ops::Range<usize>,
+        want: usize,
+        message: String,
+    ) -> LintWarning {
+        let (start_line, start_col, end_line, end_col) =
+            calculate_match_range(line_idx + 1, line, span.start, span.len());
+        let base = ctx.line_offsets.get(line_idx).copied().unwrap_or(0);
+        LintWarning {
+            rule_name: Some(self.name().to_string()),
+            severity: Severity::Warning,
+            line: start_line,
+            column: start_col,
+            end_line,
+            end_column: end_col,
+            message,
+            fix: Some(crate::rule::Fix::new(
+                base + span.start..base + span.end,
+                " ".repeat(want),
+            )),
+        }
+    }
+
+    /// If the content at byte `content_col` of `line` is an inline unordered marker
+    /// (`-`/`*`/`+` followed by spaces and then content, as in `1. - x`), return the
+    /// byte offset of the spaces after that bullet and their current count. `None`
+    /// for anything else (e.g. `1. -x` or `1. *emphasis*`, which aren't markers).
+    fn inline_unordered_spaces(line: &str, content_col: usize) -> Option<(usize, usize)> {
+        if !matches!(line.as_bytes().get(content_col), Some(b'-' | b'*' | b'+')) {
+            return None;
+        }
+        let offset = content_col + 1;
+        let rest = line.get(offset..)?;
+        let spaces = rest.len() - rest.trim_start_matches(' ').len();
+        if spaces == 0 || rest[spaces..].is_empty() {
+            return None;
+        }
+        Some((offset, spaces))
+    }
+
     /// The marker column, blockquote nesting level, and minimum (blockquote-aware)
     /// indent a following line needs to continue the list item on `line_num`. These
     /// are the inputs shared by every continuation scan. `None` if the line isn't a
@@ -321,11 +444,25 @@ impl MD030ListMarkerSpace {
     }
 
     /// Whether the list item on `line_num` spans multiple lines (has continuation or
-    /// nested content). Stops at the first line that belongs to it.
+    /// nested content).
     fn is_multi_line_list_item(&self, ctx: &crate::lint_context::LintContext, line_num: usize, lines: &[&str]) -> bool {
         let Some((marker_column, bq_level, min_indent)) = Self::continuation_params(ctx, line_num) else {
             return false;
         };
+        Self::has_continuation(ctx, line_num, lines, marker_column, bq_level, min_indent)
+    }
+
+    /// Whether any line after `line_num` (1-based) belongs to an item with the given
+    /// continuation threshold, scanning until the item ends. Shared by the multi-line
+    /// check and the inline-bullet check.
+    fn has_continuation(
+        ctx: &crate::lint_context::LintContext,
+        line_num: usize,
+        lines: &[&str],
+        marker_column: usize,
+        bq_level: usize,
+        min_indent: usize,
+    ) -> bool {
         for next in (line_num + 1)..=lines.len() {
             match Self::classify_continuation(ctx, next, lines, marker_column, bq_level, min_indent) {
                 Continuation::Belongs => return true,
@@ -334,6 +471,97 @@ impl MD030ListMarkerSpace {
             }
         }
         false
+    }
+
+    /// Byte offset on `line` where its shiftable indent begins: column 0 when the
+    /// owning item is at top level, or just past the blockquote prefix when it sits
+    /// inside a blockquote (its indent lives after the `>` markers).
+    fn write_offset(owner_bq_level: usize, line: &str) -> usize {
+        match owner_bq_level {
+            0 => 0,
+            _ => parse_blockquote_prefix(line).map_or(0, |p| p.prefix.len()),
+        }
+    }
+
+    /// Build the warning that re-indents a continuation/nested `line` (0-based
+    /// `line_idx`) by `shift` columns, within its owning item's coordinate system.
+    /// Only a positive shift (content moving right, to stay attached to a widened
+    /// marker) is emitted; a non-positive shift leaves content over-indented but
+    /// attached, which MD077 cleans up. `None` when nothing moves.
+    fn indent_shift_warning(
+        &self,
+        ctx: &crate::lint_context::LintContext,
+        line: &str,
+        line_idx: usize,
+        owner_bq_level: usize,
+        shift: isize,
+    ) -> Option<LintWarning> {
+        if shift <= 0 {
+            return None;
+        }
+        let offset = Self::write_offset(owner_bq_level, line);
+        let after = &line[offset..];
+        let indent = after.len() - after.trim_start().len();
+        let new_indent = (indent as isize + shift).max(0) as usize;
+        if new_indent == indent {
+            return None;
+        }
+        Some(self.spacing_fix_warning(
+            ctx,
+            line,
+            line_idx,
+            offset..offset + indent,
+            new_indent,
+            format!(
+                "Nested content should align with the list marker (Expected indent: {new_indent}; Actual: {indent})"
+            ),
+        ))
+    }
+
+    /// The first item of a nested unordered list shares the ordered marker's line
+    /// (`1. - x`), where the parser exposes only the outer marker. Space that inline
+    /// bullet like a sibling bullet on its own line; when its spacing changes, push a
+    /// frame so its own continuation lines pick up the extra shift. `item_shift` is
+    /// the enclosing ordered item's cumulative shift. Returns the bullet's spacing
+    /// warning, if any.
+    fn align_inline_bullet(
+        &self,
+        ctx: &crate::lint_context::LintContext,
+        line_num: usize,
+        lines: &[&str],
+        content_column: usize,
+        item_shift: isize,
+        stack: &mut Vec<AlignFrame>,
+    ) -> Option<LintWarning> {
+        let line = lines[line_num - 1];
+        let (offset, spaces) = Self::inline_unordered_spaces(line, content_column)?;
+        let bullet_content_col = offset + spaces;
+        // ul-multi if the bullet itself spans lines, else ul-single, measured with a
+        // raw indent (bq_level 0) like a bullet that begins its own line.
+        let multi = Self::has_continuation(ctx, line_num, lines, content_column, 0, bullet_content_col);
+        let want = if multi {
+            self.config.ul_multi.get()
+        } else {
+            self.config.ul_single.get()
+        };
+        if spaces == want {
+            return None;
+        }
+        let bullet_delta = want as isize - spaces as isize;
+        stack.push(AlignFrame {
+            marker_column: content_column,
+            bq_level: 0,
+            min_indent: bullet_content_col,
+            shift: item_shift + bullet_delta,
+        });
+        Some(self.spacing_fix_warning(
+            ctx,
+            line,
+            line_num - 1,
+            offset..offset + spaces,
+            want,
+            format!("Spaces after list markers (Expected: {want}; Actual: {spaces})"),
+        ))
     }
 
     /// Detect list-like patterns that the parser didn't recognize (e.g., "1.Text" with no space)
@@ -476,6 +704,7 @@ impl MD030ListMarkerSpace {
 mod tests {
     use super::*;
     use crate::lint_context::LintContext;
+    use indoc::indoc;
 
     /// Assert that running `fix()` on content with violations produces output that
     /// passes `check()` with zero remaining violations.
@@ -766,6 +995,51 @@ mod tests {
 
         // Verify the full roundtrip: fix() must resolve everything check() found.
         assert_fix_resolves_all_violations(&rule, content);
+    }
+
+    #[test]
+    fn test_ol_multi_reindents_nested_to_stay_attached() {
+        // Regression: widening a multi-line marker (here ol-multi = 3) moves its
+        // content right. Without re-indenting the nested list it would end up left of
+        // the parent's content column and detach (the nested `1.` would flatten into a
+        // sibling). The shifts accumulate down the levels so everything stays nested.
+        let rule = MD030ListMarkerSpace::new(1, 1, 1, 3); // ol-multi = 3
+        let content = indoc! {"
+            1. outer
+               1. inner
+                  deep
+        "};
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(
+            rule.fix(&ctx).unwrap(),
+            indoc! {"
+                1.   outer
+                     1.   inner
+                          deep
+            "}
+        );
+        assert_fix_resolves_all_violations(&rule, content);
+    }
+
+    #[test]
+    fn test_ol_multi_does_not_reindent_when_narrowing() {
+        // The mirror case: removing extra spaces (narrowing) leaves content
+        // over-indented but attached, which MD077 tightens, so MD030 leaves the
+        // continuation alone rather than fighting that rule.
+        let rule = MD030ListMarkerSpace::new(1, 1, 1, 1); // defaults: markers narrow to 1
+        let content = indoc! {"
+            1.   outer
+                 continuation
+        "};
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(
+            rule.fix(&ctx).unwrap(),
+            indoc! {"
+                1. outer
+                     continuation
+            "},
+            "marker narrows to 1 space; the over-indented continuation is left for MD077"
+        );
     }
 
     #[test]

--- a/tests/rules/md030_test.rs
+++ b/tests/rules/md030_test.rs
@@ -1,7 +1,28 @@
 mod tests {
     use rumdl_lib::lint_context::LintContext;
     use rumdl_lib::rule::Rule;
-    use rumdl_lib::rules::MD030ListMarkerSpace;
+    use rumdl_lib::rules::{MD030ListMarkerSpace, MD077ListContinuationIndent};
+
+    /// Apply each rule's fix in turn (re-parsing between), mirroring how the pipeline
+    /// combines MD030 (marker spacing) with MD077 (continuation indentation).
+    fn fix_pipeline(content: &str, rules: &[&dyn Rule]) -> String {
+        let mut out = content.to_string();
+        for rule in rules {
+            let ctx = LintContext::new(&out, rumdl_lib::config::MarkdownFlavor::Standard, None);
+            out = rule.fix(&ctx).unwrap();
+        }
+        out
+    }
+
+    #[test]
+    fn test_combined_narrowing_tightens_continuation_default() {
+        // MD030 narrows the marker, leaving the continuation over-indented; MD077 then
+        // tightens it to the new content column. Neither rule alone gets there.
+        let md030 = MD030ListMarkerSpace::default();
+        let md077 = MD077ListContinuationIndent;
+        let out = fix_pipeline("*   item\n    continuation\n", &[&md030 as &dyn Rule, &md077]);
+        assert_eq!(out, "* item\n  continuation\n");
+    }
 
     #[test]
     fn test_valid_single_line_lists() {
@@ -576,7 +597,8 @@ mod tests {
 
     #[test]
     fn test_multi_line_configuration_support() {
-        // Test that ul_multi and ol_multi configuration options are actually used
+        // ul_multi and ol_multi widen multi-line markers; widening pushes content
+        // right, so MD030 re-indents each continuation to stay attached to its marker.
         let rule = MD030ListMarkerSpace::new(
             1, // ul_single
             3, // ul_multi  - key test: multi-line should use this
@@ -588,27 +610,22 @@ mod tests {
         let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
 
-        // Should find 2 violations:
-        // - Line 2: multi-line unordered list (expects 3 spaces, has 2)
-        // - Line 5: multi-line ordered list (expects 4 spaces, has 3)
-        assert_eq!(
-            result.len(),
-            2,
-            "Should detect multi-line spacing violations, got: {result:?}"
-        );
+        // Two marker violations (lines 2 and 5), each followed by a continuation
+        // (lines 3 and 6) that must follow the widened marker.
+        assert_eq!(result.len(), 4, "Got: {result:?}");
 
-        // Check the specific violations
         assert_eq!(result[0].line, 2);
-        assert!(result[0].message.contains("Expected: 3"));
-        assert!(result[0].message.contains("Actual: 2"));
+        assert!(result[0].message.contains("Expected: 3") && result[0].message.contains("Actual: 2"));
+        assert_eq!(result[1].line, 3);
+        assert!(result[1].message.contains("align with the list marker"));
+        assert_eq!(result[2].line, 5);
+        assert!(result[2].message.contains("Expected: 4") && result[2].message.contains("Actual: 3"));
+        assert_eq!(result[3].line, 6);
+        assert!(result[3].message.contains("align with the list marker"));
 
-        assert_eq!(result[1].line, 5);
-        assert!(result[1].message.contains("Expected: 4"));
-        assert!(result[1].message.contains("Actual: 3"));
-
-        // Test the fix
+        // The fix widens the markers and re-indents the continuations to match.
         let fixed = rule.fix(&ctx).unwrap();
-        let expected = "* Single line\n*   Multi-line item\n   with continuation\n1. Single ordered\n1.    Multi-line ordered\n     with continuation";
+        let expected = "* Single line\n*   Multi-line item\n    with continuation\n1. Single ordered\n1.    Multi-line ordered\n      with continuation";
         assert_eq!(fixed, expected, "Multi-line spacing should be fixed correctly");
     }
 
@@ -630,18 +647,22 @@ mod tests {
         let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
 
-        // First item is multi-line (has continuation), so should expect 3 spaces (ul_multi)
-        // It only has 1 space, so should be flagged
-        assert_eq!(
-            result.len(),
-            1,
-            "Multi-line blockquote list item should be detected. Got: {result:?}"
-        );
-        assert_eq!(result[0].line, 1, "Warning should be on line 1");
+        // First item is multi-line (has continuation), so its marker expects 3 spaces
+        // (ul_multi); widening it drags `more text` right to stay attached.
+        assert_eq!(result.len(), 2, "Got: {result:?}");
+        assert_eq!(result[0].line, 1, "Marker warning on line 1");
         assert!(
             result[0].message.contains("Expected: 3"),
             "Should expect ul_multi (3) spaces. Got: {}",
             result[0].message
+        );
+        assert_eq!(result[1].line, 2, "Continuation re-indent on line 2");
+        assert!(result[1].message.contains("align with the list marker"));
+
+        // The fix keeps `more text` aligned under `First item` inside the blockquote.
+        assert_eq!(
+            rule.fix(&ctx).unwrap(),
+            "> -   First item\n>     more text\n> - Second item"
         );
     }
 


### PR DESCRIPTION
MD030 fixes the spaces after a list marker, but when that fix *widens* a
multi-line item's marker indent, it only moved the content on the same line as
the marker, leaving the continuation content behind. For a nested list that
detaches it: the child marker ends up left of the parent's content column and
flattens into a sibling. With a configured `ol-multi`/`ul-multi` greater than
the current spacing, `--fix` could therefore corrupt the document, and no other
rule recovers it.

Track the open list items on a stack, each carrying its cumulative indent shift
(its own marker re-spacing plus every ancestor's), and re-indent continuation
and nested lines to follow a widened marker. The shifts accumulate across
nesting levels in a single pass. An inline nested bullet that shares the
marker's line (`- x` in `1. - x`) is spaced and shifted like a sibling bullet.

Re-indent only when content must move *right*. Narrowing leaves content
over-indented but still attached, which MD077 (list continuation
indentation) tightens, so MD030 leaves that to it. The idea is that
MD030 owns under-indent, MD077 owns over-indent.

The whole mechanism is skipped unless a configured spacing exceeds 1, so
the default configuration is unaffected.

There is a pure refactor commit first to expose needed functionality,
followed by the fix itself.

This also introduces a use of `indoc` to allow for easier construction of
multi-line test cases with visible indentation structures.

This is a first step towards fixing #644.