### PR TITLE
fix(md058,md065): preserve the trailing newline when inserting blank lines

### DIFF
--- a/src/rules/md058_blanks_around_tables.rs
+++ b/src/rules/md058_blanks_around_tables.rs
@@ -278,7 +278,12 @@ impl Rule for MD058BlanksAroundTables {
             i += 1;
         }
 
-        Ok(result.join("\n"))
+        let mut fixed = result.join("\n");
+        if content.ends_with('\n') {
+            fixed.push('\n');
+        }
+
+        Ok(fixed)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -1484,5 +1489,32 @@ More text.";
             "MD058 must flag the missing blank after table under Standard: {result_std:?}"
         );
         assert!(result_std[0].message.contains("Missing blank line after table"));
+    }
+
+    #[test]
+    fn test_fix_preserves_trailing_newline() {
+        let rule = MD058BlanksAroundTables::default();
+
+        let content = "Intro\n| a | b |\n| --- | --- |\n| 1 | 2 |\nAfter\n";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let fixed = rule.fix(&ctx).unwrap();
+
+        assert!(fixed.ends_with('\n'), "Fix should preserve trailing newline");
+        assert_eq!(fixed, "Intro\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\nAfter\n");
+    }
+
+    #[test]
+    fn test_fix_preserves_no_trailing_newline() {
+        let rule = MD058BlanksAroundTables::default();
+
+        let content = "Intro\n| a | b |\n| --- | --- |\n| 1 | 2 |\nAfter";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let fixed = rule.fix(&ctx).unwrap();
+
+        assert!(
+            !fixed.ends_with('\n'),
+            "Fix should not add trailing newline if original didn't have one"
+        );
+        assert_eq!(fixed, "Intro\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\nAfter");
     }
 }

--- a/src/rules/md065_blanks_around_horizontal_rules.rs
+++ b/src/rules/md065_blanks_around_horizontal_rules.rs
@@ -208,7 +208,12 @@ impl Rule for MD065BlanksAroundHorizontalRules {
             }
         }
 
-        Ok(result.join("\n"))
+        let mut fixed = result.join("\n");
+        if content.ends_with('\n') {
+            fixed.push('\n');
+        }
+
+        Ok(fixed)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -1110,5 +1115,32 @@ Final thoughts.";
             fixed, expected,
             "Fix should preserve triple-nested blockquote prefix '>>>'"
         );
+    }
+
+    #[test]
+    fn test_fix_preserves_trailing_newline() {
+        let rule = MD065BlanksAroundHorizontalRules;
+
+        let content = "Text\n***\nMore text\n";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let fixed = rule.fix(&ctx).unwrap();
+
+        assert!(fixed.ends_with('\n'), "Fix should preserve trailing newline");
+        assert_eq!(fixed, "Text\n\n***\n\nMore text\n");
+    }
+
+    #[test]
+    fn test_fix_preserves_no_trailing_newline() {
+        let rule = MD065BlanksAroundHorizontalRules;
+
+        let content = "Text\n***\nMore text";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let fixed = rule.fix(&ctx).unwrap();
+
+        assert!(
+            !fixed.ends_with('\n'),
+            "Fix should not add trailing newline if original didn't have one"
+        );
+        assert_eq!(fixed, "Text\n\n***\n\nMore text");
     }
 }

--- a/tests/cli/cli_lsp_fix_consistency.rs
+++ b/tests/cli/cli_lsp_fix_consistency.rs
@@ -229,6 +229,40 @@ fn test_md075_orphaned_table_rows_issue_420_consistency() {
     test_cli_lsp_consistency(&rule, content, "MD075: issue #420 inline-fence orphan rows");
 }
 
+#[test]
+fn test_md058_blanks_around_tables_consistency() {
+    let rule = MD058BlanksAroundTables::default();
+
+    let test_cases = vec![
+        (
+            "Intro\n| a | b |\n| --- | --- |\n| 1 | 2 |\nAfter\n",
+            "Table needing blanks, content ends with a newline",
+        ),
+        (
+            "Intro\n| a | b |\n| --- | --- |\n| 1 | 2 |\nAfter",
+            "Table needing blanks, content ends without a newline",
+        ),
+    ];
+
+    for (content, description) in test_cases {
+        test_cli_lsp_consistency(&rule, content, &format!("MD058: {description}"));
+    }
+}
+
+#[test]
+fn test_md065_blanks_around_horizontal_rules_consistency() {
+    let rule = MD065BlanksAroundHorizontalRules;
+
+    let test_cases = vec![
+        ("Text\n***\nMore text\n", "Thematic break, content ends with a newline"),
+        ("Text\n***\nMore text", "Thematic break, content ends without a newline"),
+    ];
+
+    for (content, description) in test_cases {
+        test_cli_lsp_consistency(&rule, content, &format!("MD065: {description}"));
+    }
+}
+
 /// Create appropriate test content for each rule based on what it checks
 fn get_test_content_for_rule(rule_name: &str) -> Option<&'static str> {
     match rule_name {
@@ -285,14 +319,14 @@ fn get_test_content_for_rule(rule_name: &str) -> Option<&'static str> {
         "MD055" => Some("|col1|col2|\n|--|--|\ncol3|col4"),
         "MD056" => Some("|col1|col2|\n|--|--|\n|a|"),
         "MD057" => Some("[link](missing.md)"),
-        "MD058" => Some("Text\n|table|\nText"),
+        "MD058" => Some("Text\n| a | b |\n| - | - |\n| 1 | 2 |\nText\n"),
         "MD059" => Some("[click here](https://example.com)"),
         "MD060" => Some("|col1|col2|\n|-|-|\n|a|b|"),
         "MD061" => Some("This contains a TODO marker"),
         "MD062" => Some("[link]( https://example.com )"),
         "MD063" => Some("# heading in lowercase"),
         "MD064" => Some("Text with  multiple  spaces"),
-        "MD065" => Some("Text\n---\nMore text"),
+        "MD065" => Some("Text\n***\nMore text\n"),
         "MD066" => Some("Text[^1]\n\n[^1]:"),
         "MD067" => Some("Text[^2][^1]\n\n[^1]: First\n[^2]: Second"),
         "MD068" => Some("[^1]:\n\n[^1]: Empty footnote"),


### PR DESCRIPTION
## Description

MD058 and MD065 rebuild the document in `fix()` from `ctx.raw_lines()` and return
`result.join("\n")`. `raw_lines()` carries no information about a final line terminator,
so the join cannot reproduce one and a trailing newline the input had is dropped.

```
$ printf '[global]\nenable = ["MD058", "MD065"]\n' > .rumdl.toml
$ printf 'Intro\n| a | b |\n| --- | --- |\n| 1 | 2 |\nAfter\n' > g.md

$ rumdl fmt g.md
g.md:2:1: [MD058] Missing blank line before table [fixed]
g.md:4:10: [MD058] Missing blank line after table [fixed]

Fixed: Fixed 2/2 issues in 1 file

$ od -c g.md | tail -2
0000040        1       |       2       |  \n  \n   A   f   t   e   r
0000057
```

The file went in ending `After\n` at 46 bytes and came out ending `After` at 47 (octal
`0000057`): the two inserted blank lines are `+2` and the lost trailing newline is `-1`.
MD065 does the same with `Text\n***\nMore text\n`.

### Where this is and is not observable

I want to be precise about the blast radius, because it is narrower than it first looks.

| condition | trailing newline |
|---|---|
| `rumdl fmt`, default rule set | **preserved** — MD047 runs afterwards and restores it |
| `rumdl fmt` with `disable = ["MD047"]` | **lost** |
| `rumdl fmt` with a restricted `enable` list, as above | **lost** |
| library `rule.fix()` called directly | **lost** |
| CLI vs LSP agreement | **broken unconditionally** (see below) |

So default `rumdl fmt` is not affected and this is not a file-corruption report. I ran each
row above against a build with the guard absent rather than reasoning about it.

The unconditional part is the two-path divergence. The warning-level fixes are byte-range
insertions and are unaffected, so the LSP path keeps the newline and the CLI path does not,
on identical input:

| path | `"Text\n***\nMore text\n"` becomes |
|---|---|
| `rule.fix()` (CLI batch) | `"Text\n\n***\n\nMore text"` |
| `apply_warning_fixes()` (LSP) | `"Text\n\n***\n\nMore text\n"` |

This is the same defect as MD071 in #262, fixed in 04edace3 — *"The fix() method used
lines().collect() which strips trailing newlines, then join("\n") doesn't restore them."*
The symptom presents differently today than it did in #262: that issue's repro no longer
surfaces under default `fmt`, because the pipeline now applies fixes iteratively to
convergence (`file_processor/processing.rs:1048`), so MD047 gets a later pass in which to
clean up after the offending rule. The underlying defect in `fix()` is unchanged.

### Cause and fix

Restore the newline after the join when the original content ended with one:

```rust
let mut fixed = result.join("\n");
if content.ends_with('\n') {
    fixed.push('\n');
}
```

This is the guard MD032 already carries at `md032_blanks_around_lists.rs:1022-1025`, copied
verbatim in shape. MD031 does not carry it and does not need it — e4c2f4ee converted MD031
to derive `fix()` from `check()`, so there is no join left to lose the newline at — but it
kept the pair of tests this change mirrors, at `md031_blanks_around_fences.rs:673` and
`:687`.

I deliberately used MD032's unconditional `push` rather than MD071's
`if had_trailing_newline && !fixed.ends_with('\n')`. On content ending in a blank line the
MD071 variant collapses `"…After\n\n\n"` to `"…After\n\n"`; MD032's shape preserves it. I
verified both behaviours.

I checked the other `fix()` implementations for the same pattern. MD058 and MD065 were the
only two remaining.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

Four unit tests, a matched `test_fix_preserves_trailing_newline` /
`test_fix_preserves_no_trailing_newline` pair in each rule's `mod tests`, mirroring the
existing MD031 pair. Two integration tests in `tests/cli/cli_lsp_fix_consistency.rs`,
`test_md058_blanks_around_tables_consistency` and
`test_md065_blanks_around_horizontal_rules_consistency`, following that file's existing
per-rule pattern and covering content both with and without a trailing newline.

I verified these fail without the fix. Reverting only the two `fix()` hunks and leaving the
tests in place gives four failures (the source line numbers below are from that reverted
tree, which is five lines shorter per file than this branch):

```
thread 'rules::md058_blanks_around_tables::tests::test_fix_preserves_trailing_newline' panicked at src/rules/md058_blanks_around_tables.rs:1497:9:
Fix should preserve trailing newline

thread 'rules::md065_blanks_around_horizontal_rules::tests::test_fix_preserves_trailing_newline' panicked at src/rules/md065_blanks_around_horizontal_rules.rs:1123:9:
Fix should preserve trailing newline

thread 'cli::cli_lsp_fix_consistency::test_md065_blanks_around_horizontal_rules_consistency' panicked at tests/cli/cli_lsp_fix_consistency.rs:30:21:
assertion `left == right` failed: MD065: Thematic break, content ends with a newline: CLI and LSP fixes produced different results.
Original: "Text\n***\nMore text\n"
CLI: "Text\n\n***\n\nMore text"
LSP: "Text\n\n***\n\nMore text\n"

Summary 6 tests run: 2 passed, 4 failed, 12443 skipped
```

Restoring the fix gives 6/6 passing. The two `no_trailing_newline` cases pass in both
states, which is what they are there for.

Full suite: **12444 passed, 0 failed, 5 skipped**. Baseline on `7535e208` before the change
is 12438 passed, so the delta is exactly the six new tests. `cargo fmt --check` clean.
`rumdl fmt --check docs/` clean, 20 files.

Clippy is green apart from one pre-existing `collapsible_match` at
`src/utils/code_block_utils.rs:142`, which reproduces on an unmodified checkout of `main`
here and is an artifact of my local 1.95 toolchain. It does not fire on the 1.96 pinned in
`rust-toolchain.toml`, so it should not appear in CI. It is not related to this change and I
have not touched it.

### One change in here is coverage only

The two edited fixtures in `get_test_content_for_rule` do not gate anything, and I do not
want them read as added enforcement. `test_all_53_rules_systematic_coverage` records
inconsistencies into a counter and prints them, but never asserts on them, so those two
lines cannot fail either way. I changed them because neither fixture exercised its rule at
all: MD065's `"Text\n---\nMore text"` parses as a setext heading, so the rule never fired,
and MD058's `"Text\n|table|\nText"` has no delimiter row, so `rumdl check` reports no issues
on it. Happy to split them into a separate PR or drop them if you would rather keep this to
the fix.

## Checklist

- [x] Code follows project style (`cargo fmt --check`; `make lint` needs `actionlint` and
      `uvx zizmor`, which I do not have locally)
- [x] Conventional commit messages used (they generate the changelog)
- [x] Documentation updated (if needed) — no user-facing behaviour change to document
- [x] Tests added, and verified to fail without the fix

## Alternative

The alternative is your existing direction rather than anything I would invent: the 28-commit
`derive fix() from check() to eliminate two-path divergence` campaign from 2026-04-07 to
04-10 (4bc7ae34, e4c2f4ee, d476ddc1, cc35cbcf and the rest). "Two-path divergence" is exactly
the second symptom above, and MD058 and MD065 are two rules that campaign did not reach, as
is MD032.

I chose the guard instead for three reasons. It is surgical. MD032 is still on the join path,
so the guard is the current convention there rather than a dead end. And converting these two
rules to derive `fix()` from `check()` is not a pure refactor for them — MD058 emits a
variable number of blank lines parsed back out of the warning message, and both rules build
blockquote-prefixed blank lines via `blockquote_prefix_for_blank_line`, so the conversion
would move real behaviour and belongs in your hands rather than bundled into a one-line fix.

Say the word and I will convert both rules instead, or close this if you would rather sweep
the remaining rules yourself in one pass.

---

Written with AI assistance (Claude); every transcript quoted above is captured output from a
run I made myself — the failure transcripts against this branch with the two `fix()` hunks
reverted, everything else against the branch as it stands.
