### PR TITLE
feat(reflow): support breaking within emphasis spans

### DIFF
--- a/docs/md013.md
+++ b/docs/md013.md
@@ -52,6 +52,7 @@ and work with in various contexts.
 line-length = 100  # Maximum characters per line (default: 80)
 code-blocks = false  # Don't check code blocks (default: true)
 code-spans = false  # Don't flag lines whose only overflow is an unbreakable inline code span (default: true)
+emphasis-spans = false  # Allow reflow breaking inside emphasis/strong/strikethrough spans (default: false)
 tables = false  # Don't check tables (default: false)
 headings = true  # Check headings (default: true)
 paragraphs = true  # Check paragraph/regular text (default: true)
@@ -73,6 +74,7 @@ require-sentence-capital = true  # Require uppercase after periods for sentence 
 - `line-length`: The maximum number of characters allowed per line (set to `0` to disable all line length checks)
 - `code-blocks`: Whether to check line length in code blocks (default: `true`)
 - `code-spans`: Whether to check lines whose length comes from an inline code span (default: `true`). Inline code spans (`` `like this` ``) cannot be wrapped, so reflow cannot shorten a line whose excess length is one. When `false`, a line is not reported if it would fit within the limit once its inline code spans are excluded - useful with `reflow` so an unbreakable code incantation does not fail an otherwise-clean file
+- `emphasis-spans`: Whether to allow reflow breaking inside emphasis, strong, and strikethrough spans (default: `false`). When `true`, text inside emphasis elements is wrapped word-by-word like normal text. When `false`, emphasis spans are treated as atomic units and kept on a single line unless they exceed the maximum line length on their own
 - `tables`: Whether to check line length in tables (default: `false`)
 - `headings`: Whether to check line length in headings (default: `true`)
 - `paragraphs`: Whether to check line length in regular text/paragraphs (default: `true`). When false, `line-length` is still used for reflow but no warnings are reported. Blockquote content is treated as paragraph text, so `paragraphs = false` also skips blockquotes

--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -73,6 +73,7 @@ impl MD013LineLength {
                 abbreviations: Vec::new(),
                 require_sentence_capital: true,
                 ignore_link_urls: true,
+                emphasis_spans: false,
             },
             list_spacing: MD030Config::default(),
         }
@@ -134,6 +135,7 @@ impl MD013LineLength {
                 None
             },
             defined_references: Some(Self::defined_reference_labels(ctx)),
+            emphasis_spans: config.emphasis_spans,
         }
     }
 

--- a/src/rules/md013_line_length/md013_config.rs
+++ b/src/rules/md013_line_length/md013_config.rs
@@ -165,6 +165,16 @@ pub struct MD013Config {
         alias = "strict-sentences"
     )]
     pub require_sentence_capital: bool,
+
+    /// Whether to allow reflow breaking inside emphasis/strong/strikethrough spans.
+    /// When true, emphasis text is wrapped word-by-word like normal text.
+    /// When false (default), emphasis spans are treated as atomic units.
+    #[serde(
+        default = "default_emphasis_spans",
+        alias = "emphasis_spans",
+        alias = "emphasis-spans"
+    )]
+    pub emphasis_spans: bool,
 }
 
 fn default_line_length() -> LineLength {
@@ -203,6 +213,10 @@ fn default_ignore_link_urls() -> bool {
     true
 }
 
+fn default_emphasis_spans() -> bool {
+    false
+}
+
 impl Default for MD013Config {
     fn default() -> Self {
         Self {
@@ -223,6 +237,7 @@ impl Default for MD013Config {
             length_mode: LengthMode::default(),
             abbreviations: Vec::new(),
             require_sentence_capital: default_require_sentence_capital(),
+            emphasis_spans: default_emphasis_spans(),
         }
     }
 }
@@ -300,6 +315,7 @@ impl MD013Config {
             // No document context here (config-only), so shortcut references
             // stay atomic. The rule's fix path supplies the defined labels.
             defined_references: None,
+            emphasis_spans: self.emphasis_spans,
         }
     }
 }
@@ -405,6 +421,7 @@ mod tests {
             abbreviations: Vec::new(),
             require_sentence_capital: true,
             ignore_link_urls: true,
+            emphasis_spans: false,
         };
 
         let toml_str = toml::to_string(&config).unwrap();

--- a/src/rules/md013_line_length/tests.rs
+++ b/src/rules/md013_line_length/tests.rs
@@ -2699,6 +2699,7 @@ fn test_paragraphs_false_skips_regular_text() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2736,6 +2737,7 @@ fn test_paragraphs_false_still_checks_code_blocks() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2774,6 +2776,7 @@ fn test_paragraphs_false_still_checks_headings() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2810,6 +2813,7 @@ fn test_paragraphs_false_with_reflow_sentence_per_line() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2846,6 +2850,7 @@ fn test_paragraphs_true_checks_regular_text() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2882,6 +2887,7 @@ fn test_line_length_zero_disables_all_checks() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2918,6 +2924,7 @@ fn test_line_length_zero_with_headings() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2954,6 +2961,7 @@ fn test_line_length_zero_with_code_blocks() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -2990,6 +2998,7 @@ fn test_line_length_zero_with_sentence_per_line_reflow() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3054,6 +3063,7 @@ Final paragraph.
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
     let result = rule.check(&ctx).unwrap();
@@ -3122,6 +3132,7 @@ fn test_reflow_preserves_mkdocstrings_autodoc_block() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3156,6 +3167,7 @@ fn test_reflow_preserves_mkdocstrings_with_identifier() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3191,6 +3203,7 @@ fn test_reflow_preserves_mkdocstrings_surrounded_by_paragraphs() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3229,6 +3242,7 @@ fn test_reflow_mkdocstrings_not_detected_in_standard_flavor() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -3260,6 +3274,7 @@ fn test_reflow_preserves_mkdocstrings_with_blank_line_in_block() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5266,6 +5281,7 @@ fn test_reflow_admonition_in_list_item_basic() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5330,6 +5346,7 @@ fn test_reflow_collapsible_admonition_in_list_item() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5386,6 +5403,7 @@ fn test_reflow_multiple_admonitions_in_list_item() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5464,6 +5482,7 @@ fn test_reflow_admonition_short_content_preserved() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5511,6 +5530,7 @@ fn test_reflow_admonition_with_multiple_paragraphs() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5580,6 +5600,7 @@ fn test_reflow_admonition_not_in_standard_flavor() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5629,6 +5650,7 @@ fn test_reflow_admonition_idempotent() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5683,6 +5705,7 @@ fn test_reflow_admonition_only_in_list_no_long_text() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5742,6 +5765,7 @@ fn test_reflow_content_after_admonition_in_list_item() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5806,6 +5830,7 @@ fn test_reflow_content_after_admonition_short_lines() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5854,6 +5879,7 @@ fn test_reflow_multiple_blocks_after_admonition() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5910,6 +5936,7 @@ fn test_reflow_admonition_empty_body() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -5960,6 +5987,7 @@ fn test_reflow_admonition_no_blank_line_before_body() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6014,6 +6042,7 @@ fn test_reflow_admonition_body_indent_preserved() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6074,6 +6103,7 @@ fn test_reflow_admonition_with_code_block_in_list_item() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6139,6 +6169,7 @@ fn test_reflow_admonition_with_tilde_fence_in_list_item() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6198,6 +6229,7 @@ fn test_reflow_admonition_with_multiple_code_blocks_in_list_item() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6265,6 +6297,7 @@ fn test_reflow_admonition_code_block_idempotent() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6317,6 +6350,7 @@ fn test_reflow_tab_container_in_list_item() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6962,6 +6996,7 @@ fn test_paragraphs_false_skips_blockquote_content() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -6998,6 +7033,7 @@ fn test_blockquotes_false_skips_blockquote_content() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7034,6 +7070,7 @@ fn test_blockquotes_true_paragraphs_true_checks_blockquotes() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7069,6 +7106,7 @@ fn test_blockquotes_false_still_checks_regular_paragraphs() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7104,6 +7142,7 @@ fn test_blockquotes_false_paragraphs_false_skips_blockquotes() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7155,6 +7194,7 @@ fn test_nested_blockquote_skipped_when_blockquotes_false() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7190,6 +7230,7 @@ fn test_paragraphs_false_skips_nested_blockquote() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7226,6 +7267,7 @@ fn test_blockquotes_false_skips_reflow_warnings() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7262,6 +7304,7 @@ fn test_paragraphs_false_skips_blockquote_reflow_warnings() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7298,6 +7341,7 @@ fn test_blockquotes_true_with_reflow_still_warns() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7333,6 +7377,7 @@ fn test_blockquotes_false_skips_lazy_continuation() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7368,6 +7413,7 @@ fn test_blockquotes_false_reflow_skips_lazy_continuation() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 
@@ -7404,6 +7450,7 @@ fn test_blockquotes_false_paragraph_after_blockquote_still_warns() {
         abbreviations: Vec::new(),
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     };
     let rule = MD013LineLength::from_config_struct(config);
 

--- a/src/utils/text_reflow.rs
+++ b/src/utils/text_reflow.rs
@@ -89,6 +89,9 @@ pub struct ReflowOptions {
     /// atomic regardless, because their `][ref]` / `[]` syntax is an explicit
     /// link signal that does not depend on a definition being in scope.
     pub defined_references: Option<HashSet<String>>,
+    /// Whether to allow reflow breaking inside emphasis/strong/strikethrough spans
+    /// when they would otherwise exceed line length or fit on a new line.
+    pub emphasis_spans: bool,
 }
 
 impl Default for ReflowOptions {
@@ -106,6 +109,7 @@ impl Default for ReflowOptions {
             require_sentence_capital: true,
             max_list_continuation_indent: None,
             defined_references: None,
+            emphasis_spans: false,
         }
     }
 }
@@ -2313,15 +2317,12 @@ fn split_at_break_word(
 /// The whole line is parsed into markdown elements once up front; every
 /// remaining suffix reuses those element spans (re-based to the suffix offset)
 /// instead of re-parsing, which keeps repeated element parsing out of the loop.
-fn cascade_split_line(
-    text: &str,
-    line_length: usize,
-    abbreviations: &Option<Vec<String>>,
-    length_mode: ReflowLengthMode,
-    attr_lists: bool,
-    myst_roles: bool,
-    defined_references: Option<&HashSet<String>>,
-) -> Vec<String> {
+fn cascade_split_line(text: &str, options: &ReflowOptions) -> Vec<String> {
+    let line_length = options.line_length;
+    let length_mode = options.length_mode;
+    let attr_lists = options.attr_lists;
+    let myst_roles = options.myst_roles;
+    let defined_references = options.defined_references.as_ref();
     if line_length == 0 || display_len(text, length_mode) <= line_length {
         return vec![text.to_string()];
     }
@@ -2379,29 +2380,21 @@ fn cascade_split_line(
     }
 
     // Fallback: word wrap the still-oversized suffix using reflow_elements.
-    let options = ReflowOptions {
-        line_length,
-        break_on_sentences: false,
-        preserve_breaks: false,
-        sentence_per_line: false,
-        semantic_line_breaks: false,
-        abbreviations: abbreviations.clone(),
-        length_mode,
-        attr_lists,
-        myst_roles,
-        require_sentence_capital: true,
-        max_list_continuation_indent: None,
-        // Unused here: this fallback arranges already-parsed elements and never
-        // re-parses links, so shortcut definedness is never consulted.
-        defined_references: None,
-    };
+    let mut fallback_options = options.clone();
+    fallback_options.break_on_sentences = false;
+    fallback_options.preserve_breaks = false;
+    fallback_options.sentence_per_line = false;
+    fallback_options.semantic_line_breaks = false;
+    fallback_options.require_sentence_capital = true;
+    fallback_options.max_list_continuation_indent = None;
+    fallback_options.defined_references = None;
     let remaining = &text[start..];
     let tail_elements = if start == 0 {
         elements
     } else {
         parse_markdown_elements_inner(remaining, attr_lists, myst_roles, defined_references)
     };
-    result.extend(reflow_elements(&tail_elements, &options));
+    result.extend(reflow_elements(&tail_elements, &fallback_options));
     result
 }
 
@@ -2425,15 +2418,7 @@ fn reflow_elements_semantic(elements: &[Element], options: &ReflowOptions) -> Ve
         if display_len(&line, length_mode) <= options.line_length {
             result.push(line);
         } else {
-            result.extend(cascade_split_line(
-                &line,
-                options.line_length,
-                &options.abbreviations,
-                length_mode,
-                options.attr_lists,
-                options.myst_roles,
-                options.defined_references.as_ref(),
-            ));
+            result.extend(cascade_split_line(&line, options));
         }
     }
 
@@ -2614,7 +2599,7 @@ fn reflow_elements(elements: &[Element], options: &ReflowOptions) -> Vec<String>
         } else if matches!(
             element,
             Element::Italic { .. } | Element::Bold { .. } | Element::Strikethrough { .. }
-        ) && element_len > options.line_length
+        ) && (options.emphasis_spans || element_len > options.line_length)
         {
             // Italic, bold, and strikethrough with content longer than line_length need word wrapping.
             // Split content word-by-word, attach the opening marker to the first word
@@ -3729,7 +3714,12 @@ mod tests {
         let words: Vec<String> = (0..4000).map(|i| format!("word{i}")).collect();
         let line = words.join(" ");
 
-        let out = cascade_split_line(&line, 80, &None, ReflowLengthMode::Chars, false, false, None);
+        let options = ReflowOptions {
+            line_length: 80,
+            length_mode: ReflowLengthMode::Chars,
+            ..Default::default()
+        };
+        let out = cascade_split_line(&line, &options);
 
         assert!(out.len() > 1, "a very long line should split into many lines");
         for segment in &out {
@@ -4316,5 +4306,38 @@ mod tests {
             let elements = parse_markdown_elements_inner(input, false, false, None);
             assert_eq!(format!("{elements:?}"), expected, "input: {input:?}");
         }
+    }
+
+    #[test]
+    fn test_emphasis_spans() {
+        let text = "hello **word1 word2**";
+
+        // With emphasis_spans = false (default), the short emphasis span is kept atomic
+        // because its total length (15) <= line_length (18), even though it doesn't fit on line 1.
+        let options_disabled = ReflowOptions {
+            line_length: 18,
+            emphasis_spans: false,
+            ..Default::default()
+        };
+        let lines_disabled = reflow_line(text, &options_disabled);
+        assert_eq!(lines_disabled, vec!["hello", "**word1 word2**"]);
+
+        // With emphasis_spans = true, the emphasis span is split across lines.
+        let options_enabled = ReflowOptions {
+            line_length: 18,
+            emphasis_spans: true,
+            ..Default::default()
+        };
+        let lines_enabled = reflow_line(text, &options_enabled);
+        assert_eq!(lines_enabled, vec!["hello **word1", "word2**"]);
+
+        // Verify other markers work too (italic and strikethrough)
+        let text_italic = "hello *word1 word2*";
+        let lines_italic = reflow_line(text_italic, &options_enabled);
+        assert_eq!(lines_italic, vec!["hello *word1", "word2*"]);
+
+        let text_strike = "hello ~~word1 word2~~";
+        let lines_strike = reflow_line(text_strike, &options_enabled);
+        assert_eq!(lines_strike, vec!["hello ~~word1", "word2~~"]);
     }
 }

--- a/tests/formats/sentence_per_line_test.rs
+++ b/tests/formats/sentence_per_line_test.rs
@@ -23,6 +23,7 @@ fn create_sentence_per_line_rule() -> MD013LineLength {
         abbreviations: vec![],
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     })
 }
 
@@ -310,6 +311,7 @@ fn test_single_sentence_with_no_line_length_constraint() {
         abbreviations: vec![],
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     });
     let content = "This document provides advice for porting Rust code using PyO3 to run under\n\
                    free-threaded Python.";
@@ -377,6 +379,7 @@ fn test_custom_abbreviations_recognized() {
         abbreviations: vec!["Assn".to_string()],
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     });
 
     // With custom "Assn" abbreviation, this should be ONE sentence
@@ -412,6 +415,7 @@ fn test_custom_abbreviations_merged_with_builtin() {
         abbreviations: vec!["Assn".to_string()],
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     });
 
     // Both "Dr." (built-in) and "Assn." (custom) should be recognized
@@ -447,6 +451,7 @@ fn test_custom_abbreviation_with_period_in_config() {
         abbreviations: vec!["Univ".to_string()],
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     });
 
     let rule_with_period = MD013LineLength::from_config_struct(MD013Config {
@@ -467,6 +472,7 @@ fn test_custom_abbreviation_with_period_in_config() {
         abbreviations: vec!["Univ.".to_string()],
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     });
 
     let content = "Visit Univ. Campus for the tour.";
@@ -509,6 +515,7 @@ fn test_issue_335_abbreviations_config_empty_vec_uses_defaults() {
         abbreviations: vec![], // Empty = use built-in defaults
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     });
 
     // "Dr." is a built-in abbreviation - should NOT split after it
@@ -565,6 +572,7 @@ fn test_issue_335_custom_abbreviations_extend_defaults() {
         abbreviations: vec!["Corp".to_string(), "Inc".to_string()],
         require_sentence_capital: true,
         ignore_link_urls: true,
+        emphasis_spans: false,
     });
 
     // Single sentence with multiple abbreviations - no warning expected

--- a/tests/utils/text_reflow_test.rs
+++ b/tests/utils/text_reflow_test.rs
@@ -20,6 +20,7 @@ fn test_list_item_trailing_whitespace_removal() {
         require_sentence_capital: true,
         max_list_continuation_indent: None,
         defined_references: None,
+        emphasis_spans: false,
     };
 
     let result = reflow_markdown(input, &options);
@@ -407,6 +408,7 @@ fn test_sentence_per_line_reflow() {
         require_sentence_capital: true,
         max_list_continuation_indent: None,
         defined_references: None,
+        emphasis_spans: false,
     };
 
     let input = "First sentence. Second sentence. Third sentence.";
@@ -740,6 +742,7 @@ fn test_ie_abbreviation_split_debug() {
         require_sentence_capital: true,
         max_list_continuation_indent: None,
         defined_references: None,
+        emphasis_spans: false,
     };
 
     let result = reflow_line(input, &options);
@@ -766,6 +769,7 @@ fn test_ie_abbreviation_paragraph() {
         require_sentence_capital: true,
         max_list_continuation_indent: None,
         defined_references: None,
+        emphasis_spans: false,
     };
 
     let result = reflow_markdown(input, &options);
@@ -847,6 +851,7 @@ fn test_definition_list_with_paragraphs() {
         require_sentence_capital: true,
         max_list_continuation_indent: None,
         defined_references: None,
+        emphasis_spans: false,
     };
 
     let content = "Regular paragraph. With multiple sentences.\n\nTerm\n: Definition.\n\nAnother paragraph.";


### PR DESCRIPTION
Adds a new configuration option `emphasis_spans` to MD013 (Line Length) config (which translates into `emphasis_spans` in `ReflowOptions`), matching the naming of `code_spans`.

When enabled (`true`), emphasis spans (bold, italic, strikethrough) are no longer treated as atomic units. Instead, they are split word-by-word like normal text and wrapped across line boundaries if they don't fit on the current line.

By default, this option is `false` to preserve the original behavior of keeping short emphasis spans atomic.

Also includes:
- Refactoring of internal `cascade_split_line` signature to take `&ReflowOptions` directly, simplifying option propagation.
- Unit tests verifying the wrapping of emphasis spans with different markers.
- Documentation for the new `emphasis-spans` configuration option in `docs/md013.md`.

Assisted-by: Antigravity with Gemini