### PR TITLE
fix(config): discover global config from cwd for multi-path runs

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -46,7 +46,16 @@ pub fn run_check(args: &CheckArgs, global_config_path: Option<&str>, isolated: b
     // Use the first target path for config discovery if it's a directory
     // Otherwise use current directory to ensure config files are found
     // when pre-commit or other tools pass relative file paths
-    let discovery_dir = if !args.paths.is_empty() {
+    // When multiple paths are given they may span several config scopes
+    // (e.g. a repo root config plus nested `.rumdl.toml` files that
+    // `extend-disable` a rule). Seeding the *global* config from the first
+    // path's directory then makes whichever file sorts first decide the
+    // baseline for every file — a nested `extend-disable = ["MD013"]` would
+    // silently disable that rule repo-wide. For multi-path runs discover the
+    // global config from the cwd (project root) instead; per-file grouping
+    // still layers each file's own nearest config on top. Only a single path
+    // keeps the "discover next to that path" behaviour.
+    let discovery_dir = if args.paths.len() == 1 {
         let first_path = std::path::Path::new(&args.paths[0]);
         if first_path.is_dir() {
             Some(first_path)

--- a/tests/config/config_upward_traversal_test.rs
+++ b/tests/config/config_upward_traversal_test.rs
@@ -253,3 +253,60 @@ MD013:
         "MD013 should not trigger - .markdownlint.yaml at repo root should be discovered. Output: {combined}"
     );
 }
+
+#[test]
+fn test_multi_path_global_config_not_seeded_from_first_path() {
+    // Regression: with multiple paths spanning several config scopes, the
+    // *global* config must be discovered from the project root (cwd), not from
+    // the first path's directory. Otherwise whichever file sorts first decides
+    // the baseline for every file, so a nested `extend-disable` silently
+    // disables that rule for files in other directories that inherit the root
+    // config (e.g. `rumdl check .claude/a.md d/b.md` would drop MD013 on d/b.md
+    // because `.claude/.rumdl.toml` extend-disables it).
+    let temp_dir = tempdir().unwrap();
+    let project_dir = temp_dir.path();
+
+    // `.git` marks the project root so config discovery treats `project_dir`
+    // (not `dir_a`) as the project root for the inheriting files.
+    fs::create_dir(project_dir.join(".git")).unwrap();
+
+    // Project-root config: MD013 enabled.
+    fs::write(project_dir.join(".rumdl.toml"), "[MD013]\nline-length = 120\n").unwrap();
+
+    // dir_a: nested config that extend-disables MD013.
+    let dir_a = project_dir.join("dir_a");
+    fs::create_dir_all(&dir_a).unwrap();
+    fs::write(
+        dir_a.join(".rumdl.toml"),
+        "extends = \"../.rumdl.toml\"\n\n[global]\nextend-disable = [\"MD013\"]\n",
+    )
+    .unwrap();
+    fs::write(dir_a.join("a.md"), "# A\n\nshort line.\n").unwrap();
+
+    // dir_b: no own config, inherits the root config, so its long line must fire MD013.
+    let dir_b = project_dir.join("dir_b");
+    fs::create_dir_all(&dir_b).unwrap();
+    let long_line = "This is a deliberately long line in dir_b which inherits the root config and clearly exceeds one hundred twenty characters so MD013 must fire.";
+    fs::write(dir_b.join("b.md"), format!("# B\n\n{long_line}\n")).unwrap();
+
+    // Pass the dir_a file FIRST: a regression seeds the global config from
+    // dir_a (MD013 disabled) and wrongly suppresses MD013 for dir_b/b.md.
+    let rumdl_exe = env!("CARGO_BIN_EXE_rumdl");
+    let output = Command::new(rumdl_exe)
+        .args(["check", "dir_a/a.md", "dir_b/b.md"])
+        .current_dir(project_dir)
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let combined = format!("{stdout}{stderr}");
+
+    // Only dir_b/b.md can produce MD013 (dir_a disables it and a.md is short),
+    // so the rule firing at all proves dir_b kept the root config's MD013.
+    assert!(
+        combined.contains("MD013"),
+        "MD013 must fire for dir_b/b.md (inherits root config) even though the \
+         first path is in dir_a whose config extend-disables MD013. Output: {combined}"
+    );
+}


### PR DESCRIPTION
## Summary

`rumdl check` with multiple paths can silently drop findings for files that should be linted. When the
paths span several config scopes, the *global* config is seeded from the **first path's directory**. If that
path lives in a subdirectory whose `.rumdl.toml` `extend-disable`s a rule, that nested config becomes the
global baseline for the whole run — disabling the rule for files in other directories that inherit the
project-root config.

## Reproduction

```text
proj/.rumdl.toml        → [MD013] line-length = 120                       (MD013 enabled)
proj/.git/              → project-root marker
proj/dir_a/.rumdl.toml  → extends "../.rumdl.toml" + extend-disable = ["MD013"]
proj/dir_a/a.md         → short
proj/dir_b/b.md         → long line (inherits root config → MD013 must fire)
```

```console
$ cd proj
$ rumdl check dir_a/a.md dir_b/b.md   # MD013 NOT reported for dir_b/b.md  ← bug
$ rumdl check dir_b/b.md dir_a/a.md   # MD013 reported                      ← ok
$ rumdl check dir_b/b.md              # MD013 reported                      ← ok
```

The result depends on argument order. Tools that pass a sorted file list (pre-commit, editor wrappers) hit
this whenever the alphabetically-first file sits under such a subdirectory — e.g. a repo with a root config
plus `.claude/.rumdl.toml` / `src/.rumdl.toml` that `extend-disable` a rule will have that rule disabled
repo-wide on a full-tree `rumdl check`, even for files that should keep it. The effect is a false-negative
gate (long lines pass), which is how this was found.

## Root cause

`src/commands/check.rs` derives `discovery_dir` from the first path's directory:

```rust
let discovery_dir = if !args.paths.is_empty() {
    let first_path = Path::new(&args.paths[0]);
    if first_path.is_dir() { Some(first_path) }
    else { first_path.parent().filter(|p| p.is_dir()) }
} else { None };
```

`load_config_with_cli_error_handling_with_dir` then `chdir`s there and discovers the nearest `.rumdl.toml`,
which becomes `root_config`. In `resolution.rs`, files outside that subdirectory land in the root group
(`effective_config = None`) and use this contaminated `root_config`, so a rule the project root enables
ends up disabled for them.

## Fix

For multi-path runs, discover the global config from the cwd (project root) instead of the first path's
directory. Per-file grouping still layers each file's own nearest config on top, so nested `extend-disable`
keeps working for files actually under those directories. Single-path runs keep the existing
"discover next to that path" behavior.

## Tests

Added `test_multi_path_global_config_not_seeded_from_first_path` in
`tests/config/config_upward_traversal_test.rs` — it fails before this change and passes after. The full
`cargo test` suite passes, and the existing single-path config-discovery tests are unchanged.
