### PR TITLE
docs(pre-commit): fix version typo in suggested pre-commit config

### DIFF
--- a/docs/usage/pre-commit.md
+++ b/docs/usage/pre-commit.md
@@ -13,7 +13,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml title=".pre-commit-config.yaml"
 repos:
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.0.222  # Use latest version
+    rev: v0.2.22  # Use latest version
     hooks:
       - id: rumdl      # Lint only; add args [--fix] to auto-fix
       - id: rumdl-fmt  # Pure format, always exits 0


### PR DESCRIPTION
Version given in example is 0.0.222, rather than 0.2.22.