### PR TITLE
fix(MD007): keep nested lists nested under a fence-opening list item

### DIFF
--- a/src/rules/md007_ul_indent.rs
+++ b/src/rules/md007_ul_indent.rs
@@ -237,7 +237,21 @@ impl Rule for MD007ULIndent {
             let is_skipped_region = |info: &crate::lint_context::LineInfo| {
                 info.in_code_block || info.in_front_matter || info.in_mkdocstrings || info.in_footnote_definition
             };
-            if is_skipped_region(line_info) {
+            // Exception: a fenced code block can open on a list-marker line
+            // (e.g. "- ```"). Such a line is flagged `in_code_block` but is
+            // genuinely a list item, so it must fall through to the list-item
+            // handling below to be pushed onto the ancestor stack; otherwise its
+            // descendants resolve one nesting level too shallow and get wrongly
+            // flagged (and "fixed") as over-indented. Interior fence lines are not
+            // list items, so this only matches the marker line. The other skipped
+            // regions (front matter, mkdocstrings, footnote definitions) genuinely
+            // contain their list items, so those are still skipped.
+            let fence_opening_marker_line = line_info.list_item.is_some()
+                && line_info.in_code_block
+                && !line_info.in_front_matter
+                && !line_info.in_mkdocstrings
+                && !line_info.in_footnote_definition;
+            if is_skipped_region(line_info) && !fence_opening_marker_line {
                 // The opening line of such a region (e.g. an unindented code fence)
                 // breaks out of any open list just like a paragraph would, so the
                 // stale list stack must be cleared even though the region's lines

--- a/tests/regressions/fenced_code_on_list_marker_test.rs
+++ b/tests/regressions/fenced_code_on_list_marker_test.rs
@@ -9,7 +9,7 @@ use rumdl_lib::config::MarkdownFlavor;
 use rumdl_lib::lint_context::{LintContext, ListBlock};
 use rumdl_lib::rule::Rule;
 use rumdl_lib::rules::{
-    CodeBlockStyle, MD031BlanksAroundFences, MD032BlanksAroundLists, MD040FencedCodeLanguage,
+    CodeBlockStyle, MD007ULIndent, MD031BlanksAroundFences, MD032BlanksAroundLists, MD040FencedCodeLanguage,
     MD077ListContinuationIndent,
 };
 
@@ -310,5 +310,54 @@ fn md077_flags_overindented_continuation_under_fenced_item() {
     assert!(
         result.iter().any(|w| w.line == 4),
         "expected an MD077 warning on line 4, got {result:?}"
+    );
+}
+
+#[test]
+fn md007_keeps_nesting_under_fence_opening_item() {
+    // The outer item opens a fenced code block on its marker line, then a
+    // continuation paragraph, then a correctly-indented nested list (and a deeper
+    // one). MD007 keeps its own ancestor stack and must register the fence-opening
+    // item on it; otherwise the descendants resolve one level too shallow and the
+    // correctly-nested lists get flagged "Expected ... depth 0" and the fix
+    // un-nests them. Correct nesting must produce no warnings.
+    let result = MD007ULIndent::default()
+        .check(&ctx(indoc! {"
+            - ```
+              code
+              ```
+
+              Paragraph.
+
+              - nested
+                - deeper
+        "}))
+        .unwrap();
+    assert!(
+        result.is_empty(),
+        "nested lists under a fence-opening item must stay nested, got {result:?}"
+    );
+}
+
+#[test]
+fn md007_keeps_nesting_under_ordered_fence_opening_item() {
+    // Same bug with an ordered outer item: MD007 tracks ordered items as nesting
+    // ancestors, so an ordered item opening a fence must also be registered.
+    // Otherwise its nested unordered list resolves as top-level and gets un-nested.
+    let result = MD007ULIndent::default()
+        .check(&ctx(indoc! {"
+            1. ```
+               code
+               ```
+
+               Paragraph.
+
+               - nested
+                 - deeper
+        "}))
+        .unwrap();
+    assert!(
+        result.is_empty(),
+        "nested list under an ordered fence-opening item must stay nested, got {result:?}"
     );
 }


### PR DESCRIPTION
Another fun corner case found by formatting Carbon's markdown. =D

MD007 tracks list ancestors on its own stack and skips lines inside code blocks. A list item that opens a fenced code block on its marker line
(e.g. "-   ```" or "1.  ```") is itself flagged `in_code_block`, so it
was skipped and never pushed onto the ancestor stack. Every descendant
list then resolved one nesting level too shallow: correctly-indented
nested lists were reported as over-indented and the fix stripped their
indentation, flattening the nesting.

Let a fence-opening list-marker line fall through to the normal list-item handling so it is registered on the ancestor stack. The exception is scoped to the code-block case only: front matter, mkdocstrings, and footnote definitions genuinely contain their list items, so those are still skipped.

Add regression tests that a nested list under a fence-opening item, whether the outer item is unordered or ordered, is recognized as nested.

Assisted-by: Claude Code