### PR TITLE
fix(md022): use the same list test below a heading in check and fix

### DIFF
--- a/src/rules/md022_blanks_around_headings.rs
+++ b/src/rules/md022_blanks_around_headings.rs
@@ -295,16 +295,16 @@ impl MD022BlanksAroundHeadings {
                 // Check if the next non-blank line is special (code fence or list item)
                 let next_is_special = if let Some(idx) = next_content_line_idx {
                     let next_line = &ctx.lines[idx];
-                    next_line.list_item.is_some() || {
-                        let trimmed = next_line.content(ctx.content).trim();
-                        (trimmed.starts_with("```") || trimmed.starts_with("~~~"))
+                    let trimmed = next_line.content(ctx.content).trim();
+                    next_line.list_item.is_some()
+                        || starts_with_list_marker(trimmed)
+                        || ((trimmed.starts_with("```") || trimmed.starts_with("~~~"))
                             && (trimmed.len() == 3
                                 || (trimmed.len() > 3
                                     && trimmed
                                         .chars()
                                         .nth(3)
-                                        .is_some_and(|c| c.is_whitespace() || c.is_alphabetic())))
-                    }
+                                        .is_some_and(|c| c.is_whitespace() || c.is_alphabetic()))))
                 } else {
                     false
                 };

--- a/tests/cli/cli_lsp_fix_consistency.rs
+++ b/tests/cli/cli_lsp_fix_consistency.rs
@@ -263,6 +263,25 @@ fn test_md065_blanks_around_horizontal_rules_consistency() {
     }
 }
 
+#[test]
+fn test_md022_blanks_around_headings_consistency() {
+    let rule = MD022BlanksAroundHeadings::default();
+
+    let test_cases = vec![
+        ("Text\n# Heading\nMore text", "Heading surrounded by paragraphs"),
+        (
+            "text\n# Heading\n    - deeper\n",
+            "Heading followed by an indented list marker",
+        ),
+        ("text\n# Heading\n- item\n", "Heading followed by a list item"),
+        ("text\n# Heading\n```\ncode\n```\n", "Heading followed by a code fence"),
+    ];
+
+    for (content, description) in test_cases {
+        test_cli_lsp_consistency(&rule, content, &format!("MD022: {description}"));
+    }
+}
+
 /// Create appropriate test content for each rule based on what it checks
 fn get_test_content_for_rule(rule_name: &str) -> Option<&'static str> {
     match rule_name {
@@ -283,7 +302,7 @@ fn get_test_content_for_rule(rule_name: &str) -> Option<&'static str> {
         "MD019" => Some("##  Multiple spaces"),
         "MD020" => Some("##No space in closed##"),
         "MD021" => Some("##  Multiple  spaces  ##"),
-        "MD022" => Some("Text\n# Heading\nMore text"),
+        "MD022" => Some("text\n# Heading\n    - deeper\n"),
         "MD023" => Some("  # Indented heading"),
         "MD024" => Some("# Duplicate\n# Duplicate"),
         "MD025" => Some("# First\n# Second H1"),

--- a/tests/rules/md022_test.rs
+++ b/tests/rules/md022_test.rs
@@ -622,3 +622,20 @@ fn test_roundtrip_code_block_heading() {
         &rule,
     );
 }
+
+#[test]
+fn test_roundtrip_heading_followed_by_indented_list_marker() {
+    let rule = MD022BlanksAroundHeadings::default();
+    assert_check_fix_roundtrip("text\n# Heading\n    - deeper\n", &rule);
+}
+
+#[test]
+fn test_no_blank_below_heading_followed_by_indented_list_marker() {
+    let rule = MD022BlanksAroundHeadings::default();
+    let content = "text\n# Heading\n    - deeper\n";
+    let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
+    let result = rule.check(&ctx).unwrap();
+    assert_eq!(result.len(), 1);
+    assert!(result[0].message.contains("above"), "got: {:?}", result[0].message);
+    assert_eq!(rule.fix(&ctx).unwrap(), "text\n\n# Heading\n    - deeper\n");
+}


### PR DESCRIPTION
## Description

MD022 applies an edit it never reported. On `text\n# Heading\n    - deeper\n`:

```console
$ rumdl check --no-cache -e MD022 b.md
b.md:2:1: [MD022] Expected 1 blank line above heading [*]
$ rumdl check --no-cache --fix -e MD022 b.md
b.md:2:1: [MD022] Expected 1 blank line above heading [fixed]
Fixed: Fixed 1/1 issues in 1 file
$ cat b.md
text

# Heading

    - deeper
```

One warning, one advertised fix, two blank lines inserted. The LSP quick-fix
path applies the warning's own fix rather than calling `rule.fix()`, so it
inserts only the blank above — the CLI and the editor produce different
documents from the same warning.

Low severity: both variants parse identically (MD046 reports the indented code
block either way), so nothing rendered changes, and the default rule set is no
different — MD041 and MD046 also fire here but neither is fixable. The defect is
the unadvertised edit, not the output.

**Cause.** `    - deeper` is an indented code block, so the parser leaves
`list_item` as `None`. `check()` (:544) therefore also tests the line
syntactically with `starts_with_list_marker`; the comment there says this keeps
the guard "and therefore the fix" idempotent. `fix_content()` (:296) tested only
`list_item`, saw a plain line, and inserted the blank.

**Fix.** Add the same term to `fix_content()`, so both sides ask the same
question.

Swept `rule.fix()` against `apply_warning_fixes(check())` over every 1–4 line
document from a synthetic 16-line alphabet (69904 docs, Standard flavour only —
MkDocs/MDX/Quarto unswept): divergences removed, none introduced, and no
document that converged in one `fix()` pass now needs two. Absolute counts
depend on the alphabet, so that is the direction, not a number. What remains is
pre-existing classes — trailing blank lines, HTML comments, blockquotes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] Two cases in `tests/rules/md022_test.rs` plus one in the CLI/LSP
      consistency harness. Reverting the source hunk with the tests kept fails
      all three; restoring it passes all three.
- [x] `cargo nextest run` and the lint-job gates match `main`.

## Checklist

- [x] Conventional commit; no documented behaviour changes
