### PR TITLE
fix(lint-context): attach list items whose marker line opens a code fence

### DIFF
--- a/src/lint_context/list_blocks.rs
+++ b/src/lint_context/list_blocks.rs
@@ -88,8 +88,16 @@ pub(super) fn parse_list_blocks(content: &str, lines: &[LineInfo]) -> Vec<ListBl
     for (line_idx, line_info) in lines.iter().enumerate() {
         let line_num = line_idx + 1;
 
-        // Enhanced code block handling using Design #3's context analysis
-        if line_info.in_code_block {
+        // Enhanced code block handling using Design #3's context analysis.
+        //
+        // Exception: a fenced code block can *open on a list-marker line*, e.g.
+        // "- ```python" or "1. ```js". Such a line is flagged `in_code_block`
+        // (it begins a code block) but is genuinely the start of a list item, so
+        // it must fall through to the list-item handling below to be registered;
+        // otherwise the whole item — and everything indented under it — would be
+        // dropped from the list model. Lines *inside* the fence are never flagged
+        // as list items, so this exception only ever matches the marker line.
+        if line_info.in_code_block && line_info.list_item.is_none() {
             if let Some(ref mut block) = current_block {
                 // Calculate minimum indentation for list continuation
                 let min_continuation_indent =

--- a/tests/regressions/fenced_code_on_list_marker_test.rs
+++ b/tests/regressions/fenced_code_on_list_marker_test.rs
@@ -1,0 +1,264 @@
+//! Tests that a fenced code block opening on a list-marker line — `- ```py`,
+//! `1. ```py`, or `- ~~~py` — is handled correctly: the item and everything
+//! indented under it stay attached in the parsed list-block model, and the
+//! rules that lint the opening fence line (MD040, MD031, MD046) still apply.
+
+use indoc::indoc;
+use rumdl_lib::MD046CodeBlockStyle;
+use rumdl_lib::config::MarkdownFlavor;
+use rumdl_lib::lint_context::{LintContext, ListBlock};
+use rumdl_lib::rule::Rule;
+use rumdl_lib::rules::{CodeBlockStyle, MD031BlanksAroundFences, MD040FencedCodeLanguage};
+
+fn ctx(content: &str) -> LintContext<'_> {
+    LintContext::new(content, MarkdownFlavor::Standard, None)
+}
+
+/// The sole list block in `ctx`, asserting there is exactly one.
+fn single_block<'a>(ctx: &'a LintContext) -> &'a ListBlock {
+    assert_eq!(
+        ctx.list_blocks.len(),
+        1,
+        "expected one list block, got {:?}",
+        ctx.list_blocks
+    );
+    &ctx.list_blocks[0]
+}
+
+// --- List-block model --------------------------------------------------------
+
+#[test]
+fn fenced_item_between_plain_items_stays_attached() {
+    // A fenced item between two plain items keeps its continuation paragraph;
+    // all three items form one list.
+    let lc = ctx(indoc! {"
+        - First item, normal text.
+
+        - ```python
+          print('hi')
+          ```
+
+          Attached paragraph.
+
+        - Third item, normal text.
+    "});
+    let block = single_block(&lc);
+    assert!(!block.is_ordered);
+    assert_eq!(block.start_line, 1);
+    assert_eq!(block.end_line, 9);
+    assert_eq!(block.item_lines, vec![1, 3, 9]);
+
+    for line in 1..=9 {
+        assert!(lc.is_in_list_block(line), "line {line} should be in the list block");
+    }
+}
+
+#[test]
+fn fenced_first_item_stays_attached() {
+    // A fenced item as the first item, with nothing preceding it to anchor the block.
+    let lc = ctx(indoc! {"
+        - ```python
+          print('hi')
+          ```
+
+          Attached paragraph.
+
+        - Second item.
+    "});
+    let block = single_block(&lc);
+    assert_eq!(block.start_line, 1);
+    assert_eq!(block.end_line, 7);
+    assert_eq!(block.item_lines, vec![1, 7]);
+}
+
+#[test]
+fn fenced_item_with_nested_list_keeps_parent() {
+    // A fenced item followed by a nested list keeps the parent item.
+    let lc = ctx(indoc! {"
+        - ```python
+          code
+          ```
+
+          - nested one
+          - nested two
+    "});
+    let block = single_block(&lc);
+    assert_eq!(block.start_line, 1);
+    assert_eq!(block.end_line, 6);
+    assert!(
+        block.item_lines.contains(&1),
+        "parent item missing, got {:?}",
+        block.item_lines
+    );
+}
+
+#[test]
+fn tilde_fenced_item_stays_attached() {
+    // Tilde fences on the marker line.
+    let lc = ctx(indoc! {"
+        - ~~~python
+          code
+          ~~~
+
+          Attached paragraph.
+    "});
+    let block = single_block(&lc);
+    assert_eq!(block.start_line, 1);
+    assert_eq!(block.end_line, 5);
+    assert_eq!(block.item_lines, vec![1]);
+}
+
+#[test]
+fn ordered_fenced_item_stays_attached() {
+    // Ordered lists.
+    let lc = ctx(indoc! {"
+        1. ```python
+           code
+           ```
+
+           Attached paragraph.
+
+        2. Second item.
+    "});
+    let block = single_block(&lc);
+    assert!(block.is_ordered);
+    assert_eq!(block.start_line, 1);
+    assert_eq!(block.end_line, 7);
+    assert_eq!(block.item_lines, vec![1, 7]);
+}
+
+#[test]
+fn marker_like_lines_inside_fence_are_not_items() {
+    // Lines that look like list markers but live inside the fence are not items.
+    let lc = ctx(indoc! {"
+        - ```text
+          - not a real item
+          - also not
+          ```
+
+          Attached paragraph.
+    "});
+    let block = single_block(&lc);
+    assert_eq!(block.item_lines, vec![1], "only the marker line is an item");
+    assert_eq!(block.end_line, 6);
+}
+
+#[test]
+fn inline_code_item_stays_attached() {
+    // Inline code as the whole item content.
+    let lc = ctx(indoc! {"
+        - `config.toml`
+
+          Attached paragraph.
+
+        - Second item.
+    "});
+    let block = single_block(&lc);
+    assert_eq!(block.start_line, 1);
+    assert_eq!(block.end_line, 5);
+    assert_eq!(block.item_lines, vec![1, 5]);
+}
+
+#[test]
+fn inline_code_containing_backticks_is_not_a_fence() {
+    // An inline span containing a backtick run must not be read as a fence.
+    let lc = ctx(indoc! {"
+        - ``` not a fence, inline ```
+
+          Attached paragraph.
+
+        - Second item.
+    "});
+    let block = single_block(&lc);
+    assert_eq!(block.item_lines, vec![1, 5]);
+    assert_eq!(block.end_line, 5);
+}
+
+#[test]
+fn indented_fence_continuation_stays_attached() {
+    // A fence indented as continuation (on its own line, not the marker line).
+    let lc = ctx(indoc! {"
+        - Item text
+
+          ```python
+          code
+          ```
+
+          Attached paragraph.
+    "});
+    let block = single_block(&lc);
+    assert_eq!(block.start_line, 1);
+    assert_eq!(block.end_line, 7);
+    assert_eq!(block.item_lines, vec![1]);
+}
+
+// --- Rules that lint the opening fence line -----------------------------------
+
+#[test]
+fn md040_flags_missing_language() {
+    // MD040 flags a marker-line fence with no language, at the fence line.
+    let result = MD040FencedCodeLanguage::default()
+        .check(&ctx(indoc! {"
+            - ```
+              code here
+              ```
+        "}))
+        .unwrap();
+    assert_eq!(result.len(), 1, "got {result:?}");
+    assert_eq!(result[0].line, 1);
+}
+
+#[test]
+fn md040_clean_with_language() {
+    // MD040 is clean when the marker-line fence has a language.
+    let result = MD040FencedCodeLanguage::default()
+        .check(&ctx(indoc! {"
+            - ```python
+              code here
+              ```
+        "}))
+        .unwrap();
+    assert!(result.is_empty(), "got {result:?}");
+}
+
+#[test]
+fn md031_flags_missing_blank_after_fence() {
+    // MD031 flags text butting against the closing fence.
+    let result = MD031BlanksAroundFences::default()
+        .check(&ctx(indoc! {"
+            - ```python
+              y = 2
+              ```
+              text right after fence
+        "}))
+        .unwrap();
+    assert!(
+        result.iter().any(|w| w.line == 3),
+        "expected a warning on line 3, got {result:?}"
+    );
+}
+
+#[test]
+fn md046_treats_marker_line_fence_as_fenced() {
+    // Under the indented style, a marker-line fence is flagged like any fenced
+    // block — at the same line as a standalone fence.
+    let marker = MD046CodeBlockStyle::new(CodeBlockStyle::Indented)
+        .check(&ctx(indoc! {"
+            - ```python
+              y = 2
+              ```
+        "}))
+        .unwrap();
+    assert_eq!(marker.len(), 1, "got {marker:?}");
+    assert_eq!(marker[0].line, 1);
+
+    let standalone = MD046CodeBlockStyle::new(CodeBlockStyle::Indented)
+        .check(&ctx(indoc! {"
+            ```python
+            y = 2
+            ```
+        "}))
+        .unwrap();
+    assert_eq!(standalone.len(), 1);
+    assert_eq!(standalone[0].line, 1);
+}

--- a/tests/regressions/mod.rs
+++ b/tests/regressions/mod.rs
@@ -2,6 +2,7 @@ mod code_block_blockquote_edge_cases;
 mod consistency_regression_tests;
 mod embedded_markdown_fix_gate_issue_643_test;
 mod escaped_brackets_test;
+mod fenced_code_on_list_marker_test;
 mod final_confidence_assessment;
 mod html_comments_test;
 mod lint_context_list_blocks_issue_148_test;


### PR DESCRIPTION
A list marker line that also opens a fenced code block (e.g. "- ```python" or "1. ```js") is flagged `in_code_block`. `parse_list_blocks` short-circuited at its top-of-loop `in_code_block` guard before inspecting `list_item`, so the item was never registered and everything indented under it — continuation paragraphs and nested lists — was dropped from the list model. Tilde-fenced first items produced no list block at all.

Skip the code-block branch only when the line is not also a list item, letting the marker line fall through to normal list-item handling. Lines inside a fence are never flagged as list items, so this matches only the genuine marker line; marker-like lines within the fenced content stay out of the list. Inline code spans (single- or multi-line) were never affected.

Add regression tests for the parser fix (fenced item mid-list, as the first item, with a nested list, plus tilde and ordered variants and inline-code control cases) and for the rules that lint the opening fence line (MD040, MD031, MD046), confirming they still apply when the fence opens on a marker line.

Assisted-by: Claude Code