### PR TITLE
docs(nvim): Native Neovim LSP integration & configuration examples

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -85,6 +85,11 @@ vim.lsp.config("rumdl", {
   cmd = { "rumdl", "server" },
   filetypes = { "markdown" },
   root_markers = { ".git" },
+  settings = {
+    rumdl = {
+      lineLength = 100,
+    },
+  },
 })
 
 vim.lsp.enable("rumdl")

--- a/docs/usage/editors.md
+++ b/docs/usage/editors.md
@@ -27,6 +27,23 @@ See [VS Code Integration](../vscode-extension.md) for detailed setup.
 
 ## Neovim
 
+### Native LSP (Neovim 0.11+)
+
+```lua
+vim.lsp.config("rumdl", {
+  cmd = { "rumdl", "server" },
+  filetypes = { "markdown" },
+  root_markers = { ".git", ".rumdl.toml" },
+  settings = {
+    rumdl = {
+      lineLength = 100,
+    },
+  },
+})
+
+vim.lsp.enable("rumdl")
+```
+
 ### Using nvim-lspconfig
 
 ```lua


### PR DESCRIPTION
Hello!

I struggled with the current docs to configure global settings in `rumdl` as LSP server in Neovim. I had to go into the internals to figure out the contract. 

These examples should make it much easier to understand how global configuration options can be passed. Specifically what I was missing is the following table in the `vim.lsp` setup:

```lua
settings = {
    rumdl = {
      lineLength = 100,
    }
  }
```