### PR TITLE
fix(md018): accept the tags option instead of reporting it as unknown

### DIFF
--- a/src/rules/md018_no_missing_space_atx.rs
+++ b/src/rules/md018_no_missing_space_atx.rs
@@ -385,7 +385,7 @@ impl Rule for MD018NoMissingSpaceAtx {
         self
     }
 
-    crate::impl_rule_config_methods!(MD018Config);
+    crate::impl_rule_config_methods!(MD018Config, nullable);
 }
 
 #[cfg(test)]

--- a/src/rules/md018_no_missing_space_atx/md018_config.rs
+++ b/src/rules/md018_no_missing_space_atx/md018_config.rs
@@ -16,7 +16,7 @@ pub struct MD018Config {
     /// When true, single-hash patterns like `#tag`, `#project/active` are
     /// skipped. When null/unset, defaults to true for Obsidian flavor
     /// and false otherwise.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub tags: Option<bool>,
 }
 

--- a/tests/config/documented_alias_reachability_test.rs
+++ b/tests/config/documented_alias_reachability_test.rs
@@ -124,6 +124,27 @@ fn md077_indent_is_not_reported_as_an_unknown_option() {
 }
 
 #[test]
+fn md018_tags_is_not_reported_as_an_unknown_option() {
+    const TAG_LINE: &str = "# T\n\n#todo something\n";
+
+    let (baseline, _) = findings_for("MD018", "[MD018]\n", TAG_LINE);
+    assert_eq!(baseline, 1, "control: `#todo` is flagged without the setting");
+
+    let (count, stderr) = findings_for("MD018", "[MD018]\ntags = true\n", TAG_LINE);
+    assert_eq!(count, 0, "control: the setting must actually take effect");
+    assert!(
+        !stderr.contains("Unknown option"),
+        "a supported setting must not be reported as unknown, got:\n{stderr}"
+    );
+
+    let (_, stderr) = findings_for("MD018", "[MD018]\ntagz = true\n", TAG_LINE);
+    assert!(
+        stderr.contains("Unknown option"),
+        "a misspelled key must still be reported, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn a_genuinely_unknown_option_is_still_reported() {
     // Control: the validator must still catch real typos.
     let (_, stderr) = findings_for("MD013", "[MD013]\nignore-link-urlz = true\n", "# T\n\nbody\n");


### PR DESCRIPTION
`[MD018] tags` is documented in `docs/md018.md` and works, but the config key validator reports it as unknown, so a run with `--deny-config-warnings` fails on a valid config. On `main` @ `26543648`:

```console
$ printf '[MD018]\ntags = true\n' > .rumdl.toml
$ printf '#todo something\n\n# Real heading\n' > doc.md
$ rumdl check --no-cache --deny-config-warnings doc.md
[config warning] Unknown option for rule MD018: tags

Success: No issues found in 1 file (26ms)
$ echo $?
2
```

"No issues found" is the setting doing its job — `#todo` is skipped. Only the validator cannot see the key.

## Cause

The same one you fixed for MD077 in `cba175c0`: the plain `impl_rule_config_methods!` arm derives the known keys by serializing the default config, which drops `None` fields.

Here the `nullable` arm alone is not enough. `tags` also carried `skip_serializing_if = "Option::is_none"`, so the key is gone from the serialized value before `config_schema_table` can substitute a sentinel for it. Reverting either line on its own leaves the warning in place. MD018 is the only rule config using that attribute.

## Trade-off

As with MD077's `indent`, `rumdl config` now prints the nullable sentinel for `tags` — 11 keys across 8 rules already do on `main`. `rumdl init` and `rumdl config --output json` are byte-identical. Happy to filter the sentinel out of the config display path in a separate PR if you want that cleaned up.

## Tests

One test in `tests/config/documented_alias_reachability_test.rs` beside the MD077 one: `tags = true` produces no warning and takes effect, and `tagz = true` is still reported as unknown. Verified it fails with the source change stashed and passes with it restored.

Full suite, `cargo fmt --check` and `rumdl schema check` green on the branch.
