### PR TITLE
fix: allow building for WASI

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -28,7 +28,11 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// because `CacheEntry.timestamp` differs per write.
 fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    #[cfg(not(target_arch = "wasm32"))]
     let tmp_path = target.with_extension(format!("tmp.{}.{counter}", std::process::id()));
+    // pid not available on WASI
+    #[cfg(target_arch = "wasm32")]
+    let tmp_path = target.with_extension(format!("tmp.{counter}"));
     match fs::write(&tmp_path, bytes).and_then(|()| fs::rename(&tmp_path, target)) {
         Ok(()) => Ok(()),
         Err(e) => {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod import;
 pub mod init;
 pub mod rule;
 pub mod schema;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod server;
 pub mod version;
 pub mod vscode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub mod lint_context;
 pub mod markdownlint_config;
 pub mod profiling;
 pub mod rule;
-#[cfg(feature = "native")]
+#[cfg(feature = "colored")]
 pub mod vscode;
 pub mod workspace_index;
 #[macro_use]
@@ -75,7 +75,7 @@ pub mod utils;
 // Native-only modules (require tokio, tower-lsp, etc.)
 #[cfg(feature = "native")]
 pub mod lsp;
-#[cfg(feature = "native")]
+#[cfg(feature = "colored")]
 pub mod output;
 #[cfg(feature = "native")]
 pub mod parallel;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 // Use jemalloc for better memory allocation performance on Unix-like systems
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(not(target_env = "msvc"), not(target_arch = "wasm32")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
@@ -161,6 +161,7 @@ enum Commands {
         output: Option<String>,
     },
     /// Start the Language Server Protocol server
+    #[cfg(not(target_arch = "wasm32"))]
     Server {
         /// TCP port to listen on (for debugging)
         #[arg(long)]
@@ -391,6 +392,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             Commands::CodeBlockToolsDocs { action } => {
                 commands::code_block_tools_docs::handle_code_block_tools_docs(action);
             }
+            #[cfg(not(target_arch = "wasm32"))]
             Commands::Server { port, stdio, verbose } => {
                 let config_path = if cli.no_config || cli.isolated {
                     None

--- a/src/workspace_index.rs
+++ b/src/workspace_index.rs
@@ -260,7 +260,7 @@ pub fn extract_cross_file_links(ctx: &LintContext) -> ExtractedCrossFileLinks {
 }
 
 /// Magic bytes identifying a workspace index cache file
-#[cfg(feature = "native")]
+#[cfg(feature = "postcard")]
 const CACHE_MAGIC: &[u8; 4] = b"RWSI";
 
 /// Cache format version - increment when WorkspaceIndex serialization changes
@@ -268,11 +268,11 @@ const CACHE_MAGIC: &[u8; 4] = b"RWSI";
 /// no longer correct. Version 8 forces a rebuild so the new `root_relative_links`
 /// field is populated; earlier caches lack it, leaving find-references unable to
 /// discover root-relative (`/path`) links until a rescan.
-#[cfg(feature = "native")]
+#[cfg(feature = "postcard")]
 const CACHE_FORMAT_VERSION: u32 = 8;
 
 /// Cache file name within the version directory
-#[cfg(feature = "native")]
+#[cfg(feature = "postcard")]
 const CACHE_FILE_NAME: &str = "workspace_index.bin";
 
 /// Workspace-wide index for cross-file analysis
@@ -565,7 +565,7 @@ impl WorkspaceIndex {
     /// - Magic header for file type validation
     /// - Format version for compatibility detection
     /// - Atomic writes (temp file + rename) to prevent corruption
-    #[cfg(feature = "native")]
+    #[cfg(feature = "postcard")]
     pub fn save_to_cache(&self, cache_dir: &Path) -> std::io::Result<()> {
         use std::fs;
         use std::io::Write;
@@ -585,7 +585,11 @@ impl WorkspaceIndex {
 
         // Write atomically: write to temp file then rename
         let final_path = cache_dir.join(CACHE_FILE_NAME);
+        #[cfg(not(target_arch = "wasm32"))]
         let temp_path = cache_dir.join(format!("{}.tmp.{}", CACHE_FILE_NAME, std::process::id()));
+        // pid not available on WASI
+        #[cfg(target_arch = "wasm32")]
+        let temp_path = cache_dir.join(format!("{CACHE_FILE_NAME}.tmp"));
 
         // Write to temp file
         {
@@ -614,7 +618,7 @@ impl WorkspaceIndex {
     /// - Magic header doesn't match
     /// - Format version is incompatible
     /// - Data is corrupted
-    #[cfg(feature = "native")]
+    #[cfg(feature = "postcard")]
     pub fn load_from_cache(cache_dir: &Path) -> Option<Self> {
         use std::fs;
 


### PR DESCRIPTION
I am interested in being able to compile my own build of rumdl to a WASI wasm file (i.e., runnable with wasmtime, not browser) and found it's a very small amount of guards for it to work. I can maintain it as a fork but wonder if it's acceptable here. Note that while I didn't try it, I think it allows the CLI to build for browser as well.

- Removes use of pid in cache entry on wasm32
- Guards LSP and jemmalloc out of `wasm32`
- Target a few spots from the broad `native` feature group to the specific dependency being used

Builds with

```
cargo build --target wasm32-wasip1-threads --no-default-features \
  --features parallel,colored,blake3,postcard,chrono,env_logger,notify
```