### PR TITLE
docs(nav): add Code Block Tools page to navigation

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -34,6 +34,7 @@ nav = [
     { "Global Settings" = "global-settings.md" },
     { "Inline Configuration" = "inline-configuration.md" },
     { "Markdown Flavors" = "flavors.md" },
+    { "Code Block Tools" = "code-block-tools.md"},
   ]},
   { "Rules" = "rules.md" },
   { "Playground" = "playground.md" },


### PR DESCRIPTION
To help with discoverability of the Code Block Tools feature (https://github.com/rvben/rumdl/blob/4997ff07b63c7a54d6a495ebcd3ce7f23ee1173f/docs/code-block-tools.md), let's add it to the website navigation.