### PR TITLE
fix(MD007): align nested lists to a widened parent's content column

### DIFF
--- a/src/lsp/tests.rs
+++ b/src/lsp/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::lsp::types::{warning_to_code_actions, warning_to_diagnostic};
 use crate::rule::LintWarning;
+use indoc::indoc;
 use tower_lsp::LspService;
 
 fn create_test_server() -> RumdlLanguageServer {
@@ -8727,7 +8728,12 @@ async fn test_formatting_idempotent_cascading_list_indent_issue_145() {
     let server = server_with_md030_spacing(3, 3).await;
     let uri = Url::parse("file:///nested.md").unwrap();
     // The exact testcase from the issue.
-    let input = "- Bullet 1\n    - Sub-bullet with long text that is long enough that it is wrapped onto\n      multiple lines.\n- Bullet 2\n";
+    let input = indoc! {"
+        - Bullet 1
+            - Sub-bullet with long text that is long enough that it is wrapped onto
+              multiple lines.
+        - Bullet 2
+    "};
 
     let (after_first, after_second) = format_twice(&server, &uri, input).await;
 
@@ -8737,8 +8743,16 @@ async fn test_formatting_idempotent_cascading_list_indent_issue_145() {
     );
 
     // A single pass must also land on the exact fixpoint that `rumdl check --fix`
-    // (the iterative engine) produces for this input and config.
-    let expected = "-   Bullet 1\n  -   Sub-bullet with long text that is long enough that it is wrapped onto\n      multiple lines.\n-   Bullet 2\n";
+    // (the iterative engine) produces for this input and config. With the markers
+    // widened to `-   ` (content column 4), the sub-bullet stays nested under the
+    // parent at column 4 rather than detaching to column 2 (MD007 aligns it to the
+    // parent's widened content column).
+    let expected = indoc! {"
+        -   Bullet 1
+            -   Sub-bullet with long text that is long enough that it is wrapped onto
+                multiple lines.
+        -   Bullet 2
+    "};
     assert_eq!(
         after_first, expected,
         "one formatting pass should match the `rumdl check --fix` fixpoint, got:\n{after_first}"

--- a/src/rules/md007_ul_indent.rs
+++ b/src/rules/md007_ul_indent.rs
@@ -498,7 +498,17 @@ impl Rule for MD007ULIndent {
                 } else {
                     expected_indent
                 };
-                let expected_content_visual_col = accepted_indent + 2;
+                // Store the content column the item will have *after* its indent is
+                // fixed: the corrected marker column plus this marker's actual width
+                // (marker char + the spaces after it). Using the real width rather than a
+                // hard-coded 2 keeps a child aligned to a parent whose marker was widened
+                // by a non-default MD030 (e.g. `-   ` under `ul-multi = 3`, content column
+                // 4); hard-coding 2 stored column 2 and flagged the correctly-nested child
+                // as over-indented, then "fixed" it to a column where it detaches into a
+                // sibling. For the common single-space marker the width is 2, so the
+                // stored value is unchanged.
+                let marker_width = visual_content_column.saturating_sub(visual_marker_column);
+                let expected_content_visual_col = accepted_indent + marker_width;
                 list_stack.push((
                     visual_marker_column,
                     line_idx,
@@ -802,6 +812,7 @@ mod tests {
     use super::*;
     use crate::lint_context::LintContext;
     use crate::rule::Rule;
+    use indoc::indoc;
 
     #[test]
     fn test_valid_list_indent() {
@@ -2939,6 +2950,126 @@ items:
         assert!(
             result.is_empty(),
             "indent=4 under '100.' should accept 4-space indent: {result:?}"
+        );
+    }
+
+    /// Maximum list-nesting depth a real CommonMark parser sees in `md`: 1 for a
+    /// flat list, 2 for a list nested inside a list item. Guards against indent
+    /// "fixes" that silently flatten a child into a sibling.
+    fn commonmark_max_list_depth(md: &str) -> usize {
+        use pulldown_cmark::{Event, Parser, Tag, TagEnd};
+        let (mut depth, mut max) = (0usize, 0usize);
+        for event in Parser::new(md) {
+            match event {
+                Event::Start(Tag::List(_)) => {
+                    depth += 1;
+                    max = max.max(depth);
+                }
+                Event::End(TagEnd::List(_)) => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        max
+    }
+
+    #[test]
+    fn test_md007_widened_parent_marker_keeps_nested_child() {
+        // A non-default MD030 (e.g. `ul-multi = 3`) widens a parent bullet to `-   `,
+        // moving its content column to 4. A child aligned to that column (indent 4) is
+        // correctly nested in CommonMark, so MD007 must accept it instead of flagging it
+        // as over-indented — the old behavior stored the parent's content column as 2 and
+        // "fixed" the child to column 2, detaching it into a sibling.
+        let rule = MD007ULIndent::default();
+        let content = indoc! {"
+            -   Parent item
+                - Nested item
+        "};
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let result = rule.check(&ctx).unwrap();
+        assert!(
+            result.is_empty(),
+            "a child aligned to a widened parent's content column must not be flagged: {result:?}"
+        );
+        assert_eq!(commonmark_max_list_depth(content), 2, "precondition: source is nested");
+        assert_eq!(
+            rule.fix(&ctx).unwrap(),
+            content,
+            "fix must be a no-op for an already correctly nested child"
+        );
+    }
+
+    #[test]
+    fn test_md007_widened_parent_aligns_child_to_content_column() {
+        // A child mis-indented under a widened parent is corrected to the parent's
+        // content column (4 here), not to the fixed-grid column 2 that would detach it.
+        let rule = MD007ULIndent::default();
+        let content = indoc! {"
+            -   Parent item
+                 - Nested item
+        "};
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(
+            fixed,
+            indoc! {"
+                -   Parent item
+                    - Nested item
+            "},
+            "child must align to the parent's content column 4: {fixed:?}"
+        );
+        assert_eq!(
+            commonmark_max_list_depth(&fixed),
+            2,
+            "fixed child must remain nested, not flattened to a sibling:\n{fixed}"
+        );
+    }
+
+    #[test]
+    fn test_md007_widened_markers_nested_multiple_levels() {
+        // Several levels of widened markers all stay nested: each child aligns to its
+        // own parent's widened content column.
+        let rule = MD007ULIndent::default();
+        let content = indoc! {"
+            -   Level 0
+                -   Level 1
+                    - Level 2
+        "};
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let result = rule.check(&ctx).unwrap();
+        assert!(
+            result.is_empty(),
+            "deeply nested widened markers must not be flagged: {result:?}"
+        );
+        assert_eq!(
+            commonmark_max_list_depth(content),
+            3,
+            "three nesting levels are preserved"
+        );
+    }
+
+    #[test]
+    fn test_md007_default_marker_indent_still_enforced() {
+        // Regression guard: the widened-marker handling must not relax the check for
+        // ordinary single-space markers. An over-indented child is still flagged and
+        // fixed back to the 2-space grid.
+        let rule = MD007ULIndent::default();
+        let content = indoc! {"
+            - Parent item
+                - Nested item
+        "};
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let result = rule.check(&ctx).unwrap();
+        assert_eq!(
+            result.len(),
+            1,
+            "an over-indented child under a normal marker is still flagged: {result:?}"
+        );
+        assert_eq!(
+            rule.fix(&ctx).unwrap(),
+            indoc! {"
+                - Parent item
+                  - Nested item
+            "}
         );
     }
 }


### PR DESCRIPTION
When a non-default MD030 widens a parent bullet (e.g. ul-multi = 3 produces
"-   ", moving its content column to 4), a child list correctly nested at that
column was flagged as over-indented and "fixed" back to column 2 — detaching it
into a sibling under CommonMark, silently flattening the structure.

MD007 stored each unordered item's content column as marker_column + 2, assuming a single-space "- " marker. Store marker_column + actual_marker_width (the bullet plus the spaces after it) instead, so a child is measured against the parent's real content column. The common single-space marker keeps width 2, so default behavior and output are byte-identical.

Add regression tests: a widened parent keeps its nested child, a mis-indented child is corrected to the widened content column (verified with a CommonMark parse so a regression to flattening fails the test), multi-level widened nesting stays nested, and ordinary single-space markers are still enforced. Update the issue-145 LSP idempotency test, which had pinned the old flattened fixpoint, to the correct nested fixpoint.

Assisted-by: Claude <noreply@anthropic.com>