### PR TITLE
fix(MD013): adjust paragraph reflow limit for common indent

### DIFF
--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -3515,7 +3515,7 @@ impl MD013LineLength {
                 let reflow_line_length = if config.line_length.is_unlimited() {
                     usize::MAX
                 } else {
-                    config.line_length.get()
+                    config.line_length.get().saturating_sub(common_indent.len()).max(1)
                 };
                 let reflow_options = Self::reflow_options(ctx, config, reflow_line_length);
                 let mut reflowed = crate::utils::text_reflow::reflow_line(&paragraph_text, &reflow_options);

--- a/src/rules/md013_line_length/tests.rs
+++ b/src/rules/md013_line_length/tests.rs
@@ -1044,6 +1044,40 @@ And a bullet list:
 }
 
 #[test]
+fn test_reflow_paragraph_following_nested_list() {
+    let config = MD013Config {
+        line_length: crate::types::LineLength::from_const(80),
+        reflow: true,
+        ..Default::default()
+    };
+    let rule = MD013LineLength::from_config_struct(config);
+
+    let content = indoc! {"
+        -   Parent Item
+
+            1.  Sub-item 1
+            2.  Sub-item 2
+
+            This paragraph is at the parent item level (indented by 4 spaces). It is a long paragraph that should be wrapped to stay within the 80-character limit, but the formatter fails to reflow it.
+    "};
+
+    let expected = indoc! {"
+        -   Parent Item
+
+            1.  Sub-item 1
+            2.  Sub-item 2
+
+            This paragraph is at the parent item level (indented by 4 spaces). It is a
+            long paragraph that should be wrapped to stay within the 80-character limit,
+            but the formatter fails to reflow it.
+    "};
+
+    let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+    let fixed = rule.fix(&ctx).unwrap();
+    assert_eq!(fixed, expected);
+}
+
+#[test]
 fn test_issue_83_numbered_list_with_backticks() {
     // Test for issue #83: enable_reflow was incorrectly handling numbered lists
     let config = MD013Config {


### PR DESCRIPTION
When reflowing a paragraph that has a common indent (e.g. a paragraph following a nested list, structurally inside a list block), the reflow engine was using the full configured line length limit. This resulted in lines that exceeded the limit once the common indent was re-applied.

Subtract `common_indent.len()` from the target line length when reflowing paragraphs to ensure the final indented lines stay within the limit.

Assisted-by: Antigravity with Gemini