### PR TITLE
fix(links): read backslash escapes in a reference definition label

### DIFF
--- a/src/lint_context/link_parser.rs
+++ b/src/lint_context/link_parser.rs
@@ -69,6 +69,13 @@ fn extend_collapsed_byte_end(content: &str, link_type: LinkType, byte_end: usize
 // Mirrors the CommonMark §4.7 grammar closely enough for downstream consumers
 // (MD053, MD057, the MD054 round-trip pass) to see every valid ref def:
 //
+// - **Label** (group 1) ends at the first `]` that is not backslash-escaped
+//   (§6.3), so it permits `\]` — without that, `[ref\[\]]: url` is not read as
+//   a definition at all and its destination is left looking like a bare URL.
+//   `\` is excluded from the negated class so it has exactly one reading.
+//   §6.3 also forbids an *unescaped* `[` inside a label; that is still
+//   accepted here, as it was before.
+//
 // - **Destination** has two §6.6 forms: a bare sequence containing no spaces
 //   (group 3), or an angle-bracketed sequence that may contain spaces but no
 //   line endings or unescaped `<`/`>` (group 2). Without the angle form,
@@ -89,7 +96,7 @@ fn extend_collapsed_byte_end(content: &str, link_type: LinkType, byte_end: usize
 // out of `ctx.reference_defs` and breaking MD053/MD057 follow-ups.
 static REF_DEF_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r#"(?m)^[ ]{0,3}\[([^\]]+)\]:\s*(?:<((?:[^<>\n\\]|\\.)*)>|([^\s<][^\s]*))(?:\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|\(((?:[^()\\]|\\.)*)\)))?$"#,
+        r#"(?m)^[ ]{0,3}\[((?:[^\]\\]|\\.)+)\]:\s*(?:<((?:[^<>\n\\]|\\.)*)>|([^\s<][^\s]*))(?:\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|\(((?:[^()\\]|\\.)*)\)))?$"#,
     )
     .unwrap()
 });

--- a/tests/regressions/md034_ref_def_escaped_label_issue_814_test.rs
+++ b/tests/regressions/md034_ref_def_escaped_label_issue_814_test.rs
@@ -1,0 +1,96 @@
+//! Tests for reference definitions whose link label contains an escaped
+//! closing bracket (Issue #814)
+//!
+//! CommonMark §6.3: a link label ends at the first `]` that is **not**
+//! backslash-escaped. `[ref\[\]]: url` is therefore a reference definition
+//! with the label `ref\[\]`, but the label group of `REF_DEF_PATTERN` did not
+//! read escapes, so the line was not recognised as a definition at all and
+//! MD034 saw its destination as a bare URL.
+
+use rumdl_lib::config::MarkdownFlavor;
+use rumdl_lib::lint_context::LintContext;
+use rumdl_lib::rule::Rule;
+use rumdl_lib::rules::{MD034NoBareUrls, MD053LinkImageReferenceDefinitions};
+
+/// The reporter's document: only the escaped-closing-bracket label misbehaves,
+/// so the three definitions must agree with each other.
+#[test]
+fn test_md034_not_flagged_for_escaped_bracket_label() {
+    let content = "# Reference Example\n\n\
+                   * [this is a link to example.com][ref1\\[\\]]\n\
+                   * [this is also a link to example.com][ref2\\[]\n\
+                   * [this is also a link to example.com][ref3]\n\n\
+                   [ref1\\[\\]]: https://example.com/ref1\n\
+                   [ref2\\[]: https://example.com/ref2\n\
+                   [ref3]: https://example.com/ref3\n";
+    let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+
+    let warnings = MD034NoBareUrls.check(&ctx).unwrap();
+
+    assert!(
+        warnings.is_empty(),
+        "A reference definition destination is not a bare URL: {:?}",
+        warnings.iter().map(|w| (w.line, &w.message)).collect::<Vec<_>>()
+    );
+}
+
+/// The parse itself, not just MD034's view of it: an escaped `]` must not end
+/// the label, so all three definitions reach `ctx.reference_definitions()`.
+/// Every rule that reads reference definitions (MD052/MD053/MD057) depends on
+/// this, so assert the parse directly rather than only its MD034 symptom.
+#[test]
+fn test_escaped_bracket_label_parsed_as_reference_def() {
+    let content = "[ref1\\[\\]]: https://example.com/ref1\n\
+                   [ref2\\[]: https://example.com/ref2\n\
+                   [ref3]: https://example.com/ref3\n";
+    let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+
+    let ids: Vec<&str> = ctx.reference_definitions().iter().map(|d| d.id.as_str()).collect();
+
+    assert_eq!(ids, vec!["ref1\\[\\]", "ref2\\[", "ref3"]);
+}
+
+/// The same rule seen from the other side, and the one line whose behavior this
+/// change reverses: an escaped `]` does not close the label, so `[ref\]:` never
+/// closes one and the line is a paragraph rather than a definition — which
+/// leaves its destination a genuinely bare URL for MD034 to report.
+///
+/// Both halves are asserted together because they are one fact. This is also
+/// the input that separates the label pattern from a looser `(?:[^\]]|\\.)+`,
+/// which fixes the reported bug just as well but lets a `\` be read as either a
+/// literal or an escape, whichever makes the line match.
+#[test]
+fn test_label_left_open_by_escaped_bracket_is_not_a_reference_def() {
+    let content = "[ref\\]: https://example.com/ref\n";
+    let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+
+    assert!(
+        ctx.reference_definitions().is_empty(),
+        "`[ref\\]:` leaves the label unclosed, so it is not a reference definition: {:?}",
+        ctx.reference_definitions()
+    );
+    assert_eq!(
+        MD034NoBareUrls.check(&ctx).unwrap().len(),
+        1,
+        "and so its destination is a bare URL"
+    );
+}
+
+/// The fix's real blast radius: definitions that were invisible now reach every
+/// rule reading `ctx`, MD053 ("unused reference") among them. A *used* escaped
+/// label must not be reported as unused — which holds only because MD053
+/// unescapes the definition side and the usage side alike. Assert it rather
+/// than rely on the two staying in step.
+#[test]
+fn test_used_escaped_bracket_label_is_not_reported_unused() {
+    let content = "[a][used\\[\\]]\n\n[used\\[\\]]: https://example.com/u\n";
+    let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+
+    let warnings = MD053LinkImageReferenceDefinitions::default().check(&ctx).unwrap();
+
+    assert!(
+        warnings.is_empty(),
+        "the definition is used, so it is not unused: {:?}",
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>()
+    );
+}

--- a/tests/regressions/mod.rs
+++ b/tests/regressions/mod.rs
@@ -28,6 +28,7 @@ mod md032_ordered_list_bug_test;
 mod md033_edge_cases_test;
 mod md033_link_img_fix_test;
 mod md034_parentheses_url_test;
+mod md034_ref_def_escaped_label_issue_814_test;
 mod md037_multiline_span_false_positive_test;
 mod md037_xxxx_regression_test;
 mod md038_false_positive_test;


### PR DESCRIPTION
## Description

Fixes #814.

`REF_DEF_PATTERN` reads a reference definition's label as `[^\]]+`, which stops at the first `]` on the line whether or not it is escaped. CommonMark §6.3 ends a label at the first `]` that is **not** backslash-escaped, so `[ref1\[\]]: https://example.com/ref1` has the label `ref1\[\]` — but the regex commits to the `\]` as the terminator, then finds `]` where it needs `:`, and the line matches nothing at all. It is not a reference definition as far as `ctx.reference_defs` is concerned, so MD034 reads the rest of the line as ordinary paragraph text and reports its destination as a bare URL:

```
test.md:7:13: [MD034] URL without angle brackets or link formatting: 'https://example.com/ref1' [*]
```

The reporter's `[ref2\[]` case works today only because an escaped `[` needs no escape handling to get past — that label still ends at a real `]`. That the two forms of the same construct disagree is what makes this read as an oversight rather than a decision.

The label group now takes the escape alternation the destination and title groups have carried all along:

```
[^\]]+   ->   (?:[^\]\\]|\\.)+
```

The comment above the regex already documents why the angle-bracket destination and all three title forms accept `\<delim>`; the label now has its entry there too.

## Scope of the behavior change

Only lines whose label contains a backslash are affected, in two directions, both toward the spec:

- `[ref1\[\]]: url` is now a definition. That is the fix.
- `[ref\]: url` is no longer one. The `\]` is escaped, so the label never closes and the line is a paragraph — which means MD034 will now flag a bare URL there. It previously parsed as a definition with the label `ref\`. This is not separable from reading escapes at all: the rule that lets `\]` sit inside a label is the same rule that stops it from ending one.

Both were checked against a reference CommonMark implementation (markdown-it in `commonmark` mode) rather than against my reading of the spec: the first renders `[x][ref1\[\]]` as a resolved link, the second renders as a `<p>`.

`\` is ASCII punctuation, so `\\` is consumed as one escaped backslash and the alternation cannot be left mid-escape. A label ending on a lone `\` no longer matches, since `\\.` has nothing to consume — the paragraph reading again.

Deliberately not widened further, but there is something you should know, because this commit is what makes it reachable. There are three ref-def label patterns in the tree:

- `src/lint_context/link_parser.rs` — `(?:[^\]\\]|\\.)+` (this change)
- `src/rules/md052_reference_links_images.rs:18` — `(?:[^\[\]\\]|\\.|\[[^\]]*\])*`, escape-aware but a different shape
- `src/rules/md053_link_image_reference_definitions.rs:16` — `^\s*\[([^\]]+)\]:\s+(.+)$`, the exact pre-fix shape

MD053 reads escaped-label definitions from `ctx` but cannot match the same line with its own regex, so its multi-line-title continuation tracking (`:268`) skips them and its case-variant duplicate detection (`:514`) does too. Neither produces a wrong warning today — `fix_capability()` is `Unfixable` and `fix()` is a no-op — but if MD053 ever gains a real fix, the first one would delete such a definition and strand its title line as a paragraph. I left it alone: it is a separate, narrower bug that wants its own change. Say the word and I will file it, or take it in a follow-up.

The regression test covers the direction that *is* this PR's risk — a newly-visible definition being reported unused by MD053 — which holds because MD053 unescapes the definition and usage sides alike.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added — `tests/regressions/md034_ref_def_escaped_label_issue_814_test.rs`, four cases: the reporter's document produces no MD034 warning; all three of its definitions reach `ctx.reference_definitions()` with their labels intact; `[ref\]:` is left a non-definition *and* its URL is reported bare, pinning the reversed direction; and a used escaped label is not reported unused by MD053. The first three fail on `main`; the fourth passes there and is a guard on this change's blast radius rather than a test of the bug.
- [x] All tests passing — full `cargo test` (`cargo nextest` was not available here; `make test-legacy` runs the same targets). The only failures are wall-clock assertions that trip on an unoptimized build — around ten of them, every one matching the `default-filter` your `ci` nextest profile already excludes as "flaky due to resource variability". The set is not even stable between two runs of the same tree (`md050` in one, `md051` in the next), and it fails the same way on a clean checkout with my commit stashed, which is the signature of timing noise rather than of this change. No correctness test fails.
- [x] Manual testing performed — the reporter's exact `test.md` and CLI invocation, failing before and clean after.

## Checklist

- [x] Code follows project style — `cargo fmt --check` clean; `cargo clippy --workspace --lib --bins --tests -- -D warnings -D clippy::uninlined_format_args` clean. The `lint-actions` half of `make lint` was not run, as no workflow files are touched.
- [x] Conventional commit messages used
- [x] Documentation updated (if needed) — none needed. MD034's documented behavior is unchanged; the parser it reads was wrong.

---
Used AI assistance on this; I reviewed and tested the change myself.