### PR TITLE
test(action): restore malformed fixture and widen test-action.yml paths filter

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -2,9 +2,9 @@ name: Test Action
 on:
   push:
     branches: [main]
-    paths: ["action.yml", "scripts/rumdl-action.sh"]
+    paths: ["action.yml", "scripts/rumdl-action.sh", "__tests__/fixtures/**", ".github/workflows/test-action.yml"]
   pull_request:
-    paths: ["action.yml", "scripts/rumdl-action.sh"]
+    paths: ["action.yml", "scripts/rumdl-action.sh", "__tests__/fixtures/**", ".github/workflows/test-action.yml"]
   workflow_dispatch:
 
 concurrency:

--- a/__tests__/fixtures/malformed/bad.md
+++ b/__tests__/fixtures/malformed/bad.md
@@ -1,3 +1,2 @@
 # Bad markdown
-
-## No space after hash
+##No space after hash


### PR DESCRIPTION
Follow-up from the discussion on #712.

`__tests__/fixtures/malformed/bad.md` stopped being malformed as a side effect of 497ab922 back in April, an unrelated commit whose message says "bad.md fixture corrected to valid markdown", but that file exists specifically to be malformed for these tests. This restores it.

Nothing caught the breakage for months because `test-action.yml` only triggered on changes to `action.yml`/`scripts/rumdl-action.sh`. Added `__tests__/fixtures/**` and the workflow file itself to the `paths` filters so this class of breakage triggers CI going forward.

**What's tested:**
- Opened a disposable PR against my own fork's main to confirm the widened paths filter actually fires on `pull_request` (it does)
- All 13 `Test Action` jobs pass with both changes combined, including the 4 that were failing on unmodified `main` (`test-args`, `test-expected-failure`, `test-combined-informational-with-output`, `test-output-file-with-violations`)