### PR TITLE
feat(MD013): add semantic-link-understanding to flag long-URL links in stern mode

### DIFF
--- a/docs/md013.md
+++ b/docs/md013.md
@@ -58,6 +58,7 @@ paragraphs = true  # Check paragraph/regular text (default: true)
 blockquotes = true  # Check blockquote content (default: true)
 strict = false  # Disables exceptions for URLs, etc. (default: false)
 stern = false  # Like strict, but unwrappable single-token lines are still permitted (default: false)
+semantic-link-understanding = true  # Forgive lines that exceed only because of an inline link/image URL (default: true)
 heading-line-length = 100  # Optional per-context limit for headings; falls back to line-length when unset
 code-block-line-length = 120  # Optional per-context limit for code blocks; falls back to line-length when unset
 reflow = false  # Enable automatic text reflow/wrapping (default: false)
@@ -78,6 +79,7 @@ require-sentence-capital = true  # Require uppercase after periods for sentence 
 - `blockquotes`: Whether to check line length in blockquote content (default: `true`). Set to `false` to skip blockquote lines specifically without disabling all paragraph checks
 - `strict`: When true, disables exceptions for URLs and other special content (default: `false`). Overrides `stern`.
 - `stern`: Tighter than the default but laxer than strict. Disables the trailing-token forgiveness used in default mode (so a line is flagged even when only the final token spills past the limit), but keeps the "unwrappable line" exemption — lines that consist of a single non-whitespace token, optionally prefixed by `#` heading or `>` blockquote markers, are still permitted (default: `false`). Mirrors markdownlint's `stern` option.
+- `semantic-link-understanding`: Whether to forgive a line that exceeds the limit only because of the URL inside an inline `[text](url)` / `![alt](url)` (default: `true`; see [Semantic link understanding](#semantic-link-understanding-non-strict-mode)). Set to `false` to count those URLs toward the line length. Combined with `stern`, this flags a link line that has wrappable text around it while still exempting a line that is a single unbreakable token (a bare URL or a standalone link) — i.e. stricter than `stern` about links, but without `strict` flagging genuinely unbreakable link lines. Has no effect under `strict` (which already disables all forgiveness).
 - `heading-line-length`: Per-context maximum length for heading lines. Unset (`null`) falls back to `line-length`; `0` means "no limit for headings". Mirrors markdownlint's `heading_line_length` option.
 - `code-block-line-length`: Per-context maximum length for fenced or indented code-block lines. Unset (`null`) falls back to `line-length`; `0` means "no limit for code blocks". Mirrors markdownlint's `code_block_line_length` option.
 - `reflow`: When true, enables automatic text reflow to wrap long lines intelligently (default: `false`)
@@ -95,7 +97,7 @@ require-sentence-capital = true  # Require uppercase after periods for sentence 
   - When `false`, `word. lowercase` is also treated as a sentence boundary (more splitting)
   - Does not affect `!` and `?` which are always treated as sentence boundaries
 
-## Inline link URL tolerance (non-strict mode)
+## Semantic link understanding (non-strict mode)
 
 In non-strict mode, this rule understands that inline links and images often contain
 long URLs that the author cannot reasonably shorten. When a line exceeds the limit,
@@ -114,6 +116,7 @@ This does **not** apply to:
 - Reference links (`[text][ref]`) — these already have no inline URL
 - Autolinks (`<url>`) — the URL itself is the visible content
 - Strict mode — all exceptions are disabled
+- `semantic-link-understanding = false` — count inline link/image URLs toward the line length. With `stern`, this flags a link line that has wrappable text around it, while a line that is a single unbreakable token (a bare URL or a standalone link) is still permitted by stern's unwrappable-line exemption.
 
 ### Example
 

--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -66,6 +66,7 @@ impl MD013LineLength {
                 length_mode: LengthMode::default(),
                 abbreviations: Vec::new(),
                 require_sentence_capital: true,
+                semantic_link_understanding: true,
             },
         }
     }
@@ -221,6 +222,16 @@ impl Rule for MD013LineLength {
                 if let Some(strict) = obj.get("strict").and_then(serde_json::Value::as_bool) {
                     config.strict = strict;
                 }
+                if let Some(stern) = obj.get("stern").and_then(serde_json::Value::as_bool) {
+                    config.stern = stern;
+                }
+                if let Some(v) = obj
+                    .get("semantic_link_understanding")
+                    .or_else(|| obj.get("semantic-link-understanding"))
+                    .and_then(serde_json::Value::as_bool)
+                {
+                    config.semantic_link_understanding = v;
+                }
                 if let Some(reflow) = obj.get("reflow").and_then(serde_json::Value::as_bool) {
                     config.reflow = reflow;
                 }
@@ -371,8 +382,10 @@ impl Rule for MD013LineLength {
                 continue;
             }
 
-            // Semantic link understanding: suppress when excess comes entirely from inline URLs
-            if !effective_config.strict {
+            // Semantic link understanding: suppress when excess comes entirely from inline URLs.
+            // Disabled by `strict` (all forgiveness off) and by `semantic_link_understanding = false`
+            // (count link/image URLs toward the line length so such lines are flagged).
+            if !effective_config.strict && effective_config.semantic_link_understanding {
                 let text_only_length = self.calculate_text_only_length(effective_length, line_number, ctx);
                 if text_only_length <= line_limit {
                     continue;

--- a/src/rules/md013_line_length/md013_config.rs
+++ b/src/rules/md013_line_length/md013_config.rs
@@ -98,6 +98,21 @@ pub struct MD013Config {
     #[serde(default)]
     pub stern: bool,
 
+    /// Whether to apply semantic link understanding (default: true).
+    ///
+    /// In non-strict mode, a line that exceeds the limit only because of the URL
+    /// portion of an inline `[text](url)` / `![alt](url)` is forgiven (the URL
+    /// cannot be shortened). Set to `false` to count those URLs toward the line
+    /// length so the line is flagged. Combine with `stern` to flag a link line
+    /// that has wrappable text around it while still exempting a line that is a
+    /// single unbreakable token (a bare URL or a standalone link). Has no effect
+    /// in `strict` mode, which already disables all forgiveness.
+    #[serde(
+        default = "default_semantic_link_understanding",
+        alias = "semantic_link_understanding"
+    )]
+    pub semantic_link_understanding: bool,
+
     /// Per-context maximum line length for headings.
     ///
     /// `None` (unset) falls back to `line_length`. `Some(0)` means "no limit
@@ -179,6 +194,10 @@ fn default_require_sentence_capital() -> bool {
     true
 }
 
+fn default_semantic_link_understanding() -> bool {
+    true
+}
+
 impl Default for MD013Config {
     fn default() -> Self {
         Self {
@@ -191,6 +210,7 @@ impl Default for MD013Config {
             blockquotes: default_blockquotes(),
             strict: false,
             stern: false,
+            semantic_link_understanding: default_semantic_link_understanding(),
             heading_line_length: None,
             code_block_line_length: None,
             reflow: false,
@@ -372,6 +392,7 @@ mod tests {
             length_mode: LengthMode::default(),
             abbreviations: Vec::new(),
             require_sentence_capital: true,
+            semantic_link_understanding: true,
         };
 
         let toml_str = toml::to_string(&config).unwrap();

--- a/src/rules/md013_line_length/tests.rs
+++ b/src/rules/md013_line_length/tests.rs
@@ -2697,6 +2697,7 @@ fn test_paragraphs_false_skips_regular_text() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2733,6 +2734,7 @@ fn test_paragraphs_false_still_checks_code_blocks() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2770,6 +2772,7 @@ fn test_paragraphs_false_still_checks_headings() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2805,6 +2808,7 @@ fn test_paragraphs_false_with_reflow_sentence_per_line() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2840,6 +2844,7 @@ fn test_paragraphs_true_checks_regular_text() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2875,6 +2880,7 @@ fn test_line_length_zero_disables_all_checks() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2910,6 +2916,7 @@ fn test_line_length_zero_with_headings() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2945,6 +2952,7 @@ fn test_line_length_zero_with_code_blocks() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2980,6 +2988,7 @@ fn test_line_length_zero_with_sentence_per_line_reflow() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3043,6 +3052,7 @@ Final paragraph.
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
     let result = rule.check(&ctx).unwrap();
@@ -3110,6 +3120,7 @@ fn test_reflow_preserves_mkdocstrings_autodoc_block() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3143,6 +3154,7 @@ fn test_reflow_preserves_mkdocstrings_with_identifier() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3177,6 +3189,7 @@ fn test_reflow_preserves_mkdocstrings_surrounded_by_paragraphs() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3214,6 +3227,7 @@ fn test_reflow_mkdocstrings_not_detected_in_standard_flavor() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3244,6 +3258,7 @@ fn test_reflow_preserves_mkdocstrings_with_blank_line_in_block() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5175,6 +5190,7 @@ fn test_reflow_admonition_in_list_item_basic() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5238,6 +5254,7 @@ fn test_reflow_collapsible_admonition_in_list_item() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5293,6 +5310,7 @@ fn test_reflow_multiple_admonitions_in_list_item() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5370,6 +5388,7 @@ fn test_reflow_admonition_short_content_preserved() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5416,6 +5435,7 @@ fn test_reflow_admonition_with_multiple_paragraphs() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5484,6 +5504,7 @@ fn test_reflow_admonition_not_in_standard_flavor() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5532,6 +5553,7 @@ fn test_reflow_admonition_idempotent() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5585,6 +5607,7 @@ fn test_reflow_admonition_only_in_list_no_long_text() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5643,6 +5666,7 @@ fn test_reflow_content_after_admonition_in_list_item() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5706,6 +5730,7 @@ fn test_reflow_content_after_admonition_short_lines() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5753,6 +5778,7 @@ fn test_reflow_multiple_blocks_after_admonition() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5808,6 +5834,7 @@ fn test_reflow_admonition_empty_body() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5857,6 +5884,7 @@ fn test_reflow_admonition_no_blank_line_before_body() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5910,6 +5938,7 @@ fn test_reflow_admonition_body_indent_preserved() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5969,6 +5998,7 @@ fn test_reflow_admonition_with_code_block_in_list_item() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6033,6 +6063,7 @@ fn test_reflow_admonition_with_tilde_fence_in_list_item() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6091,6 +6122,7 @@ fn test_reflow_admonition_with_multiple_code_blocks_in_list_item() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6157,6 +6189,7 @@ fn test_reflow_admonition_code_block_idempotent() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6208,6 +6241,7 @@ fn test_reflow_tab_container_in_list_item() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6852,6 +6886,7 @@ fn test_paragraphs_false_skips_blockquote_content() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6887,6 +6922,7 @@ fn test_blockquotes_false_skips_blockquote_content() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6922,6 +6958,7 @@ fn test_blockquotes_true_paragraphs_true_checks_blockquotes() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6956,6 +6993,7 @@ fn test_blockquotes_false_still_checks_regular_paragraphs() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6990,6 +7028,7 @@ fn test_blockquotes_false_paragraphs_false_skips_blockquotes() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7040,6 +7079,7 @@ fn test_nested_blockquote_skipped_when_blockquotes_false() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7074,6 +7114,7 @@ fn test_paragraphs_false_skips_nested_blockquote() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7109,6 +7150,7 @@ fn test_blockquotes_false_skips_reflow_warnings() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7144,6 +7186,7 @@ fn test_paragraphs_false_skips_blockquote_reflow_warnings() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7179,6 +7222,7 @@ fn test_blockquotes_true_with_reflow_still_warns() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7213,6 +7257,7 @@ fn test_blockquotes_false_skips_lazy_continuation() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7247,6 +7292,7 @@ fn test_blockquotes_false_reflow_skips_lazy_continuation() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7282,6 +7328,7 @@ fn test_blockquotes_false_paragraph_after_blockquote_still_warns() {
         length_mode: LengthMode::default(),
         abbreviations: Vec::new(),
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -8085,6 +8132,99 @@ fn test_md013_stern_strict_takes_precedence() {
         result.len(),
         1,
         "strict must override stern's unwrappable exemption, got {result:?}"
+    );
+}
+
+// A long URL that pushes the line past 80 on its own; the visible text is short.
+const LONG_URL: &str = "https://example.com/an/extremely/long/url/path/that/keeps/going/well/past/eighty/columns";
+
+#[test]
+fn test_md013_semantic_link_understanding_on_forgives_wrappable_link_line() {
+    // Default: semantic_link_understanding = true. A line over the limit only because of an
+    // inline link's URL is forgiven, even in stern mode.
+    let config = MD013Config {
+        stern: true,
+        ..MD013Config::default()
+    };
+    let rule = make_rule(config);
+    let content = format!("Some lead text here [x]({LONG_URL}) and trailing words.\n");
+    let ctx = LintContext::new(&content, MarkdownFlavor::Standard, None);
+    let result = rule.check(&ctx).unwrap();
+    assert!(
+        result.is_empty(),
+        "with semantic_link_understanding on, a URL-only-over link line is forgiven, got {result:?}"
+    );
+}
+
+#[test]
+fn test_md013_semantic_link_understanding_off_flags_wrappable_link_line() {
+    // stern + semantic_link_understanding = false: count the URL toward the line length, so a
+    // link line with wrappable text around it is flagged (what strict also does).
+    let config = MD013Config {
+        stern: true,
+        semantic_link_understanding: false,
+        ..MD013Config::default()
+    };
+    let rule = make_rule(config);
+    let content = format!("Some lead text here [x]({LONG_URL}) and trailing words.\n");
+    let ctx = LintContext::new(&content, MarkdownFlavor::Standard, None);
+    let result = rule.check(&ctx).unwrap();
+    assert_eq!(
+        result.len(),
+        1,
+        "with semantic_link_understanding off, the link line must be flagged, got {result:?}"
+    );
+}
+
+#[test]
+fn test_md013_semantic_link_understanding_off_still_exempts_unbreakable_link() {
+    // The key difference from strict: a standalone link (a single unbreakable
+    // token) stays exempt under stern even with tolerance off, because stern's
+    // single-token exemption is independent of semantic_link_understanding.
+    let config = MD013Config {
+        stern: true,
+        semantic_link_understanding: false,
+        ..MD013Config::default()
+    };
+    let rule = make_rule(config);
+    for content in [format!("[x]({LONG_URL})\n"), format!("- [x]({LONG_URL})\n")] {
+        let ctx = LintContext::new(&content, MarkdownFlavor::Standard, None);
+        let result = rule.check(&ctx).unwrap();
+        assert!(
+            result.is_empty(),
+            "stern + tolerance off must still exempt an unbreakable standalone link, got {result:?} for {content:?}"
+        );
+    }
+
+    // strict, by contrast, flags even the unbreakable standalone link.
+    let strict = make_rule(MD013Config {
+        strict: true,
+        ..MD013Config::default()
+    });
+    let content = format!("[x]({LONG_URL})\n");
+    let ctx = LintContext::new(&content, MarkdownFlavor::Standard, None);
+    assert_eq!(
+        strict.check(&ctx).unwrap().len(),
+        1,
+        "strict flags the standalone link that stern + tolerance off exempts"
+    );
+}
+
+#[test]
+fn test_md013_semantic_link_understanding_off_default_mode() {
+    // semantic_link_understanding is orthogonal to stern: it also disables the forgiveness
+    // in default mode (the trailing-token rule does not save a mid-line link).
+    let config = MD013Config {
+        semantic_link_understanding: false,
+        ..MD013Config::default()
+    };
+    let rule = make_rule(config);
+    let content = format!("Some lead text here [x]({LONG_URL}) and trailing words.\n");
+    let ctx = LintContext::new(&content, MarkdownFlavor::Standard, None);
+    assert_eq!(
+        rule.check(&ctx).unwrap().len(),
+        1,
+        "semantic_link_understanding off flags the link line in default mode too"
     );
 }
 

--- a/tests/formats/sentence_per_line_test.rs
+++ b/tests/formats/sentence_per_line_test.rs
@@ -22,6 +22,7 @@ fn create_sentence_per_line_rule() -> MD013LineLength {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec![],
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     })
 }
 
@@ -239,6 +240,7 @@ fn test_single_sentence_with_no_line_length_constraint() {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec![],
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     });
     let content = "This document provides advice for porting Rust code using PyO3 to run under\n\
                    free-threaded Python.";
@@ -305,6 +307,7 @@ fn test_custom_abbreviations_recognized() {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec!["Assn".to_string()],
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     });
 
     // With custom "Assn" abbreviation, this should be ONE sentence
@@ -339,6 +342,7 @@ fn test_custom_abbreviations_merged_with_builtin() {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec!["Assn".to_string()],
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     });
 
     // Both "Dr." (built-in) and "Assn." (custom) should be recognized
@@ -373,6 +377,7 @@ fn test_custom_abbreviation_with_period_in_config() {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec!["Univ".to_string()],
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     });
 
     let rule_with_period = MD013LineLength::from_config_struct(MD013Config {
@@ -392,6 +397,7 @@ fn test_custom_abbreviation_with_period_in_config() {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec!["Univ.".to_string()],
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     });
 
     let content = "Visit Univ. Campus for the tour.";
@@ -433,6 +439,7 @@ fn test_issue_335_abbreviations_config_empty_vec_uses_defaults() {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec![], // Empty = use built-in defaults
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     });
 
     // "Dr." is a built-in abbreviation - should NOT split after it
@@ -488,6 +495,7 @@ fn test_issue_335_custom_abbreviations_extend_defaults() {
         length_mode: rumdl_lib::rules::md013_line_length::md013_config::LengthMode::default(),
         abbreviations: vec!["Corp".to_string(), "Inc".to_string()],
         require_sentence_capital: true,
+        semantic_link_understanding: true,
     });
 
     // Single sentence with multiple abbreviations - no warning expected


### PR DESCRIPTION
In non-strict mode MD013 forgives a line that exceeds the limit only because of the URL inside an inline `[text](url)` / `![alt](url)` — this "semantic link understanding" is gated on `!strict`, so `stern` inherits it and behaves like default for such link lines. There was no way to flag a wrappable link line without going to full `strict`, which also flags genuinely unbreakable single-token links.

Add a `semantic-link-understanding` option (default `true`, preserving current behavior). Set it to `false` to count inline link/image URLs toward the line length. The gate becomes `!strict && semantic_link_understanding`, so combined with `stern` it flags a link line that has wrappable text around it while still exempting a line that is a single unbreakable token (a bare URL or a standalone link) via stern's unwrappable-line exemption. No effect under `strict`.

Also parse `stern` and `semantic-link-understanding` from inline (per-file) config.

Add tests covering the option across stern/default/strict and document it.

Assisted-by: Claude Code