### PR TITLE
fix(lsp): iterate formatting fixes to a fixpoint so one format pass converges

### DIFF
--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -17,8 +17,6 @@ use crate::config::{Config, is_valid_rule_name};
 use crate::discovery::{ExcludeMatchers, is_markdown_extension};
 use crate::lsp::index_worker::IndexWorker;
 use crate::lsp::types::{IndexState, IndexUpdate, LspRuleSettings, RumdlLspConfig};
-use crate::rule::FixCapability;
-use crate::rules;
 use crate::workspace_index::WorkspaceIndex;
 
 /// Maximum number of rules in enable/disable lists (DoS protection)
@@ -1087,85 +1085,22 @@ impl LanguageServer for RumdlLanguageServer {
         );
 
         if let Some(text) = self.get_document_content(&uri).await {
-            // Get config with LSP overrides
-            let config_guard = self.config.read().await;
-            let lsp_config = config_guard.clone();
-            drop(config_guard);
-
-            // Resolve configuration for this specific file
-            let file_path = uri.to_file_path().ok();
-            let file_config = if let Some(ref path) = file_path {
-                self.resolve_config_for_file(path).await
-            } else {
-                // Fallback to global config for non-file URIs
-                self.rumdl_config.read().await.clone()
-            };
-
-            // Merge LSP settings with file config based on configuration_preference
-            let rumdl_config = self.merge_lsp_settings(file_config, &lsp_config);
-
-            let all_rules = rules::all_rules(&rumdl_config);
-            let flavor = if let Some(ref path) = file_path {
-                rumdl_config.get_flavor_for_file(path)
-            } else {
-                rumdl_config.markdown_flavor()
-            };
-
-            // Use the standard filter_rules function which respects config's disabled rules
-            let mut filtered_rules = rules::filter_rules(&all_rules, &rumdl_config.global);
-
-            // Apply LSP config overrides
-            filtered_rules = self.apply_lsp_config_overrides(filtered_rules, &lsp_config);
-
-            // Phase 1: Apply lint rule fixes
-            let mut result = text.clone();
-            match crate::lint(
-                &text,
-                &filtered_rules,
-                false,
-                flavor,
-                file_path.clone(),
-                Some(&rumdl_config),
-            ) {
-                Ok(warnings) => {
-                    log::debug!(
-                        "Found {} warnings, {} with fixes",
-                        warnings.len(),
-                        warnings.iter().filter(|w| w.fix.is_some()).count()
-                    );
-
-                    let has_fixes = warnings.iter().any(|w| w.fix.is_some());
-                    if has_fixes {
-                        // Only apply fixes from fixable rules during formatting
-                        let fixable_warnings: Vec<_> = warnings
-                            .iter()
-                            .filter(|w| {
-                                if let Some(rule_name) = &w.rule_name {
-                                    filtered_rules
-                                        .iter()
-                                        .find(|r| r.name() == rule_name)
-                                        .is_some_and(|r| r.fix_capability() != FixCapability::Unfixable)
-                                } else {
-                                    false
-                                }
-                            })
-                            .cloned()
-                            .collect();
-
-                        match crate::utils::fix_utils::apply_warning_fixes(&text, &fixable_warnings) {
-                            Ok(fixed_content) => {
-                                result = fixed_content;
-                            }
-                            Err(e) => {
-                                log::error!("Failed to apply fixes: {e}");
-                            }
-                        }
-                    }
-                }
+            // Phase 1: Apply lint rule fixes, iterating to a fixpoint through the
+            // same `FixCoordinator` engine as `rumdl check --fix` and the editor's
+            // fix-all action. A single fix pass can leave cascading fixes
+            // unapplied — e.g. MD030 widening a list marker, which then requires
+            // MD007 to re-indent the nested content and its continuation lines —
+            // which forced "Format Document" to be run several times to converge
+            // (rvben/rumdl-vscode#145). `apply_all_fixes` also handles config
+            // resolution, rule filtering, LSP overrides and excludes for the URI.
+            let mut result = match self.apply_all_fixes(&uri, &text).await {
+                Ok(Some(fixed)) => fixed,
+                Ok(None) => text.clone(),
                 Err(e) => {
-                    log::error!("Failed to lint document: {e}");
+                    log::error!("Failed to apply fixes during formatting: {e}");
+                    text.clone()
                 }
-            }
+            };
 
             // Phase 2: Apply FormattingOptions (standard LSP behavior)
             // This ensures we respect editor preferences even if lint rules don't catch everything

--- a/src/lsp/tests.rs
+++ b/src/lsp/tests.rs
@@ -8636,3 +8636,163 @@ reflow-mode = "semantic-line-breaks"
         actions.iter().map(|a| &a.title).collect::<Vec<_>>()
     );
 }
+
+/// Apply one LSP `formatting` pass and return the resulting document content,
+/// persisting it back to the server (mimicking the editor applying the edit).
+/// The handler returns a single whole-document edit, so `new_text` is the full
+/// new content.
+async fn format_once(server: &RumdlLanguageServer, uri: &Url, options: &FormattingOptions) -> String {
+    let before = server.documents.read().await.get(uri).unwrap().content.clone();
+    let params = DocumentFormattingParams {
+        text_document: TextDocumentIdentifier { uri: uri.clone() },
+        options: options.clone(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    };
+    let after = match server.formatting(params).await.unwrap() {
+        Some(edits) if !edits.is_empty() => edits[0].new_text.clone(),
+        _ => before,
+    };
+    server.documents.write().await.insert(
+        uri.clone(),
+        DocumentEntry {
+            content: after.clone(),
+            version: Some(1),
+            from_disk: false,
+        },
+    );
+    after
+}
+
+/// Standard editor formatting options used by the formatting tests.
+fn editor_formatting_options() -> FormattingOptions {
+    FormattingOptions {
+        tab_size: 4,
+        insert_spaces: true,
+        properties: HashMap::new(),
+        trim_trailing_whitespace: Some(true),
+        insert_final_newline: Some(true),
+        trim_final_newlines: Some(true),
+    }
+}
+
+/// Build a test server whose resolved config sets MD030 `ul-single`/`ul-multi`,
+/// using the same config representation the CLI loads from a `rumdl.toml`.
+async fn server_with_md030_spacing(ul_single: usize, ul_multi: usize) -> RumdlLanguageServer {
+    let server = create_test_server();
+    let mut config = crate::config::Config::default();
+    let toml_src = format!("[MD030]\nul-single = {ul_single}\nul-multi = {ul_multi}\n");
+    let parsed: toml::Table = toml::from_str(&toml_src).unwrap();
+    for (key, value) in parsed {
+        let mut values = std::collections::BTreeMap::new();
+        if let toml::Value::Table(table) = value {
+            for (k, v) in table {
+                values.insert(k, v);
+            }
+        }
+        config
+            .rules
+            .insert(key, crate::config::RuleConfig { severity: None, values });
+    }
+    *server.rumdl_config.write().await = config;
+    // Force config resolution to use the injected config instead of on-disk discovery.
+    server.config.write().await.config_path = Some("rumdl.toml".to_string());
+    server
+}
+
+/// Store `content` under `uri`, format it twice, and return both results so the
+/// caller can assert the formatting handler reaches a fixpoint in a single pass.
+async fn format_twice(server: &RumdlLanguageServer, uri: &Url, content: &str) -> (String, String) {
+    server.documents.write().await.insert(
+        uri.clone(),
+        DocumentEntry {
+            content: content.to_string(),
+            version: Some(1),
+            from_disk: false,
+        },
+    );
+    let options = editor_formatting_options();
+    let first = format_once(server, uri, &options).await;
+    let second = format_once(server, uri, &options).await;
+    (first, second)
+}
+
+/// Regression for rvben/rumdl-vscode#145: a single "Format Document" must reach a
+/// fixpoint. Nested lists whose marker spacing AND continuation indent both need
+/// adjusting (MD030 `ul-single`/`ul-multi` = 3) used to need several passes in the
+/// editor because the LSP formatting handler applied fixes in a single pass.
+/// `rumdl check --fix` converges in one run by iterating to a fixpoint; the
+/// formatting handler must do the same.
+#[tokio::test]
+async fn test_formatting_idempotent_cascading_list_indent_issue_145() {
+    let server = server_with_md030_spacing(3, 3).await;
+    let uri = Url::parse("file:///nested.md").unwrap();
+    // The exact testcase from the issue.
+    let input = "- Bullet 1\n    - Sub-bullet with long text that is long enough that it is wrapped onto\n      multiple lines.\n- Bullet 2\n";
+
+    let (after_first, after_second) = format_twice(&server, &uri, input).await;
+
+    assert_eq!(
+        after_first, after_second,
+        "formatting must reach a fixpoint in one pass (rvben/rumdl-vscode#145):\n--- after first pass ---\n{after_first}\n--- after second pass ---\n{after_second}"
+    );
+
+    // A single pass must also land on the exact fixpoint that `rumdl check --fix`
+    // (the iterative engine) produces for this input and config.
+    let expected = "-   Bullet 1\n  -   Sub-bullet with long text that is long enough that it is wrapped onto\n      multiple lines.\n-   Bullet 2\n";
+    assert_eq!(
+        after_first, expected,
+        "one formatting pass should match the `rumdl check --fix` fixpoint, got:\n{after_first}"
+    );
+}
+
+/// Same root cause as #145 but with continuation lines at both nesting levels:
+/// widening the markers cascades into re-indenting each level's continuation, so
+/// a single-pass formatter could not converge. One pass must now be a fixpoint.
+#[tokio::test]
+async fn test_formatting_idempotent_nested_continuation_both_levels() {
+    let server = server_with_md030_spacing(3, 3).await;
+    let uri = Url::parse("file:///both-levels.md").unwrap();
+    let input = "- Outer item with text long enough that it is\n  wrapped onto a second line here.\n  - Inner item with text long enough that it is\n    wrapped onto a second line here.\n";
+
+    let (after_first, after_second) = format_twice(&server, &uri, input).await;
+
+    assert_eq!(
+        after_first, after_second,
+        "formatting must reach a fixpoint in one pass with continuation at both levels:\n--- after first pass ---\n{after_first}\n--- after second pass ---\n{after_second}"
+    );
+    // Both markers were widened to three spaces after the bullet.
+    assert!(
+        after_first.contains("-   Outer"),
+        "outer marker widened, got:\n{after_first}"
+    );
+    assert!(
+        after_first.contains("-   Inner"),
+        "inner marker widened, got:\n{after_first}"
+    );
+}
+
+/// The formatting handler routes through `apply_all_fixes`, which must keep
+/// applying the LSP-specific config (VS Code settings), not just the on-disk
+/// file config. Disabling MD030 via the LSP `disable_rules` setting must stop
+/// the formatter from re-spacing list markers, even though the file config
+/// enables MD030 `ul-single`/`ul-multi` = 3.
+#[tokio::test]
+async fn test_formatting_honors_lsp_disable_rules() {
+    let server = server_with_md030_spacing(3, 3).await;
+    // LSP-specific override: a VS Code user/workspace setting disabling MD030.
+    server.config.write().await.disable_rules = Some(vec!["MD030".to_string()]);
+
+    let uri = Url::parse("file:///lsp-disable.md").unwrap();
+    let input = "- Bullet 1\n  - Sub-bullet here.\n- Bullet 2\n";
+    let (after_first, _after_second) = format_twice(&server, &uri, input).await;
+
+    // MD030 is disabled through LSP settings, so markers keep their single space.
+    assert!(
+        !after_first.contains("-   "),
+        "LSP disable_rules must suppress MD030 marker spacing during formatting, got:\n{after_first}"
+    );
+    assert!(
+        after_first.contains("- Bullet 1"),
+        "single-space marker must be preserved, got:\n{after_first}"
+    );
+}


### PR DESCRIPTION
Before, the LSP textDocument/formatting handler (VS Code's "Format Document") applied lint fixes in a single pass: it linted once and applied those fixes. When fixes cascade — e.g. MD030 widening a list marker, which then needs MD007 to re-indent the nested content and its continuation lines — one pass left work undone, so the editor had to run "Format Document" several times to converge. `rumdl check --fix` was unaffected because it iterates to a fixpoint through the FixCoordinator (rvben/rumdl#271).

After, the formatting handler routes through `apply_all_fixes`, the same iterative FixCoordinator engine the fix-all code action and the CLI use, so a single format pass reaches a fixpoint and the editor matches the CLI.

This is not a loss of LSP-specific behavior: `apply_all_fixes` performs the same config management the handler used to do inline — `merge_lsp_settings`, the VS Code enable/disable rule overrides (`apply_lsp_config_overrides`), and per-file flavor — and additionally honors file excludes and per-file-ignores, which the single-pass path skipped. Only the inline duplicate of that logic is removed. Range formatting, which delegates here, is covered too.

Add LSP regression tests: one formatting pass is idempotent and equals the `rumdl check --fix` output (the reported case and nested lists with continuation at both levels), and the formatter still honors an LSP disable-rules override.

Resolves rvben/rumdl-vscode#145

Assisted-by: Claude <noreply@anthropic.com>