### PR TITLE
fix(MD013): associate paragraph reflow fix with all violating lines

### DIFF
--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -3194,62 +3194,77 @@ impl MD013LineLength {
 
                 // Only generate a warning if the replacement is different from the original
                 if original_text != replacement {
-                    // Create warning with actual fix
-                    // In default mode, report the specific line that violates
-                    // In normalize mode, report the whole paragraph
-                    // In sentence-per-line mode, report the entire paragraph
-                    let (warning_line, warning_end_line) = match config.reflow_mode {
-                        ReflowMode::Normalize => (paragraph_start + 1, end_line + 1),
-                        ReflowMode::SentencePerLine | ReflowMode::SemanticLineBreaks => {
-                            // Highlight the entire paragraph that needs reformatting
-                            (paragraph_start + 1, paragraph_start + paragraph_lines.len())
-                        }
+                    // Determine which line ranges and messages to report based on the reflow mode.
+                    let warnings_to_report: Vec<(usize, usize, String)> = match config.reflow_mode {
                         ReflowMode::Default => {
-                            // Find the first line that exceeds the limit
-                            let mut violating_line = paragraph_start;
-                            for (idx, line) in paragraph_lines.iter().enumerate() {
-                                if self.calculate_effective_length(line) > config.line_length.get() {
-                                    violating_line = paragraph_start + idx;
-                                    break;
-                                }
-                            }
-                            (violating_line + 1, violating_line + 1)
+                            // In default mode, report a warning for *every* line in the paragraph
+                            // that exceeds the limit. Each warning will carry the same paragraph-level
+                            // fix, making all of them auto-fixable.
+                            paragraph_lines
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, line)| self.calculate_effective_length(line) > config.line_length.get())
+                                .map(|(idx, _)| {
+                                    let violating_line = paragraph_start + idx + 1;
+                                    (
+                                        violating_line,
+                                        violating_line,
+                                        format!("Line length exceeds {} characters", config.line_length.get()),
+                                    )
+                                })
+                                .collect()
+                        }
+                        ReflowMode::Normalize => {
+                            // In normalize mode, report the whole paragraph as needing normalization.
+                            vec![(
+                                paragraph_start + 1,
+                                end_line + 1,
+                                format!(
+                                    "Paragraph could be normalized to use line length of {} characters",
+                                    config.line_length.get()
+                                ),
+                            )]
+                        }
+                        ReflowMode::SentencePerLine => {
+                            // In sentence-per-line mode, highlight the entire paragraph that needs reformatting.
+                            let num_sentences = split_into_sentences(&paragraph_text).len();
+                            let message = if paragraph_lines.len() == 1 {
+                                // Single line with multiple sentences
+                                format!("Line contains {num_sentences} sentences (one sentence per line required)")
+                            } else {
+                                // Multiple lines - could be split sentences or mixed
+                                let num_lines = paragraph_lines.len();
+                                format!(
+                                    "Paragraph should have one sentence per line (found {num_sentences} sentences across {num_lines} lines)"
+                                )
+                            };
+                            vec![(paragraph_start + 1, paragraph_start + paragraph_lines.len(), message)]
+                        }
+                        ReflowMode::SemanticLineBreaks => {
+                            // In semantic-line-breaks mode, highlight the entire paragraph.
+                            let num_sentences = split_into_sentences(&paragraph_text).len();
+                            vec![(
+                                paragraph_start + 1,
+                                paragraph_start + paragraph_lines.len(),
+                                format!("Paragraph should use semantic line breaks ({num_sentences} sentences)"),
+                            )]
                         }
                     };
 
-                    warnings.push(LintWarning {
-                        rule_name: Some(self.name().to_string()),
-                        message: match config.reflow_mode {
-                            ReflowMode::Normalize => format!(
-                                "Paragraph could be normalized to use line length of {} characters",
-                                config.line_length.get()
-                            ),
-                            ReflowMode::SentencePerLine => {
-                                let num_sentences = split_into_sentences(&paragraph_text).len();
-                                if paragraph_lines.len() == 1 {
-                                    // Single line with multiple sentences
-                                    format!("Line contains {num_sentences} sentences (one sentence per line required)")
-                                } else {
-                                    let num_lines = paragraph_lines.len();
-                                    // Multiple lines - could be split sentences or mixed
-                                    format!("Paragraph should have one sentence per line (found {num_sentences} sentences across {num_lines} lines)")
-                                }
-                            },
-                            ReflowMode::SemanticLineBreaks => {
-                                let num_sentences = split_into_sentences(&paragraph_text).len();
-                                format!(
-                                    "Paragraph should use semantic line breaks ({num_sentences} sentences)"
-                                )
-                            },
-                            ReflowMode::Default => format!("Line length exceeds {} characters", config.line_length.get()),
-                        },
-                        line: warning_line,
-                        column: 1,
-                        end_line: warning_end_line,
-                        end_column: lines[warning_end_line.saturating_sub(1)].chars().count() + 1,
-                        severity: Severity::Warning,
-                        fix: Some(crate::rule::Fix::new(byte_range, replacement)),
-                    });
+                    // Generate the actual lint warnings. All warnings for this paragraph
+                    // share the same paragraph-level fix.
+                    for (w_start, w_end, msg) in warnings_to_report {
+                        warnings.push(LintWarning {
+                            rule_name: Some(self.name().to_string()),
+                            message: msg,
+                            line: w_start,
+                            column: 1,
+                            end_line: w_end,
+                            end_column: lines[w_end.saturating_sub(1)].chars().count() + 1,
+                            severity: Severity::Warning,
+                            fix: Some(crate::rule::Fix::new(byte_range.clone(), replacement.clone())),
+                        });
+                    }
                 }
             }
         }

--- a/src/rules/md013_line_length/tests.rs
+++ b/src/rules/md013_line_length/tests.rs
@@ -8554,3 +8554,27 @@ fn test_md013_standalone_link_with_trailing_punctuation() {
         );
     }
 }
+
+#[test]
+fn test_md013_reflow_consecutive_long_lines() {
+    // Two consecutive long lines in a paragraph.
+    // Limit is 30.
+    let content = indoc::indoc! {"
+        This is line one which is very long.
+        This is line two which is also very long.
+    "};
+
+    let config = MD013Config {
+        line_length: crate::types::LineLength::from_const(30),
+        reflow: true,
+        ..Default::default()
+    };
+    let rule = MD013LineLength::from_config_struct(config);
+    let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+    let result = rule.check(&ctx).unwrap();
+
+    // We expect 2 warnings, and BOTH should have a fix.
+    assert_eq!(result.len(), 2, "Expected 2 warnings, got: {result:?}");
+    assert!(result[0].fix.is_some(), "First warning should have a fix");
+    assert!(result[1].fix.is_some(), "Second warning should have a fix");
+}


### PR DESCRIPTION
When a paragraph is reflowed in Default mode, it now generates a warning and associates the paragraph-level fix with every line in the paragraph that exceeds the line length limit.

Previously, only the first violating line received the warning with the fix, while subsequent violating lines received line-level warnings without fixes, making them appear unfixable.

Added a integration test to verify that all consecutive violating lines in a reflowable paragraph are reported as fixable.

Assisted-by: Antigravity with Gemini