### PR TITLE
fix(MD076): preserve spacing before fenced list items

### DIFF
--- a/src/rules/md076_list_item_spacing.rs
+++ b/src/rules/md076_list_item_spacing.rs
@@ -49,7 +49,7 @@ enum GapKind {
     Tight,
     /// Blank line that is a genuine inter-item separator.
     Loose,
-    /// Blank line required by another rule (MD031, MD058) after structural content.
+    /// Blank line required by another rule (MD031, MD058) around structural content.
     /// Excluded from consistency analysis — neither loose nor tight.
     Structural,
     /// Blank line after continuation content within a list item.
@@ -136,6 +136,29 @@ impl MD076ListItemSpacing {
         false
     }
 
+    /// Check whether a list item opens a fenced code block on its marker line.
+    ///
+    /// MD031 requires a blank line before that fence. MD076 must treat the same
+    /// blank as structural rather than removing it as an inter-item separator.
+    fn is_fenced_code_block_list_item(ctx: &LintContext, line_num: usize) -> bool {
+        let Some(info) = ctx.line_info(line_num) else {
+            return false;
+        };
+        let Some(item) = info.list_item.as_ref() else {
+            return false;
+        };
+        if !info.in_code_block {
+            return false;
+        }
+
+        info.content(ctx.content)
+            .get(item.content_column..)
+            .is_some_and(|content| {
+                let content = content.trim_start();
+                content.starts_with("```") || content.starts_with("~~~")
+            })
+    }
+
     /// Check whether a non-blank line is continuation content within a list item
     /// (indented prose that is not itself a list marker or structural content).
     ///
@@ -184,6 +207,12 @@ impl MD076ListItemSpacing {
         // The gap has a blank line only if the line immediately before the next item is blank.
         if !Self::is_effectively_blank(ctx, next - 1) {
             return GapKind::Tight;
+        }
+        // A fence opened directly on a list marker is still part of that list
+        // item. The blank before it belongs to MD031, not to MD076's spacing
+        // consistency policy, so removing it would create a fix loop.
+        if Self::is_fenced_code_block_list_item(ctx, next) {
+            return GapKind::Structural;
         }
         // Walk backwards past blank lines to find the last non-blank content line.
         // If that line is structural content, the blank is required (not a separator).

--- a/tests/regressions/md031_md076_issue_787_test.rs
+++ b/tests/regressions/md031_md076_issue_787_test.rs
@@ -1,0 +1,31 @@
+//! Regression test for issue #787: MD031 and MD076 must converge when a list
+//! item starts with a fenced code block.
+
+use rumdl_lib::config::{Config, MarkdownFlavor};
+use rumdl_lib::fix_coordinator::FixCoordinator;
+use rumdl_lib::rules::all_rules;
+
+const REPRO_INPUT: &str = "# Heading\n\n- foo\n- bar\n\n- ```text\n  baz\n  ```\n";
+
+#[test]
+fn md031_md076_converge_for_fenced_list_item() {
+    let config = Config::default();
+    let rules = all_rules(&config);
+    let warnings =
+        rumdl_lib::lint(REPRO_INPUT, &rules, false, MarkdownFlavor::Standard, None, None).expect("lint must succeed");
+    let mut fixed = REPRO_INPUT.to_string();
+
+    let result = FixCoordinator::new()
+        .apply_fixes_iterative(&rules, &warnings, &mut fixed, &config, 100, None)
+        .expect("fix pipeline must succeed");
+
+    assert!(result.converged, "fix pipeline reported a cycle: {result:?}");
+    assert!(
+        result.conflicting_rules.is_empty(),
+        "MD031 and MD076 must not conflict: {result:?}"
+    );
+    assert!(
+        fixed.contains("- bar\n\n- ```text"),
+        "MD031's required blank line before the fenced list item must be preserved:\n{fixed}"
+    );
+}

--- a/tests/regressions/mod.rs
+++ b/tests/regressions/mod.rs
@@ -22,6 +22,7 @@ mod md013_reflow_math_blocks_issue_762_test;
 mod md013_reflow_ordered_lookalike_issue_760_test;
 mod md013_reflow_span_spacing_issue_767_test;
 mod md030_grid_cards_issue_583_test;
+mod md031_md076_issue_787_test;
 mod md032_edge_cases_test;
 mod md032_ordered_list_bug_test;
 mod md033_edge_cases_test;


### PR DESCRIPTION
## Description

Fixes #787 by treating a blank line before a fenced code block opened on a list-item marker as structural spacing. MD076 no longer removes the blank line required by MD031, so the formatter converges instead of reporting an MD031/MD076 cycle.

## Root cause

MD076 classified the blank immediately before `- ```...` as an inter-item separator because the previous line was another list item. MD031 then restored that blank before the fence, causing the two auto-fixes to oscillate. The list-item line is itself the opening fence, so the preceding blank must be excluded from MD076's consistency analysis.

## Testing

- Added an end-to-end regression through `FixCoordinator` covering the reported Markdown.
- `cargo nextest run md031_md076_converge_for_fenced_list_item`
- `make test-dev` (12,269 passed, 226 skipped)
- `cargo fmt -- --check`
- `git diff --check`
- `cargo clippy --workspace --lib --bins --tests -- -D warnings -D clippy::uninlined_format_args -A clippy::collapsible-match`

`make lint` was also attempted; the available local Rust 1.95 toolchain reports the repository's pre-existing `src/utils/code_block_utils.rs:142` `clippy::collapsible-match` warning. The changed paths pass clippy with that unrelated baseline warning excluded.
