### PR TITLE
fix(MD013): treat standalone links as paragraph boundaries in reflow

### DIFF
--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -1252,6 +1252,7 @@ impl MD013LineLength {
                 || is_link_ref_def
                 || ctx.line_info(line_num).is_some_and(|info| info.is_div_marker)
                 || is_html_only_line(lines[i])
+                || (!config.strict && is_standalone_link_or_image_line(lines[i]))
             {
                 i += 1;
                 continue;
@@ -2962,6 +2963,7 @@ impl MD013LineLength {
                     || is_snippet_block_delimiter(next_line)
                     || ctx.line_info(next_line_num).is_some_and(|info| info.is_div_marker)
                     || is_html_only_line(next_line)
+                    || (!config.strict && is_standalone_link_or_image_line(next_line))
                 {
                     break;
                 }

--- a/src/rules/md013_line_length/tests.rs
+++ b/src/rules/md013_line_length/tests.rs
@@ -8379,3 +8379,25 @@ fn test_myst_colon_figure_directive_options_only_preserved() {
         "options-only `:::{{figure}}` directive must be preserved verbatim, got:\n{fixed}"
     );
 }
+
+#[test]
+fn test_md013_reflow_standalone_link_boundary() {
+    let long_url = "a".repeat(100);
+    // Two short lines that will be merged by reflow, plus the standalone link.
+    let content = format!("Line one.\nLine two.\n[link]({})\n", long_url);
+
+    let config = MD013Config {
+        line_length: crate::types::LineLength::from_const(30),
+        reflow: true,
+        ..Default::default()
+    };
+    let rule = MD013LineLength::from_config_struct(config);
+    let ctx = LintContext::new(&content, MarkdownFlavor::Standard, None);
+    let result = rule.check(&ctx).unwrap();
+
+    assert!(
+        result.is_empty(),
+        "Expected no warnings for standalone link in reflow, got: {:?}",
+        result
+    );
+}

--- a/src/rules/md013_line_length/tests.rs
+++ b/src/rules/md013_line_length/tests.rs
@@ -8523,7 +8523,7 @@ fn test_myst_colon_figure_directive_options_only_preserved() {
 fn test_md013_reflow_standalone_link_boundary() {
     let long_url = "a".repeat(100);
     // Two short lines that will be merged by reflow, plus the standalone link.
-    let content = format!("Line one.\nLine two.\n[link]({})\n", long_url);
+    let content = format!("Line one.\nLine two.\n[link]({long_url})\n");
 
     let config = MD013Config {
         line_length: crate::types::LineLength::from_const(30),
@@ -8536,8 +8536,7 @@ fn test_md013_reflow_standalone_link_boundary() {
 
     assert!(
         result.is_empty(),
-        "Expected no warnings for standalone link in reflow, got: {:?}",
-        result
+        "Expected no warnings for standalone link in reflow, got: {result:?}"
     );
 }
 


### PR DESCRIPTION
When `reflow` is enabled, the paragraph reflow engine groups consecutive lines into paragraphs and reflows them. Previously, it did not check if a line was a standalone link before including it in a paragraph.

This caused two issues:
1. The standalone link line could be merged with adjacent text, causing it to lose its "standalone" status and thus its exemption from MD013.
2. If other lines in the paragraph were reflowed (causing a change), the entire paragraph was flagged. The warning was then emitted for the longest line in the paragraph, which was the (conceptually exempt) link line, even if the link itself did not change.

This change fixes the issue by:
- Skipping standalone link lines at the top level of the paragraph collection loop in `generate_paragraph_fixes`.
- Treating standalone link lines as paragraph boundaries (similar to HTML-only lines) to break the paragraph collection, preventing them from being merged with adjacent text.

Added a regression test `test_md013_reflow_standalone_link_boundary` that reproduces the issue by placing a simple link after two short lines that are merged by reflow.

Assisted-by: Antigravity with Gemini