### PR TITLE
fix(MD013): keep the space after an inline code span before punctuation

### DIFF
--- a/src/utils/text_reflow.rs
+++ b/src/utils/text_reflow.rs
@@ -2295,10 +2295,17 @@ fn reflow_elements(elements: &[Element], options: &ReflowOptions) -> Vec<String>
                     current_length = word_len;
                     current_line_element_spans.clear();
                 } else {
-                    // Add word to current line
-                    // Only add space if: we have content AND (this isn't the first word OR original had leading space)
-                    // AND this isn't trailing punctuation (which attaches directly)
-                    if current_length > 0 && (i > 0 || has_leading_space) && !is_trailing_punct {
+                    // Add a space only where the source had whitespace at this position.
+                    // For the first word of a text run (i == 0) that means the source had a
+                    // leading space — and reaching this branch already implies the word is
+                    // not adjacent to the previous element, so the space is real and must be
+                    // kept even for punctuation. Suppressing it here would delete the space
+                    // after an inline element, e.g. `` `code` } `` -> `` `code`} ``. The
+                    // no-space (adjacent) case is handled above by `is_first_adjacent`.
+                    // Within a text run (i > 0) trailing punctuation still attaches to the
+                    // preceding word.
+                    let add_space = current_length > 0 && if i == 0 { has_leading_space } else { !is_trailing_punct };
+                    if add_space {
                         current_line.push(' ');
                         current_length += 1;
                     }

--- a/tests/utils/text_reflow_test.rs
+++ b/tests/utils/text_reflow_test.rs
@@ -6290,3 +6290,52 @@ fn test_slb_standalone_paren_not_merged_back() {
         "Parenthetical must be on its own line, not merged with 'elsewhere'. Got:\n{result:#?}"
     );
 }
+
+#[test]
+fn test_reflow_preserves_space_after_code_span_before_punctuation() {
+    // Regression: a punctuation / closing-bracket word that follows an inline code
+    // span with a space in the source must keep that space. Reflow used to classify
+    // such a word as "trailing punctuation" and attach it, deleting the real space
+    // after the code span (e.g. a literal "`code` }" became "`code`}").
+    let options = ReflowOptions {
+        line_length: 60,
+        ..Default::default()
+    };
+
+    // A closing brace used as a literal symbol after a code span (the reported case).
+    let input = "Closing brace as a word: `code` } and then a long tail of words to wrap.";
+    let result = reflow_markdown(input, &options);
+    assert!(
+        result.contains("`code` }"),
+        "space after the code span must be preserved, got:\n{result}"
+    );
+    assert!(
+        !result.contains("`code`}"),
+        "the space after the code span must not be deleted, got:\n{result}"
+    );
+
+    // Braces inside code spans round-trip untouched too.
+    let input2 = "A set notation example `{` 1 2 3 `}` and then some more trailing words here.";
+    let result2 = reflow_markdown(input2, &options);
+    assert!(
+        result2.contains("`{` 1 2 3 `}`"),
+        "code-span braces must be preserved verbatim, got:\n{result2}"
+    );
+
+    // No regression: punctuation directly after a code span (no source space) still
+    // attaches without a space.
+    let input3 = "Use the `foo`, then `bar`. Plus more words that are long enough to wrap here now.";
+    let result3 = reflow_markdown(input3, &options);
+    assert!(
+        result3.contains("`foo`,"),
+        "no-space comma must stay attached, got:\n{result3}"
+    );
+    assert!(
+        result3.contains("`bar`."),
+        "no-space period must stay attached, got:\n{result3}"
+    );
+    assert!(
+        !result3.contains("`foo` ,"),
+        "a space must not be introduced before attached punctuation, got:\n{result3}"
+    );
+}


### PR DESCRIPTION
Before, reflow (in the default and normalize modes) deleted the space between an inline element and a following punctuation-only word when the source had one: a line like "`code` }" was rewrapped to "`code`}". The same happened for other closing brackets and punctuation (`)`, `]`, `,`, `.`, ...), so literal symbols written after a code span lost their separating space.

The word-append step suppressed the leading space for any "trailing punctuation" word so that punctuation would attach to the preceding token. But the no-space (adjacent) case is already handled earlier, so that branch is only reached when the source actually had a space — and suppressing it there deleted a real one.

After, the space is suppressed only within a text run, where attaching grammatical punctuation is correct; the first word after an inline element keeps the source's leading space. Punctuation written directly after a code span (no source space) still attaches with no space, as before.

Add a regression test covering the reported brace case, braces inside code spans, and the no-space attachment cases.

Assisted-by: Claude <noreply@anthropic.com>