### PR TITLE
feat(MD043): report expected and actual headings at first mismatch

### DIFF
--- a/docs/md043.md
+++ b/docs/md043.md
@@ -164,6 +164,39 @@ headings = [
 ]
 ```
 
+## Diagnostic messages
+
+When a document does not match the required structure, MD043 reports the first point where the actual headings diverge from the configured pattern.
+
+For example, with this configuration:
+
+```toml
+[MD043]
+headings = ["# Overview", "## Installation", "## Usage", "## License"]
+```
+
+This document:
+
+```markdown
+# Overview
+
+## Usage
+
+## License
+```
+
+Reports that `## Installation` was expected before `## Usage`:
+
+```text
+Heading structure does not match required structure. Expected heading '## Installation' at position 2, but found '## Usage'
+```
+
+Wildcard patterns are described in the same focused way. For example, `+` requires at least one heading before the next configured heading:
+
+```text
+Heading structure does not match required structure. Expected one or more headings before '## Contributing', but found '## Contributing' immediately
+```
+
 ## Automatic fixes
 
 When enabled, this rule will:

--- a/src/rules/md043_required_headings.rs
+++ b/src/rules/md043_required_headings.rs
@@ -186,6 +186,53 @@ impl MD043RequiredHeadings {
             false
         }
     }
+
+    fn expected_pattern_description(pattern: &str) -> String {
+        match pattern {
+            "+" => "one or more headings".to_string(),
+            "?" => "one heading".to_string(),
+            "*" => "zero or more headings".to_string(),
+            _ => format!("heading '{pattern}'"),
+        }
+    }
+
+    fn structure_mismatch_message(&self, actual_headings: &[String], exp_idx: usize, act_idx: usize) -> String {
+        let prefix = "Heading structure does not match required structure.";
+
+        if let Some(expected) = self.config.headings.get(exp_idx) {
+            if let Some(previous) = exp_idx.checked_sub(1).and_then(|idx| self.config.headings.get(idx))
+                && matches!(previous.as_str(), "+" | "?")
+                && act_idx == actual_headings.len()
+                && let Some(actual) = actual_headings.last()
+                && self.headings_match(expected, actual)
+            {
+                let requirement = Self::expected_pattern_description(previous);
+                return format!(
+                    "{prefix} Expected {requirement} before '{expected}', but found '{actual}' immediately"
+                );
+            }
+
+            let expected = Self::expected_pattern_description(expected);
+            if let Some(actual) = actual_headings.get(act_idx) {
+                format!(
+                    "{prefix} Expected {expected} at position {}, but found '{actual}'",
+                    act_idx + 1
+                )
+            } else {
+                format!(
+                    "{prefix} Expected {expected} at position {}, but found no more headings",
+                    act_idx + 1
+                )
+            }
+        } else if let Some(actual) = actual_headings.get(act_idx) {
+            format!(
+                "{prefix} Expected no more headings after position {act_idx}, but found '{actual}' at position {}",
+                act_idx + 1
+            )
+        } else {
+            prefix.to_string()
+        }
+    }
 }
 
 impl Rule for MD043RequiredHeadings {
@@ -219,10 +266,12 @@ impl Rule for MD043RequiredHeadings {
         }
 
         // Use wildcard matching for pattern support
-        let (headings_match, _exp_idx, _act_idx) =
+        let (headings_match, exp_idx, act_idx) =
             self.match_headings_with_wildcards(&actual_headings, &self.config.headings);
 
         if !headings_match {
+            let message = self.structure_mismatch_message(&actual_headings, exp_idx, act_idx);
+
             // If no headings found but we have required headings, create a warning
             if actual_headings.is_empty() && !self.config.headings.is_empty() {
                 warnings.push(LintWarning {
@@ -231,7 +280,7 @@ impl Rule for MD043RequiredHeadings {
                     column: 1,
                     end_line: 1,
                     end_column: 2,
-                    message: format!("Required headings not found: {:?}", self.config.headings),
+                    message,
                     severity: Severity::Warning,
                     fix: None,
                 });
@@ -251,15 +300,14 @@ impl Rule for MD043RequiredHeadings {
                         column: start_col,
                         end_line,
                         end_column: end_col,
-                        message: "Heading structure does not match the required structure".to_string(),
+                        message: message.clone(),
                         severity: Severity::Warning,
                         fix: None,
                     });
                 }
             }
 
-            // If we have no warnings but headings don't match (could happen if we have no headings),
-            // add a warning at the beginning of the file
+            // If no heading ranges were emitted despite a mismatch, add a warning at the beginning of the file.
             if warnings.is_empty() {
                 warnings.push(LintWarning {
                     rule_name: Some(self.name().to_string()),
@@ -267,10 +315,7 @@ impl Rule for MD043RequiredHeadings {
                     column: 1,
                     end_line: 1,
                     end_column: 2,
-                    message: format!(
-                        "Heading structure does not match required structure. Expected: {:?}, Found: {:?}",
-                        self.config.headings, actual_headings
-                    ),
+                    message,
                     severity: Severity::Warning,
                     fix: None,
                 });

--- a/tests/rules/md043_test.rs
+++ b/tests/rules/md043_test.rs
@@ -1,5 +1,13 @@
-use rumdl_lib::rule::Rule;
+use rumdl_lib::rule::{LintWarning, Rule};
 use rumdl_lib::rules::MD043RequiredHeadings;
+
+fn assert_warning_message(result: &[LintWarning], expected: &str) {
+    assert!(!result.is_empty(), "Expected at least one warning");
+    assert!(
+        result.iter().all(|warning| warning.message == expected),
+        "Expected all warnings to have message {expected:?}, got: {result:?}"
+    );
+}
 
 #[test]
 fn test_matching_headings() {
@@ -30,6 +38,130 @@ fn test_missing_heading() {
     let fixed = rule.fix(&ctx).unwrap();
     // MD043 now preserves original content to prevent data loss
     assert_eq!(fixed, content);
+}
+
+#[test]
+fn test_structure_mismatch_message_reports_first_different_heading() {
+    let required = vec![
+        "# Introduction".to_string(),
+        "# Methods".to_string(),
+        "# Results".to_string(),
+    ];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "# Introduction\n\n# Results";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected heading '# Methods' at position 2, but found '# Results'",
+    );
+}
+
+#[test]
+fn test_structure_mismatch_message_reports_missing_trailing_heading() {
+    let required = vec!["# Introduction".to_string(), "# Methods".to_string()];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "# Introduction";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected heading '# Methods' at position 2, but found no more headings",
+    );
+}
+
+#[test]
+fn test_structure_mismatch_message_reports_extra_trailing_heading() {
+    let required = vec!["# Introduction".to_string()];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "# Introduction\n\n## Extra";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected no more headings after position 1, but found '## Extra' at position 2",
+    );
+}
+
+#[test]
+fn test_structure_mismatch_message_reports_extra_trailing_heading_after_wildcard() {
+    let required = vec!["# Introduction".to_string(), "*".to_string(), "# Results".to_string()];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "# Introduction\n\n## Optional 1\n\n## Optional 2\n\n# Results\n\n## Extra";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected no more headings after position 4, but found '## Extra' at position 5",
+    );
+}
+
+#[test]
+fn test_structure_mismatch_message_handles_plus_before_required_heading() {
+    let required = vec!["# Introduction".to_string(), "+".to_string(), "# Results".to_string()];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "# Introduction\n\n# Results";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected one or more headings before '# Results', but found '# Results' immediately",
+    );
+}
+
+#[test]
+fn test_structure_mismatch_message_preserves_actual_case_after_wildcard() {
+    let required = vec!["+".to_string(), "# Results".to_string()];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "# RESULTS";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected one or more headings before '# Results', but found '# RESULTS' immediately",
+    );
+}
+
+#[test]
+fn test_structure_mismatch_message_handles_question_before_required_heading() {
+    let required = vec!["?".to_string(), "## Description".to_string()];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "## Description";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected one heading before '## Description', but found '## Description' immediately",
+    );
+}
+
+#[test]
+fn test_structure_mismatch_message_handles_asterisk_missing_required_heading() {
+    let required = vec!["# Introduction".to_string(), "*".to_string(), "# Results".to_string()];
+    let rule = MD043RequiredHeadings::new(required);
+    let content = "# Introduction\n\n## Optional 1\n\n## Optional 2";
+    let ctx = rumdl_lib::lint_context::LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+
+    let result = rule.check(&ctx).unwrap();
+
+    assert_warning_message(
+        &result,
+        "Heading structure does not match required structure. Expected heading '# Results' at position 4, but found no more headings",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

MD043 previously reported heading-structure violations with a generic message:

> Heading structure does not match the required structure

Resolving this required users and automated tools to locate the MD043 configuration and manually compare it with the document.

This change makes the diagnostic actionable by reporting the first point where the configured and actual heading structures diverge. This is particularly useful for LLM-assisted remediation because the warning directly provides the expected heading and what was found instead.

## What changed

- Report the expected and actual headings at the first structural mismatch.
- Report missing and unexpected trailing headings.
- Describe unsatisfied `+`, `*`, and `?` wildcard requirements.
- Use document heading positions after wildcard consumption.
- Preserve the actual heading's capitalization in case-insensitive configurations.
- Add exact-message regression tests for literal and wildcard mismatches.
- Document the new diagnostic behavior in `docs/md043.md`.

This does not change MD043 matching semantics, warning locations/counts, or autofix behavior.

## Example

Given:

```toml
[MD043]
headings = ["# Overview", "## Installation", "## Usage"]
```
And:
```
# Overview

## Usage
```

MD043 now reports:

`Heading structure does not match required structure. Expected heading '## Installation' at position 2, but found '## Usage'`

## Caveats and risks

MD043 currently emits a warning for each heading when the structure does not match. Each warning therefore repeats the same first-divergence diagnostic. This preserves existing warning-count and location behavior while improving the information in each warning.

Reporting every independent difference would require full sequence alignment, including decisions about missing, extra, substituted, and wildcard-consumed headings. That is intentionally left for a separate follow-up change.

The diagnostic text is user-visible, so integrations or snapshots that depend on the previous exact message will need to be updated.

## Testing

- Added regression tests using a red-green TDD workflow.
- cargo nextest run md043
- cargo fmt --check
- cargo clippy --lib --tests -- -D warnings