### PR TITLE
fix(cli): replace unhelpful panic message with an actionable one

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -423,8 +423,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     });
-    if let Err(e) = result {
-        eprintln!("[rumdl panic handler] Uncaught panic: {e:?}");
+    if result.is_err() {
+        eprintln!(
+            "\n[rumdl panic handler] rumdl crashed unexpectedly (v{}). This is a bug -- please report it at https://github.com/rvben/rumdl/issues and include the panic message printed above.",
+            env!("CARGO_PKG_VERSION")
+        );
         exit::tool_error();
     } else {
         Ok(())


### PR DESCRIPTION
While reviewing rumdl's error handling I noticed the panic handler in `main.rs` always prints `Uncaught panic: Any { .. }` regardless of what actually caused the crash. That happens because `catch_unwind` returns the panic payload as `Box<dyn Any + Send>`, and printing it with `{:?}` shows the type wrapper, not the message.

I first tried extracting the message with `downcast_ref::<&str>()` / `downcast_ref::<String>()`, the pattern shown in the stdlib docs for `PanicHookInfo::payload()`. That turned out to be redundant: Rust's default panic hook already prints the real message, file and line before `catch_unwind` gets a chance to run, so the extracted text would just repeat the line already shown above it.

Instead I replaced the message with something that adds information the default hook does not provide: the rumdl version and a link to file a bug, since an uncaught panic here is always a bug.

Before:
```
[rumdl panic handler] Uncaught panic: Any { .. }
```

After (forced a panic locally to verify, reverted before this commit):
```
thread 'main' (330372) panicked at src/main.rs:315:9:
...
[rumdl panic handler] rumdl crashed unexpectedly (v0.2.31). This is a bug -- please report it at https://github.com/rvben/rumdl/issues and include the panic message printed above.
```
Exit code unchanged (2).

No behavior change beyond the message text: `catch_unwind`, the exit code and control flow stay the same.

I didn't add an automated test for this. The message is a fixed string plus `env!("CARGO_PKG_VERSION")`, which fails to compile on its own if that were ever missing, and there's no existing way to trigger a real panic through the CLI to exercise this path (the historical panic reports, #85, #87, #154 and #168, were all UTF-8 char-boundary bugs already fixed in earlier releases). I verified the change by temporarily inserting a `panic!()` in the closure, confirming the output above, and reverting it before committing.

Local checks:
- `cargo build`
- `cargo fmt --check`
- `cargo clippy --workspace --lib --bins --tests -- -D warnings -D clippy::uninlined_format_args`