### PR TITLE
fix(md075): ignore Obsidian wikilink aliases in prose after tables

### DIFF
--- a/docs/flavors.md
+++ b/docs/flavors.md
@@ -10,7 +10,7 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 | [gfm](flavors/gfm.md)                   | GitHub Flavored Markdown             | MD033, MD034                                                                              |
 | [mkdocs](flavors/mkdocs.md)             | MkDocs / Material for MkDocs         | MD024, MD031, MD033, MD038, MD040, MD042, MD046, MD049, MD050, MD052, MD056               |
 | [mdx](flavors/mdx.md)                   | MDX (JSX in Markdown)                | MD013, MD033, MD037, MD039, MD044, MD049                                                  |
-| [obsidian](flavors/obsidian.md)         | Obsidian knowledge base              | MD011, MD012, MD018, MD028, MD033, MD034, MD037, MD038, MD044, MD049, MD061, MD064, MD069 |
+| [obsidian](flavors/obsidian.md)         | Obsidian knowledge base              | MD011, MD012, MD018, MD028, MD033, MD034, MD037, MD038, MD044, MD049, MD056, MD061, MD064, MD069 |
 | [pandoc](flavors/pandoc.md)             | Pandoc Markdown                      | MD022, MD029, MD031, MD032, MD034, MD037, MD040, MD042, MD051, MD052                      |
 | [quarto](flavors/quarto.md)             | Quarto / RMarkdown                   | MD022, MD029, MD031, MD032, MD034, MD037, MD038, MD040, MD042, MD049, MD050, MD051, MD052 |
 | [kramdown](flavors/kramdown.md)         | Jekyll / kramdown                    | MD022, MD041, MD051                                                                       |
@@ -63,7 +63,7 @@ The `standard` flavor includes CommonMark plus widely-adopted GFM extensions (ta
 - **[GFM](flavors/gfm.md)** - GitHub-specific features: security-sensitive HTML warnings, extended autolinks
 - **[MkDocs](flavors/mkdocs.md)** - Admonitions, content tabs, autorefs, mkdocstrings, extended syntax
 - **[MDX](flavors/mdx.md)** - JSX components, JSX attributes, expressions, ESM imports
-- **[Obsidian](flavors/obsidian.md)** - Callouts, comments, highlights, Dataview queries, Templater syntax, tags
+- **[Obsidian](flavors/obsidian.md)** - Callouts, comments, highlights, Dataview queries, Templater syntax, tags, wikilinks in tables
 - **[Pandoc](flavors/pandoc.md)** - Fenced divs, attribute lists, citations, footnotes, definition lists, math, raw format blocks, grid/multi-line tables, line blocks, sub/superscripts, example lists
 - **[Quarto](flavors/quarto.md)** - Citations, shortcodes, div blocks, math blocks, executable code
 - **[Kramdown](flavors/kramdown.md)** - IALs, ALDs, extension blocks, kramdown anchor generation

--- a/docs/flavors.md
+++ b/docs/flavors.md
@@ -10,7 +10,7 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 | [gfm](flavors/gfm.md)                   | GitHub Flavored Markdown             | MD033, MD034                                                                              |
 | [mkdocs](flavors/mkdocs.md)             | MkDocs / Material for MkDocs         | MD024, MD031, MD033, MD038, MD040, MD042, MD046, MD049, MD050, MD052, MD056               |
 | [mdx](flavors/mdx.md)                   | MDX (JSX in Markdown)                | MD013, MD033, MD037, MD039, MD044, MD049                                                  |
-| [obsidian](flavors/obsidian.md)         | Obsidian knowledge base              | MD011, MD012, MD018, MD028, MD033, MD034, MD037, MD038, MD044, MD049, MD056, MD061, MD064, MD069 |
+| [obsidian](flavors/obsidian.md)         | Obsidian knowledge base              | MD011, MD012, MD018, MD028, MD033, MD034, MD037, MD038, MD044, MD049, MD056, MD061, MD064, MD069, MD075 |
 | [pandoc](flavors/pandoc.md)             | Pandoc Markdown                      | MD022, MD029, MD031, MD032, MD034, MD037, MD040, MD042, MD051, MD052                      |
 | [quarto](flavors/quarto.md)             | Quarto / RMarkdown                   | MD022, MD029, MD031, MD032, MD034, MD037, MD038, MD040, MD042, MD049, MD050, MD051, MD052 |
 | [kramdown](flavors/kramdown.md)         | Jekyll / kramdown                    | MD022, MD041, MD051                                                                       |

--- a/docs/flavors.md
+++ b/docs/flavors.md
@@ -4,19 +4,19 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 
 ## Quick Reference
 
-| Flavor                                  | Use Case                             | Rules Affected                                                                            |
-| --------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------- |
-| [standard](flavors/standard.md)         | Default Markdown with GFM extensions | Baseline behavior                                                                         |
-| [gfm](flavors/gfm.md)                   | GitHub Flavored Markdown             | MD033, MD034                                                                              |
-| [mkdocs](flavors/mkdocs.md)             | MkDocs / Material for MkDocs         | MD024, MD031, MD033, MD038, MD040, MD042, MD046, MD049, MD050, MD052, MD056               |
-| [mdx](flavors/mdx.md)                   | MDX (JSX in Markdown)                | MD013, MD033, MD037, MD039, MD044, MD049                                                  |
+| Flavor                                  | Use Case                             | Rules Affected                                                                                          |
+| --------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| [standard](flavors/standard.md)         | Default Markdown with GFM extensions | Baseline behavior                                                                                       |
+| [gfm](flavors/gfm.md)                   | GitHub Flavored Markdown             | MD033, MD034                                                                                            |
+| [mkdocs](flavors/mkdocs.md)             | MkDocs / Material for MkDocs         | MD024, MD031, MD033, MD038, MD040, MD042, MD046, MD049, MD050, MD052, MD056                             |
+| [mdx](flavors/mdx.md)                   | MDX (JSX in Markdown)                | MD013, MD033, MD037, MD039, MD044, MD049                                                                |
 | [obsidian](flavors/obsidian.md)         | Obsidian knowledge base              | MD011, MD012, MD018, MD028, MD033, MD034, MD037, MD038, MD044, MD049, MD056, MD061, MD064, MD069, MD075 |
-| [pandoc](flavors/pandoc.md)             | Pandoc Markdown                      | MD022, MD029, MD031, MD032, MD034, MD037, MD040, MD042, MD051, MD052                      |
-| [quarto](flavors/quarto.md)             | Quarto / RMarkdown                   | MD022, MD029, MD031, MD032, MD034, MD037, MD038, MD040, MD042, MD049, MD050, MD051, MD052 |
-| [kramdown](flavors/kramdown.md)         | Jekyll / kramdown                    | MD022, MD041, MD051                                                                       |
-| [azure_devops](flavors/azure_devops.md) | Azure DevOps wikis                   | MD013, MD031, MD034, MD046, MD048                                                         |
-| [myst](flavors/myst.md)                 | MyST / Jupyter Book / Sphinx         | MD013, MD031, MD038, MD040, MD046, MD048                                                  |
-| [hugo](flavors/hugo.md)                 | Hugo / Goldmark                      | MD022, MD031, MD058                                                                       |
+| [pandoc](flavors/pandoc.md)             | Pandoc Markdown                      | MD022, MD029, MD031, MD032, MD034, MD037, MD040, MD042, MD051, MD052                                    |
+| [quarto](flavors/quarto.md)             | Quarto / RMarkdown                   | MD022, MD029, MD031, MD032, MD034, MD037, MD038, MD040, MD042, MD049, MD050, MD051, MD052               |
+| [kramdown](flavors/kramdown.md)         | Jekyll / kramdown                    | MD022, MD041, MD051                                                                                     |
+| [azure_devops](flavors/azure_devops.md) | Azure DevOps wikis                   | MD013, MD031, MD034, MD046, MD048                                                                       |
+| [myst](flavors/myst.md)                 | MyST / Jupyter Book / Sphinx         | MD013, MD031, MD038, MD040, MD046, MD048                                                                |
+| [hugo](flavors/hugo.md)                 | Hugo / Goldmark                      | MD022, MD031, MD058                                                                                     |
 
 ## Configuration
 

--- a/docs/flavors/obsidian.md
+++ b/docs/flavors/obsidian.md
@@ -68,6 +68,17 @@ MD037 and other emphasis-related rules recognize Obsidian highlight syntax:
 This is ==highlighted text== in a sentence.
 ```
 
+### Wikilinks in Tables
+
+Table rules treat the pipe in an aliased wikilink as part of the link rather than a
+cell delimiter, so a row like this one has two cells and not three:
+
+```markdown
+| Character | Note                        |
+| --------- | --------------------------- |
+| Alice     | [[White Rabbit|the Rabbit]] |
+```
+
 ### Dataview Inline Queries
 
 MD038 recognizes Dataview plugin inline query syntax:
@@ -133,6 +144,7 @@ MD033 correctly ignores Templater plugin syntax (not flagged as inline HTML):
 | MD061 | Check link fragments           | Skip content in `%%comments%%`                   |
 | MD064 | Check multiple consecutive spaces | Skip `%%comments%%`, allow extended checkboxes `[/]`, `[-]`, etc. |
 | MD069 | Check reference links          | Skip content in `%%comments%%`                   |
+| MD056 | Count `\|` as a cell delimiter  | Treat `[[Target\|Label]]` as one cell            |
 
 ## Configuration
 

--- a/docs/flavors/obsidian.md
+++ b/docs/flavors/obsidian.md
@@ -71,7 +71,8 @@ This is ==highlighted text== in a sentence.
 ### Wikilinks in Tables
 
 Table rules treat the pipe in an aliased wikilink as part of the link rather than a
-cell delimiter, so a row like this one has two cells and not three:
+cell delimiter, so a row like this one has two cells and not three, and a paragraph
+whose only pipes sit inside wikilinks is not mistaken for a row that lost its table:
 
 ```markdown
 | Character | Note                        |
@@ -145,6 +146,7 @@ MD033 correctly ignores Templater plugin syntax (not flagged as inline HTML):
 | MD064 | Check multiple consecutive spaces | Skip `%%comments%%`, allow extended checkboxes `[/]`, `[-]`, etc. |
 | MD069 | Check reference links          | Skip content in `%%comments%%`                   |
 | MD056 | Count `\|` as a cell delimiter  | Treat `[[Target\|Label]]` as one cell            |
+| MD075 | Pipe line after a table is a row | Wikilink-only pipes stay prose                   |
 
 ## Configuration
 

--- a/src/rules/md075_orphaned_table_rows.rs
+++ b/src/rules/md075_orphaned_table_rows.rs
@@ -66,9 +66,9 @@ impl MD075OrphanedTableRows {
     }
 
     /// Check if a line is a potential table row, handling blockquote prefixes
-    fn is_table_row_line(&self, line: &str) -> bool {
+    fn is_table_row_line(&self, line: &str, flavor: crate::config::MarkdownFlavor) -> bool {
         let content = strip_blockquote_prefix(line);
-        TableUtils::is_potential_table_row(content)
+        TableUtils::is_potential_table_row_with_flavor(content, flavor)
     }
 
     /// Check if a line is a delimiter row, handling blockquote prefixes
@@ -284,7 +284,7 @@ impl MD075OrphanedTableRows {
                 if table_line_set.contains(&j) {
                     break;
                 }
-                if self.is_table_row_line(content_lines[j])
+                if self.is_table_row_line(content_lines[j], ctx.flavor)
                     && self.row_matches_table_context(table_block, content_lines, j)
                 {
                     orphan_rows.push(j);
@@ -327,7 +327,7 @@ impl MD075OrphanedTableRows {
                 if self.should_skip_line(ctx, i) || table_line_set.contains(&i) {
                     break;
                 }
-                if self.is_table_row_line(content_lines[i])
+                if self.is_table_row_line(content_lines[i], ctx.flavor)
                     && self.row_matches_table_context(table_block, content_lines, i)
                 {
                     continuation_rows.insert(i);
@@ -369,7 +369,7 @@ impl MD075OrphanedTableRows {
             }
 
             // Look for consecutive pipe rows
-            if self.is_table_row_line(content_lines[i]) {
+            if self.is_table_row_line(content_lines[i], ctx.flavor) {
                 if Self::is_templated_pipe_line(content_lines[i]) {
                     i += 1;
                     continue;
@@ -383,7 +383,7 @@ impl MD075OrphanedTableRows {
                         && !table_line_set.contains(&i)
                         && !orphaned_line_set.contains(&i)
                         && !continuation_line_set.contains(&i)
-                        && self.is_table_row_line(content_lines[i])
+                        && self.is_table_row_line(content_lines[i], ctx.flavor)
                     {
                         i += 1;
                     }
@@ -399,7 +399,7 @@ impl MD075OrphanedTableRows {
                         && !table_line_set.contains(&i)
                         && !orphaned_line_set.contains(&i)
                         && !continuation_line_set.contains(&i)
-                        && self.is_table_row_line(content_lines[i])
+                        && self.is_table_row_line(content_lines[i], ctx.flavor)
                     {
                         i += 1;
                     }
@@ -415,7 +415,7 @@ impl MD075OrphanedTableRows {
                     && !table_line_set.contains(&i)
                     && !orphaned_line_set.contains(&i)
                     && !continuation_line_set.contains(&i)
-                    && self.is_table_row_line(content_lines[i])
+                    && self.is_table_row_line(content_lines[i], ctx.flavor)
                 {
                     if Self::is_templated_pipe_line(content_lines[i]) {
                         break;
@@ -493,7 +493,7 @@ impl MD075OrphanedTableRows {
                 continue;
             }
 
-            if self.is_table_row_line(content) {
+            if self.is_table_row_line(content, ctx.flavor) {
                 let cols = TableUtils::count_cells_with_flavor(content, ctx.flavor);
                 // Require 3+ columns to avoid suppressing common 2-column headerless issues.
                 if cols < 3 {
@@ -2044,6 +2044,51 @@ Cell 1     Cell 2
         assert!(
             result_std.is_empty(),
             "MD075 table with caption — caption not a pipe row under Standard: {result_std:?}"
+        );
+    }
+
+    #[test]
+    fn md075_obsidian_wikilink_paragraph_not_orphaned_row() {
+        let rule = MD075OrphanedTableRows::default();
+        // The paragraph's only pipe sits inside a wikilink alias, so it is prose
+        // rather than a row that lost its table
+        let content = "\
+| Character | Note     |
+| --------- | -------- |
+| Alice     | curious  |
+
+She saw [[White Rabbit|the Rabbit]] run past and went down the hole.
+";
+        let ctx = LintContext::new(content, MarkdownFlavor::Obsidian, None);
+        let result = rule.check(&ctx).unwrap();
+        assert!(
+            result.is_empty(),
+            "MD075 should not treat a wikilink paragraph as an orphaned row: {result:?}"
+        );
+
+        // Under Standard the pipe is a delimiter, so the paragraph still reads as a row
+        let ctx_std = LintContext::new(content, MarkdownFlavor::Standard, None);
+        assert!(
+            !rule.check(&ctx_std).unwrap().is_empty(),
+            "MD075 should still flag the row under Standard"
+        );
+    }
+
+    #[test]
+    fn md075_obsidian_genuine_orphaned_row_still_flagged() {
+        let rule = MD075OrphanedTableRows::default();
+        // A real orphaned row is still reported under Obsidian
+        let content = "\
+| Character | Note     |
+| --------- | -------- |
+| Alice     | curious  |
+
+| Hatter    | mad      |
+";
+        let ctx = LintContext::new(content, MarkdownFlavor::Obsidian, None);
+        assert!(
+            !rule.check(&ctx).unwrap().is_empty(),
+            "MD075 should still flag a genuine orphaned row under Obsidian"
         );
     }
 }

--- a/src/utils/table_utils.rs
+++ b/src/utils/table_utils.rs
@@ -113,6 +113,17 @@ impl TableUtils {
     }
 
     /// Check if a line looks like a potential table row
+    /// Flavor-aware form of [`Self::is_potential_table_row`]
+    ///
+    /// Under Obsidian, a line whose only pipes sit inside wikilink aliases is
+    /// prose rather than a table row, so those pipes are masked before the check.
+    pub fn is_potential_table_row_with_flavor(line: &str, flavor: crate::config::MarkdownFlavor) -> bool {
+        if flavor == crate::config::MarkdownFlavor::Obsidian {
+            return Self::is_potential_table_row(&Self::mask_pipes_in_wikilinks(line));
+        }
+        Self::is_potential_table_row(line)
+    }
+
     pub fn is_potential_table_row(line: &str) -> bool {
         let trimmed = line.trim();
         if trimmed.is_empty() || !trimmed.contains('|') {

--- a/src/utils/table_utils.rs
+++ b/src/utils/table_utils.rs
@@ -642,6 +642,55 @@ impl TableUtils {
         result
     }
 
+    /// Mask pipes inside wikilink aliases for accurate table cell parsing
+    ///
+    /// In Obsidian, `[[Target|Label]]` renders `Label` as a link to `Target`, so
+    /// the pipe separates the two halves of one link rather than two table cells.
+    /// Only a pipe between `[[` and a closing `]]` on the same line is masked.
+    pub fn mask_pipes_in_wikilinks(text: &str) -> String {
+        let chars: Vec<char> = text.chars().collect();
+        let mut result = String::new();
+        let mut i = 0;
+
+        while i < chars.len() {
+            if chars[i] == '[' && i + 1 < chars.len() && chars[i + 1] == '[' {
+                // Look for the closing "]]" that ends this wikilink
+                let mut j = i + 2;
+                let mut close = None;
+                while j + 1 < chars.len() {
+                    if chars[j] == ']' && chars[j + 1] == ']' {
+                        close = Some(j);
+                        break;
+                    }
+                    // A wikilink does not span a nested "[["
+                    if chars[j] == '[' && chars[j + 1] == '[' {
+                        break;
+                    }
+                    j += 1;
+                }
+
+                if let Some(close) = close {
+                    result.push_str("[[");
+                    for &ch in chars.iter().take(close).skip(i + 2) {
+                        if ch == '|' {
+                            result.push('_'); // Mask pipe with underscore
+                        } else {
+                            result.push(ch);
+                        }
+                    }
+                    result.push_str("]]");
+                    i = close + 2;
+                    continue;
+                }
+            }
+
+            result.push(chars[i]);
+            i += 1;
+        }
+
+        result
+    }
+
     /// Mask escaped pipes for accurate table cell parsing
     ///
     /// In GFM tables, escape handling happens BEFORE cell boundary detection:
@@ -688,7 +737,7 @@ impl TableUtils {
     /// This is the foundation for both cell counting and cell content extraction.
     ///
     /// Pipes inside code spans are treated as content, not cell delimiters.
-    pub fn split_table_row_with_flavor(row: &str, _flavor: crate::config::MarkdownFlavor) -> Vec<String> {
+    pub fn split_table_row_with_flavor(row: &str, flavor: crate::config::MarkdownFlavor) -> Vec<String> {
         let trimmed = row.trim();
 
         if !trimmed.contains('|') {
@@ -699,7 +748,13 @@ impl TableUtils {
         let masked = Self::mask_pipes_for_table_parsing(trimmed);
 
         // Mask pipes inside inline code for all flavors
-        let final_masked = Self::mask_pipes_in_inline_code(&masked);
+        let mut final_masked = Self::mask_pipes_in_inline_code(&masked);
+
+        // In Obsidian, a pipe inside [[Target|Label]] separates the link from its
+        // alias rather than one cell from the next
+        if flavor == crate::config::MarkdownFlavor::Obsidian {
+            final_masked = Self::mask_pipes_in_wikilinks(&final_masked);
+        }
 
         let has_leading = final_masked.starts_with('|');
         let has_trailing = final_masked.ends_with('|');
@@ -1478,6 +1533,80 @@ But no delimiter row
             cells[1].contains("`x | y`"),
             "Inline code with pipe should be single cell"
         );
+    }
+
+    #[test]
+    fn test_split_table_row_with_flavor_obsidian_wikilink() {
+        // Obsidian flavor: the pipe in [[Target|Label]] separates a link from its
+        // alias, not one cell from the next
+        let cells = TableUtils::split_table_row_with_flavor(
+            "| Alice | [[White Rabbit|the Rabbit]] |",
+            crate::config::MarkdownFlavor::Obsidian,
+        );
+        assert_eq!(cells.len(), 2, "Aliased wikilink should be one cell, got {cells:?}");
+        assert!(cells[1].contains("[[White Rabbit|the Rabbit]]"));
+
+        // Two aliased wikilinks in one cell
+        let cells = TableUtils::split_table_row_with_flavor(
+            "| Guests | [[Mad Hatter|the Hatter]] and [[March Hare|the Hare]] |",
+            crate::config::MarkdownFlavor::Obsidian,
+        );
+        assert_eq!(
+            cells.len(),
+            2,
+            "Two aliased wikilinks should be one cell, got {cells:?}"
+        );
+
+        // A plain wikilink has no pipe to mask
+        let cells = TableUtils::split_table_row_with_flavor(
+            "| Alice | [[Cheshire Cat]] |",
+            crate::config::MarkdownFlavor::Obsidian,
+        );
+        assert_eq!(cells.len(), 2);
+
+        // An unterminated wikilink must not swallow the rest of the row
+        let cells = TableUtils::split_table_row_with_flavor(
+            "| Alice | [[White Rabbit | curious |",
+            crate::config::MarkdownFlavor::Obsidian,
+        );
+        assert_eq!(
+            cells.len(),
+            3,
+            "Unterminated wikilink should not mask pipes, got {cells:?}"
+        );
+    }
+
+    #[test]
+    fn test_split_table_row_wikilink_only_for_obsidian() {
+        // Other flavors keep GFM behaviour: an unescaped pipe is a cell delimiter
+        for flavor in [
+            crate::config::MarkdownFlavor::Standard,
+            crate::config::MarkdownFlavor::MkDocs,
+        ] {
+            let cells = TableUtils::split_table_row_with_flavor("| Alice | [[White Rabbit|the Rabbit]] |", flavor);
+            assert_eq!(
+                cells.len(),
+                3,
+                "{flavor:?} should treat the wikilink pipe as a delimiter, got {cells:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mask_pipes_in_wikilinks_preserves_length() {
+        // Masking must not change length, or cell offsets drift
+        for text in [
+            "| Alice | [[White Rabbit|the Rabbit]] |",
+            "| [[Mad Hatter|Hatter]] | [[March Hare|Hare]] |",
+            "no wikilink here | just a pipe",
+            "[[unterminated | still text",
+        ] {
+            assert_eq!(
+                TableUtils::mask_pipes_in_wikilinks(text).len(),
+                text.len(),
+                "masking changed length of {text:?}"
+            );
+        }
     }
 
     // === extract_blockquote_prefix tests ===


### PR DESCRIPTION
## Summary

- prevent MD075 from treating a prose paragraph containing an Obsidian aliased wikilink as an orphaned table row
- treat an aliased wikilink as one table cell for MD056 in the Obsidian flavour
- document the supported Obsidian table behaviour

The changes are scoped to the Obsidian flavour. Genuine orphaned table rows remain detectable, and other flavours retain GFM behaviour.

Fixes #804