### PR TITLE
fix(config): honor booleans and alias keys in markdownlint-configure-file

### DIFF
--- a/src/inline_config.rs
+++ b/src/inline_config.rs
@@ -225,7 +225,23 @@ impl InlineConfig {
                             && let Some(obj) = json_config.as_object()
                         {
                             for (rule_name, rule_config) in obj {
-                                config.file_rule_config.insert(rule_name.clone(), rule_config.clone());
+                                // markdownlint allows a boolean to turn a rule off or
+                                // back on, e.g. `{ "no-trailing-spaces": false }`, so
+                                // route those to the disable set instead of storing
+                                // them as rule options.
+                                let normalized = normalize_rule_name(rule_name);
+                                if let Some(enabled) = rule_config.as_bool() {
+                                    if enabled {
+                                        config.file_disabled_rules.remove(&normalized);
+                                    } else {
+                                        config.file_disabled_rules.insert(normalized);
+                                    }
+                                    continue;
+                                }
+                                // Store under the canonical rule id so lookups by
+                                // `MDxxx` also find configs written with an alias,
+                                // e.g. `{ "line-length": { "line_length": 70 } }`.
+                                config.file_rule_config.insert(normalized, rule_config.clone());
                             }
                         }
                     }
@@ -1131,6 +1147,52 @@ This is a test line."#;
         let obj = json.as_object().unwrap();
         assert!(obj.contains_key("tables"), "Should have tables key");
         assert!(!obj.get("tables").unwrap().as_bool().unwrap());
+    }
+
+    #[test]
+    fn test_configure_file_bool_false_disables_rule() {
+        // markdownlint documents a boolean as a way to turn a rule off for the
+        // whole file, e.g. `{ "no-trailing-spaces": false }`.
+        let content = r#"<!-- markdownlint-configure-file {"MD012": false} -->"#;
+
+        let inline_config = InlineConfig::from_content(content);
+
+        assert!(inline_config.is_rule_disabled("MD012", 1));
+        assert!(
+            inline_config.get_rule_config("MD012").is_none(),
+            "a boolean should not be stored as rule options"
+        );
+    }
+
+    #[test]
+    fn test_configure_file_bool_false_disables_rule_by_alias() {
+        let content = r#"<!-- markdownlint-configure-file {"no-multiple-blanks": false} -->"#;
+
+        let inline_config = InlineConfig::from_content(content);
+
+        assert!(inline_config.is_rule_disabled("MD012", 1));
+    }
+
+    #[test]
+    fn test_configure_file_bool_true_leaves_rule_enabled() {
+        let content = r#"<!-- markdownlint-configure-file {"MD012": true} -->"#;
+
+        let inline_config = InlineConfig::from_content(content);
+
+        assert!(!inline_config.is_rule_disabled("MD012", 1));
+    }
+
+    #[test]
+    fn test_get_rule_config_from_configure_file_alias_key() {
+        // A config written with the rule's alias must be reachable by its id.
+        let content = r#"<!-- markdownlint-configure-file {"line-length": {"line_length": 50}} -->"#;
+
+        let inline_config = InlineConfig::from_content(content);
+        let config_override = inline_config.get_rule_config("MD013");
+
+        assert!(config_override.is_some(), "alias-keyed config should resolve to MD013");
+        let obj = config_override.unwrap().as_object().unwrap();
+        assert_eq!(obj.get("line_length").unwrap().as_u64().unwrap(), 50);
     }
 
     // ── parse_disable_comment / parse_enable_comment edge cases ──────────


### PR DESCRIPTION
## Description

Two things get dropped when reading an inline `markdownlint-configure-file` comment. Both come from the same two lines in `src/inline_config.rs`:

```rust
for (rule_name, rule_config) in obj {
    config.file_rule_config.insert(rule_name.clone(), rule_config.clone());
}
```

### 1. A boolean value doesn't disable the rule

rumdl already handles this correctly in an external `.markdownlint.json`, so right now the two config paths disagree with each other:

```json
{ "MD012": false }
```

```markdown
<!-- markdownlint-configure-file { "MD012": false } -->
```

Same JSON, same rule. In the file it disables MD012. Inline it doesn't, because the boolean gets stored as if it were a set of rule options and nothing ever reads it back as "off".

### 2. A rule name written as an alias never applies

The key is stored exactly as written, but lookups use the `MDxxx` id. So this:

```markdown
<!-- markdownlint-configure-file { "line-length": { "line_length": 70 } } -->
```

is kept under `"line-length"`, while MD013 asks for `"MD013"` and finds nothing. It fails quietly, which is the annoying part. You get default behaviour and no hint that the config was ignored.

The `disable` and `enable` comments already normalize names through `normalize_rule_name`, so aliases work there. It's just this one path that skips it.

For reference, markdownlint's README uses the boolean form in its own example for this comment (`"no-trailing-spaces": false`), and `docs/markdownlint-comparison.md:282` says both syntaxes "work identically in rumdl for seamless migration".

## Fix

Booleans go to the file disable set, with `true` clearing it again, and keys are normalized before being stored.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`cargo nextest run --profile dev`)
- [x] Manual testing performed

Four tests added next to the existing configure-file ones: boolean by id, boolean by alias, `true` leaving the rule on, and an alias-keyed object resolving to its id.

Suite goes 11,455 to 11,459 tests, all passing except `vscode::test_handle_vscode_command_status`, which also fails on a clean checkout here (it expects VS Code to be missing and this machine has it).

I checked these by hand against markdownlint-cli2 v0.23.1 as well, and all five cases line up now: boolean by id, boolean by alias, alias-keyed object, plus id-keyed objects and `true` still behaving as before.

One caveat worth being upfront about. I found this by diffing rumdl against markdownlint over markdownlint's own 407 test fixtures, and this fix only moves that comparison from 1337 to 1339 agreeing findings. That is not because the fix is small, it's because 239 of those 407 fixtures write the comment across multiple lines, and that form isn't picked up at all, so the config never gets as far as this code. That's #744, kept separate since it needs buffering across lines and felt like your call.

## Checklist

- [x] Code follows project style (`cargo fmt` && `cargo clippy`)
- [x] Conventional commit messages used
- [ ] Documentation updated (if needed)
