### PR TITLE
feat(md077): support fixed continuation indent config

### DIFF
--- a/docs/md077.md
+++ b/docs/md077.md
@@ -234,7 +234,40 @@ to the content column.
 #               column (mdformat parity). Tight under-indented lazy
 #               continuation is additionally flagged and snapped up.
 style = "any"
+
+# Fixed continuation indent relative to each item's marker, e.g. 4 for
+# MkDocs-style documents. When set, this overrides the content-column-derived
+# requirement (including the MkDocs flavor's 4-space minimum). Unset (None)
+# keeps the default content-column behavior.
+# indent = 4
 ```
+
+### `indent`
+
+By default MD077 derives the required continuation indent from each item's
+content column (the W+N rule; under the MkDocs flavor a 4-space minimum is
+enforced). When a fixed `indent` is configured, the requirement becomes the
+item's *marker column plus the configured indent*, which lets documents that
+follow a `.editorconfig` style (e.g. `indent = 2`, or MkDocs's 4-space
+convention) stay consistent with tools like `editorconfig-checker`:
+
+```toml
+[MD077]
+indent = 4
+```
+
+With `indent = 4`, a top-level item (marker at column 0) requires continuation
+content at 4 spaces, and a nested item (marker at column 2) requires it at 6:
+
+```markdown
+- a long line
+    that continues 4 spaces past the marker
+  - nested item
+      that continues 4 spaces past the nested marker
+```
+
+Continuation content below the fixed requirement is flagged and fixed up to it
+(the same rules for blank-line escapes and over-indentation still apply).
 
 ### `style = "aligned"`
 

--- a/src/rules/md077_list_continuation_indent.rs
+++ b/src/rules/md077_list_continuation_indent.rs
@@ -53,7 +53,7 @@ impl MD077ListContinuationIndent {
     /// (`ContinuationStyle::Any`) preserves the historical behavior.
     pub fn new(style: ContinuationStyle) -> Self {
         Self {
-            config: MD077Config { style },
+            config: MD077Config { style, indent: None },
         }
     }
 
@@ -651,7 +651,11 @@ impl Rule for MD077ListContinuationIndent {
             .iter()
             .enumerate()
             .map(|(item_idx, &(item_line, marker_col, content_col, task_col))| {
-                let required = if strict_indent { content_col.max(4) } else { content_col };
+                let required = match self.config.indent {
+                    Some(indent) => marker_col + indent,
+                    None if strict_indent => content_col.max(4),
+                    None => content_col,
+                };
                 (
                     item_line,
                     marker_col,
@@ -2884,6 +2888,48 @@ mod tests {
         let rule = MD077ListContinuationIndent::from_config(&config);
         let ctx = LintContext::new("- item\nwrap\n", MarkdownFlavor::Standard, None);
         assert!(rule.check(&ctx).unwrap().is_empty());
+    }
+
+    #[test]
+    fn from_config_indent_sets_fixed_requirement() {
+        // End-to-end: `[MD077] indent = 4` wires through from_config and
+        // requires continuation content to sit 4 spaces past the marker.
+        let mut config = crate::config::Config::default();
+        let mut rule_config = crate::config::RuleConfig::default();
+        rule_config.values.insert("indent".to_string(), toml::Value::Integer(4));
+        config.rules.insert("MD077".to_string(), rule_config);
+
+        let rule = MD077ListContinuationIndent::from_config(&config);
+
+        // "- item\n    wrap\n" -> continuation at 4 spaces: accepted.
+        let ok_ctx = LintContext::new("- item\n    wrap\n", MarkdownFlavor::Standard, None);
+        assert!(rule.check(&ok_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&ok_ctx).unwrap(), "- item\n    wrap\n");
+
+        // "- item\n\n  wrap\n" -> continuation at 2 spaces after a blank line:
+        // flagged as under-indented (would escape the list item).
+        let bad_ctx = LintContext::new("- item\n\n  wrap\n", MarkdownFlavor::Standard, None);
+        let warnings = rule.check(&bad_ctx).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("needs 4 spaces"));
+    }
+
+    #[test]
+    fn from_config_indent_applies_per_nested_marker() {
+        // With a fixed indent, each item's requirement is its own marker
+        // column plus the configured indent (nested item marker at 2 -> 6).
+        let mut config = crate::config::Config::default();
+        let mut rule_config = crate::config::RuleConfig::default();
+        rule_config.values.insert("indent".to_string(), toml::Value::Integer(4));
+        config.rules.insert("MD077".to_string(), rule_config);
+
+        let rule = MD077ListContinuationIndent::from_config(&config);
+        let ctx = LintContext::new("- a\n  - b\n      wrap\n", MarkdownFlavor::Standard, None);
+        let warnings = rule.check(&ctx).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "continuation at 6 spaces should pass: {warnings:?}"
+        );
     }
 
     #[test]

--- a/src/rules/md077_list_continuation_indent/md077_config.rs
+++ b/src/rules/md077_list_continuation_indent/md077_config.rs
@@ -9,6 +9,12 @@ pub struct MD077Config {
     /// How strictly continuation-line indentation is enforced.
     #[serde(default)]
     pub style: ContinuationStyle,
+    /// Fixed continuation indent relative to the list marker, e.g. `4` for
+    /// MkDocs-style documents. When set, overrides the content-column-derived
+    /// requirement (`content_col`, or `max(content_col, 4)` under the MkDocs
+    /// flavor). `None` keeps the default content-column behavior.
+    #[serde(default)]
+    pub indent: Option<usize>,
 }
 
 impl RuleConfig for MD077Config {
@@ -22,19 +28,36 @@ mod tests {
     #[test]
     fn defaults_to_any() {
         assert_eq!(MD077Config::default().style, ContinuationStyle::Any);
+        assert_eq!(MD077Config::default().indent, None);
         let parsed: MD077Config = toml::from_str("").unwrap();
         assert_eq!(parsed.style, ContinuationStyle::Any);
+        assert_eq!(parsed.indent, None);
     }
 
     #[test]
     fn parses_aligned() {
         let parsed: MD077Config = toml::from_str(r#"style = "aligned""#).unwrap();
         assert_eq!(parsed.style, ContinuationStyle::Aligned);
+        assert_eq!(parsed.indent, None);
     }
 
     #[test]
     fn parses_any() {
         let parsed: MD077Config = toml::from_str(r#"style = "any""#).unwrap();
         assert_eq!(parsed.style, ContinuationStyle::Any);
+    }
+
+    #[test]
+    fn parses_fixed_indent() {
+        let parsed: MD077Config = toml::from_str("indent = 4").unwrap();
+        assert_eq!(parsed.indent, Some(4));
+        assert_eq!(parsed.style, ContinuationStyle::Any);
+    }
+
+    #[test]
+    fn parses_style_and_indent_together() {
+        let parsed: MD077Config = toml::from_str("style = \"aligned\"\nindent = 4").unwrap();
+        assert_eq!(parsed.style, ContinuationStyle::Aligned);
+        assert_eq!(parsed.indent, Some(4));
     }
 }


### PR DESCRIPTION
Adds an optional `indent` setting to MD077 so documents that follow a different indentation convention (4 spaces for MkDocs, or a `.editorconfig`-driven style) can pin the required continuation indent instead of the content-column-derived default. When set, the requirement becomes marker column + indent, per item.

Closes #784.