### PR TITLE
fix(tests): resolve String addition compilation errors under Rust 1.96

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -92,7 +92,7 @@ requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
 "#;
-        let content = basic_content.to_owned() + &config_content;
+        let content = basic_content.to_owned() + config_content.as_str();
 
         match fs::write("pyproject.toml", content) {
             Ok(()) => {

--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -2657,7 +2657,7 @@ impl MD013LineLength {
                                         // First line of first block gets marker
                                         result.push(format!(
                                             "{marker}{}",
-                                            " ".repeat(orig_indent - marker_len) + content
+                                            " ".repeat(orig_indent - marker_len) + content.as_str()
                                         ));
                                         is_first_block = false;
                                     } else if content.is_empty() {
@@ -2787,7 +2787,7 @@ impl MD013LineLength {
                                         // First line of first block gets the list marker
                                         result.push(format!(
                                             "{marker}{}",
-                                            " ".repeat(orig_indent.saturating_sub(marker_len)) + content
+                                            " ".repeat(orig_indent.saturating_sub(marker_len)) + content.as_str()
                                         ));
                                         is_first_block = false;
                                     } else {
@@ -2840,7 +2840,7 @@ impl MD013LineLength {
                                 if is_first_block {
                                     result.push(format!(
                                         "{marker}{}",
-                                        " ".repeat(header_indent.saturating_sub(marker_len)) + header
+                                        " ".repeat(header_indent.saturating_sub(marker_len)) + header.as_str()
                                     ));
                                     is_first_block = false;
                                 } else {

--- a/src/utils/anchor_styles/github.rs
+++ b/src/utils/anchor_styles/github.rs
@@ -952,18 +952,18 @@ mod tests {
         // Test ReDoS resistance with pathological inputs
 
         // Nested patterns that could cause exponential backtracking
-        let nested_emphasis = "*".repeat(50) + "text" + &"*".repeat(50);
+        let nested_emphasis = "*".repeat(50) + "text" + "*".repeat(50).as_str();
         let result = heading_to_fragment(&nested_emphasis);
         // Should not hang and should produce reasonable output
         assert!(result.len() < 200); // Bounded output
 
         // Deeply nested code blocks
-        let nested_code = "`".repeat(100) + "code" + &"`".repeat(100);
+        let nested_code = "`".repeat(100) + "code" + "`".repeat(100).as_str();
         let result = heading_to_fragment(&nested_code);
         assert!(result.len() < 300); // Bounded output
 
         // Pathological link patterns
-        let nested_links = "[".repeat(50) + "text" + &"]".repeat(50);
+        let nested_links = "[".repeat(50) + "text" + "]".repeat(50).as_str();
         let result = heading_to_fragment(&nested_links);
         assert!(result.len() < 200); // Bounded output
     }

--- a/tests/config/config_application_tests.rs
+++ b/tests/config/config_application_tests.rs
@@ -162,7 +162,7 @@ fn test_config_priority() {
 
 "
     .to_owned()
-        + &"ab ".repeat(32)
+        + "ab ".repeat(32).as_str()
         + "abcd"; // 32 * 3 + 4 = 100 chars on line 3, prefix = 97
 
     // Run linting with the NEW configured rules vector

--- a/tests/formats/mkdocs_extensions_test.rs
+++ b/tests/formats/mkdocs_extensions_test.rs
@@ -2486,7 +2486,7 @@ mod boundary_tests {
         // 79 chars (within limit)
         let short = format!(
             "# Test\n\nPress {} to continue.\n",
-            "++ctrl+alt+shift+".to_string() + &"x".repeat(40) + "++"
+            "++ctrl+alt+shift+".to_string() + "x".repeat(40).as_str() + "++"
         );
         // Should work or fail gracefully
         let _ = lint_mkdocs(&short);

--- a/tests/perf/malformed_markdown_stress_tests.rs
+++ b/tests/perf/malformed_markdown_stress_tests.rs
@@ -313,9 +313,9 @@ fn test_pathological_regex_patterns() {
         // Many alternatives
         format!("[{}](url)", "link|".repeat(100)),
         // Complex nested structures
-        "```\n".repeat(100) + &"text\n".repeat(100) + &"```\n".repeat(100),
+        "```\n".repeat(100) + "text\n".repeat(100).as_str() + "```\n".repeat(100).as_str(),
         // Mixed quote and code patterns
-        "> ".repeat(50) + &"```\n".repeat(25) + "content\n" + &"```\n".repeat(25),
+        "> ".repeat(50) + "```\n".repeat(25).as_str() + "content\n" + "```\n".repeat(25).as_str(),
     ];
 
     let rules: Vec<Box<dyn Rule>> = vec![

--- a/tests/rules/md051_critical_edge_cases_test.rs
+++ b/tests/rules/md051_critical_edge_cases_test.rs
@@ -47,9 +47,9 @@ fn test_redos_vulnerability_prevention() {
     // Patterns known to cause exponential backtracking in poorly written regex
     let malicious_patterns = vec![
         // Nested quantifiers - classic ReDoS pattern
-        "a".repeat(50) + &"a*".repeat(20) + "X",
+        "a".repeat(50) + "a*".repeat(20).as_str() + "X",
         // Alternation with repetition
-        ("(a|a)*".to_string() + &"b".repeat(30)),
+        ("(a|a)*".to_string() + "b".repeat(30).as_str()),
         // Catastrophic backtracking pattern
         "a".repeat(30) + "(a+)+",
         // Unicode variation that might stress char iteration

--- a/tests/rules/md051_edge_cases_test.rs
+++ b/tests/rules/md051_edge_cases_test.rs
@@ -167,10 +167,10 @@ mod tests {
         ];
 
         let static_patterns = vec![
-            ("*".repeat(50) + "text" + &"*".repeat(50), "Markdown asterisks"),
-            ("`".repeat(30) + "code" + &"`".repeat(30), "Markdown backticks"),
-            ("[".repeat(20) + "link" + &"]".repeat(20), "Markdown brackets"),
-            ("🎉".repeat(50) + &"a".repeat(50), "Emoji + text pattern"),
+            ("*".repeat(50) + "text" + "*".repeat(50).as_str(), "Markdown asterisks"),
+            ("`".repeat(30) + "code" + "`".repeat(30).as_str(), "Markdown backticks"),
+            ("[".repeat(20) + "link" + "]".repeat(20).as_str(), "Markdown brackets"),
+            ("🎉".repeat(50) + "a".repeat(50).as_str(), "Emoji + text pattern"),
             ("a\u{0301}".repeat(100), "Combining character repetition"),
         ];
 

--- a/tests/rules/md051_performance_edge_cases_test.rs
+++ b/tests/rules/md051_performance_edge_cases_test.rs
@@ -18,15 +18,15 @@ fn test_regex_catastrophic_backtracking_prevention() {
         ("a".repeat(30) + "(a|a)*$"),
         ("a".repeat(30) + "(a*)*$"),
         // Alternation with repetition
-        ("(a|b)*".repeat(10) + &"c".repeat(20)),
+        ("(a|b)*".repeat(10) + "c".repeat(20).as_str()),
         // Complex nested groups
-        ("((a*)*)*".to_string() + &"b".repeat(20)),
+        ("((a*)*)*".to_string() + "b".repeat(20).as_str()),
         // Mixed with actual markdown-like content
-        ("*".repeat(50) + "text" + &"*".repeat(50)),
-        ("`".repeat(30) + "code" + &"`".repeat(30)),
-        ("[".repeat(20) + "link" + &"]".repeat(20)),
+        ("*".repeat(50) + "text" + "*".repeat(50).as_str()),
+        ("`".repeat(30) + "code" + "`".repeat(30).as_str()),
+        ("[".repeat(20) + "link" + "]".repeat(20).as_str()),
         // Unicode that might stress character classification
-        ("🎉".repeat(50) + &"a".repeat(50)),
+        ("🎉".repeat(50) + "a".repeat(50).as_str()),
         // Combining characters that might stress normalization
         ("a\u{0301}".repeat(100)),
     ];
@@ -434,7 +434,7 @@ fn test_performance_under_memory_pressure() {
     let document_size = 1000; // words per document
 
     for doc_num in 0..document_count {
-        let heading = "Large Document ".to_string() + &"word ".repeat(document_size);
+        let heading = "Large Document ".to_string() + "word ".repeat(document_size).as_str();
         let content = format!("# {heading}\n\n[Link](#large-document)");
         let ctx = LintContext::new(&content, rumdl_lib::config::MarkdownFlavor::Standard, None);
 

--- a/tests/rules/md051_property_based_test.rs
+++ b/tests/rules/md051_property_based_test.rs
@@ -93,7 +93,7 @@ fn property_reasonable_fragment_length() {
     let rule = MD051LinkFragments::new();
 
     let extremely_long = "A".repeat(1000);
-    let unicode_long = "Unicode: ".to_string() + &"日".repeat(100);
+    let unicode_long = "Unicode: ".to_string() + "日".repeat(100).as_str();
     let test_inputs = vec![
         "",
         "A",


### PR DESCRIPTION
Fix compilation failures under Rust 1.96.0+ caused by attempting to add `&String` to `String` (e.g. `cannot add &String to String`).

Resolved by converting string repetitions to borrowed string slices using `.as_str()` before addition. This ensures the entire integration test registry compiles successfully.

Assisted-by: Antigravity with Gemini