### PR TITLE
docs: config.rs became a module directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1357,7 +1357,7 @@ make test
 
 ### JSON Schema Generation
 
-If you modify the configuration structures in `src/config.rs`, regenerate the JSON schema:
+If you modify the configuration structures in `src/config/`, regenerate the JSON schema:
 
 ```bash
 # Generate/update the schema


### PR DESCRIPTION
The JSON Schema Generation section tells a contributor to regenerate the schema after modifying `src/config.rs`. That file was extracted into a module directory in `3cb9af37` ("refactor(config): extract into module directory with 8 submodules", 2026-02-06), and `src/config.rs` no longer exists on `main`.

Changed to `src/config/`, since the instruction is about the configuration structures rather than about one file, and they are now spread across the submodules.
