### PR TITLE
feat(flavor): add support for Markdown with Gherkin (MDG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 | [kramdown](docs/flavors/kramdown.md)         | Jekyll / kramdown            | IALs, ALDs, extension blocks                        |
 | [azure_devops](docs/flavors/azure_devops.md) | Azure DevOps Wiki            | Colon code fences (:::lang ... :::)                 |
 | [myst](docs/flavors/myst.md)                 | MyST / Jupyter Book / Sphinx | Directives, roles, `%` comments                     |
+| [mdg](docs/flavors/mdg.md)                   | Markdown with Gherkin        | Gherkin-safe headings, tags, Doc Strings, tables    |
 
 ### Configuring Flavors
 
@@ -628,7 +629,8 @@ Or configure per-file patterns:
 "**/*.qmd" = "quarto"
 ```
 
-When no flavor is configured, rumdl auto-detects based on file extension (`.mdx` → mdx, `.qmd`/`.Rmd` → quarto, `.md` → standard).
+When no flavor is configured, rumdl auto-detects from the file name: `.mdx` → mdx, `.qmd`/`.Rmd` → quarto, `.md` → standard.
+A name ending in `.feature.md` matches that compound suffix before the plain `.md` rule, so those files are linted as mdg.
 
 For complete flavor documentation, see the [Flavors Guide](docs/flavors.md).
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -54,17 +54,18 @@ Most tools treat Markdown as a single dialect and rely on configuration or plugi
 
 **rumdl** has built-in flavor support that adjusts rule behavior for specific documentation systems:
 
-| Flavor       | Target system       | Example adjustments                                                          |
-| ------------ | ------------------- | ---------------------------------------------------------------------------- |
-| standard     | CommonMark + GFM    | Baseline behavior (GFM extensions included by default)                       |
-| mkdocs       | MkDocs / Material   | Admonitions, tabs, mkdocstrings                                              |
-| mdx          | MDX                 | JSX components, ESM imports                                                  |
-| obsidian     | Obsidian            | Callouts, wikilinks, Dataview                                                |
-| pandoc       | Pandoc Markdown     | Fenced divs, attribute lists, citations, definition lists, math, grid tables |
-| quarto       | Quarto / RMarkdown  | Citations, shortcodes, executable blocks                                     |
-| kramdown     | Jekyll / kramdown   | Attribute lists, TOC markers                                                 |
-| azure_devops | Azure DevOps wikis  | Colon code fences (`:::mermaid … :::`) treated as opaque code blocks         |
-| myst         | MyST / Jupyter Book | Directives (`:::{name}`), roles (`` {role}`text` ``), `%` comments           |
+| Flavor       | Target system         | Example adjustments                                                          |
+| ------------ | --------------------- | ---------------------------------------------------------------------------- |
+| standard     | CommonMark + GFM      | Baseline behavior (GFM extensions included by default)                       |
+| mkdocs       | MkDocs / Material     | Admonitions, tabs, mkdocstrings                                              |
+| mdx          | MDX                   | JSX components, ESM imports                                                  |
+| obsidian     | Obsidian              | Callouts, wikilinks, Dataview                                                |
+| pandoc       | Pandoc Markdown       | Fenced divs, attribute lists, citations, definition lists, math, grid tables |
+| quarto       | Quarto / RMarkdown    | Citations, shortcodes, executable blocks                                     |
+| kramdown     | Jekyll / kramdown     | Attribute lists, TOC markers                                                 |
+| azure_devops | Azure DevOps wikis    | Colon code fences (`:::mermaid … :::`) treated as opaque code blocks         |
+| myst         | MyST / Jupyter Book   | Directives (`:::{name}`), roles (`` {role}`text` ``), `%` comments           |
+| mdg          | Markdown with Gherkin | Gherkin-safe headings, tag lines, Doc String fences, indented tables         |
 
 Note: `gfm`, `github`, and `commonmark` are accepted as aliases for `standard` since the parser includes GFM extensions by default.
 

--- a/docs/flavors.md
+++ b/docs/flavors.md
@@ -21,6 +21,7 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 | [azure_devops](flavors/azure_devops.md) | Azure DevOps wikis                   | MD013, MD031, MD034, MD046, MD048                                                                       |
 | [myst](flavors/myst.md)                 | MyST / Jupyter Book / Sphinx         | MD013, MD031, MD038, MD040, MD046, MD048                                                                |
 | [hugo](flavors/hugo.md)                 | Hugo / Goldmark                      | MD022, MD031, MD058                                                                                     |
+| [mdg](flavors/mdg.md)                   | Markdown with Gherkin                | MD003, MD013, MD022, MD026, MD034, MD046, MD048, MD055, MD060, MD063                                    |
 
 ## Configuration
 
@@ -46,14 +47,19 @@ Override flavor for specific file patterns:
 
 ### Auto-Detection
 
-When no flavor is configured, rumdl auto-detects based on file extension:
+When no flavor is configured, rumdl auto-detects from the file name:
 
-| Extension          | Detected Flavor |
+| File name          | Detected Flavor |
 | ------------------ | --------------- |
+| `.feature.md`      | `mdg`           |
 | `.mdx`             | `mdx`           |
 | `.qmd`, `.Rmd`     | `quarto`        |
 | `.kramdown`        | `kramdown`      |
 | `.md`, `.markdown` | `standard`      |
+
+`.feature.md` is a compound suffix rather than an extension: it is matched case-insensitively against the whole file name, ahead of the plain `.md` row. `.feature.markdown` is not matched.
+
+A `per-file-flavor` pattern, or an explicit non-standard `[global] flavor`, still wins over any auto-detected flavor.
 
 ## Specification Versions
 
@@ -74,6 +80,7 @@ The `standard` flavor includes CommonMark plus widely-adopted GFM extensions (ta
 - **[Azure DevOps](flavors/azure_devops.md)** - Colon code fences (`:::mermaid … :::`) treated as opaque code blocks
 - **[MyST](flavors/myst.md)** - Directives (`:::{name}`, `` ```{name} ``), roles (`{role}`content``), `%` comments
 - **[Hugo](flavors/hugo.md)** - Goldmark Markdown attributes (`{class="a" id="b"}`) attached to tables, headings, and code blocks
+- **[Markdown with Gherkin](flavors/mdg.md)** - Structure headings, tag lines, Doc String fences, and indented Gherkin tables kept in the form Gherkin accepts
 
 ## Adding Flavor Support
 

--- a/docs/flavors.md
+++ b/docs/flavors.md
@@ -21,7 +21,7 @@ rumdl supports multiple Markdown flavors to accommodate different documentation 
 | [azure_devops](flavors/azure_devops.md) | Azure DevOps wikis                   | MD013, MD031, MD034, MD046, MD048                                                                       |
 | [myst](flavors/myst.md)                 | MyST / Jupyter Book / Sphinx         | MD013, MD031, MD038, MD040, MD046, MD048                                                                |
 | [hugo](flavors/hugo.md)                 | Hugo / Goldmark                      | MD022, MD031, MD058                                                                                     |
-| [mdg](flavors/mdg.md)                   | Markdown with Gherkin                | MD003, MD013, MD022, MD026, MD034, MD046, MD048, MD055, MD060, MD063                                    |
+| [mdg](flavors/mdg.md)                   | Markdown with Gherkin                | MD003, MD013, MD022, MD026, MD034, MD040, MD046, MD048, MD055, MD060, MD063                             |
 
 ## Configuration
 

--- a/docs/flavors/mdg.md
+++ b/docs/flavors/mdg.md
@@ -40,18 +40,22 @@ the name — `## Scenario: ratio: two to one` splits after `Scenario:` only.
 
 ### Tag Line
 
-A line holding nothing but backtick-wrapped tags:
+A line containing at least one backtick-wrapped tag:
 
 ```markdown
 `@billing` `@critical`
 ## Scenario: Reject an expired card
 ```
 
-Each token must open with `@`, be longer than that `@` alone, and contain no
-whitespace. Leading and trailing whitespace on the line is ignored, and tags may
-be written with or without a space between them. Anything else on the line —
-prose, or a trailing `#` comment, which MDG has no syntax for — means the line
-is not a tag line.
+The recognition follows Cucumber's `` `(@[^`]+)` `` pattern: the text inside a
+matching code span starts with `@`, has at least one further character, and may
+contain whitespace. The match may occur anywhere on the line, so adjacent tags,
+surrounding text, and a trailing `#` comment do not prevent recognition:
+
+```markdown
+`@comment_tag1` #a comment
+prefix `@tag with spaces` suffix
+```
 
 ### Table Row
 
@@ -164,9 +168,12 @@ form happens to be more prevalent in the document.
 Closing an unclosed fence is a repair rather than a style conversion, so it
 still happens under this flavor whatever `style` is configured.
 
-An info string on the fence becomes the Doc String's media type rather than
-dissolving the Doc String, so labelling a fence does not disturb the Gherkin
-structure and MD040 applies normally.
+An info string on the fence becomes the Doc String's media type. MD040 reports
+missing and inconsistent labels, but offers no fix under this flavor: adding
+the standard `text` fallback would change the parsed media type from absent to
+`text`, while normalizing an existing label would replace an explicitly chosen
+media type. Both are observable by step definitions. Add the intended media
+type manually, or disable MD040 when unlabelled Doc Strings are intentional.
 
 ### Data and Examples Tables
 
@@ -198,9 +205,10 @@ a Scenario Outline it is substituted from the `Examples` column of that name,
 so wrapping a bare URL in angle brackets can replace the surrounding text with
 whatever that column holds.
 
-MD034 is therefore disabled entirely for this flavor. The angle-bracket form
-carries Gherkin meaning wherever it lands, so the rule is not applied to prose
-either.
+MD034 still reports bare URLs and email addresses under this flavor, but offers
+no fix. The standard angle-bracket correction carries Gherkin meaning wherever
+it lands. Whether to use an explicit Markdown link or disable MD034 depends on
+the surrounding prose or step text, so rumdl leaves that choice to the user.
 
 ## Rule Behavior Changes
 
@@ -220,7 +228,8 @@ Rules whose correction is adjusted so it cannot break the Gherkin syntax:
 | MD013 | Reflow long prose when `reflow` is on    | Report an over-long unordered list item without offering a fix |
 | MD022 | Require blank lines around headings      | Keep a tag line against the structure heading below it         |
 | MD026 | Remove configured trailing punctuation   | Drop the ASCII colon from the `punctuation` set                |
-| MD034 | Wrap a bare URL in angle brackets        | Disabled — `<…>` is Gherkin placeholder syntax                 |
+| MD034 | Wrap a bare URL in angle brackets        | Report without a fix; `<…>` is Gherkin placeholder syntax      |
+| MD040 | Add `text` to an unlabelled fence        | Report without a fix; label is a Doc String media type         |
 | MD046 | Treat an indented block as code          | Exclude a run made entirely of table rows                      |
 | MD060 | Format table delimiters and cell spacing | Indent a Gherkin table to `max(2, list item content indent)`   |
 | MD063 | Recase the whole heading                 | Recase only the part after the keyword's colon                 |
@@ -232,17 +241,15 @@ while staying valid Gherkin:
 | ----- | ------------------------------------------------------------------------- |
 | MD024 | Every keyword accepts a name, so duplicate headings are always avoidable  |
 | MD025 | Heading levels carry no meaning in the Gherkin syntax tree                |
-| MD040 | A language label becomes the Doc String's media type                      |
 | MD041 | `# Feature: X` is always writable, and the fix relevels in place          |
 
 All other enabled rules lint the Markdown normally.
 
 ## Configuration Overrides
 
-Four rules enforce a form this flavor requires over a configured value that
+Five rules enforce a form this flavor requires over a configured value that
 cannot express it. When the value was set explicitly — a defaulted value is
-never reported — and the rule reaches relevant content, rumdl prints one line
-on stderr:
+never reported — and the override applies, rumdl prints one line on stderr:
 
 ```text
 [config warning] MD046: Markdown with Gherkin flavor requires style="fenced" (a Gherkin Doc String is only ever a backtick fence). Overriding style="indented" to style="fenced".
@@ -250,13 +257,20 @@ on stderr:
 
 | Rule  | Overridden value                                                          | Enforced value                   |
 | ----- | ------------------------------------------------------------------------- | -------------------------------- |
+| MD003 | any fixed `style` other than `"atx"`                                      | `style = "atx"`                  |
 | MD026 | a `punctuation` set holding the ASCII colon                               | the same set without it          |
 | MD046 | `style = "indented"`                                                      | `style = "fenced"`               |
 | MD048 | `style = "tilde"`                                                         | `style = "backtick"`             |
 | MD055 | `style = "no_leading_or_trailing"`, `"leading_only"` or `"trailing_only"` | `style = "leading_and_trailing"` |
 
 `consistent` asks for no particular form and is never reported, even though the
-flavor resolves it to the enforced value rather than by prevalence.
+flavor resolves it to the enforced value rather than by prevalence. MD003's
+explicit `style = "atx"` already names the enforced form and is not reported.
+
+MD026 reports an explicit colon override as soon as the rule reaches an MDG
+document, even when removing the colon leaves no effective punctuation to
+check and the rule subsequently skips that document. For example, a file whose
+only heading is `#### Examples:` still produces the warning.
 
 Because the flavor is detected per file, the override is only knowable once a
 `.feature.md` is checked, not when the configuration is read. Each rule reports
@@ -266,6 +280,14 @@ at most one line per process however many files trigger it.
 
 Some rules can still rewrite `.feature.md` content. Each entry below was
 reproduced against the current build.
+
+MD003 always converts Setext headings to plain ATX. In a document without an
+explicit `# Feature:` heading, Cucumber may derive the feature name from the
+leading Markdown content; the inserted `#` and following space then become
+literal content in that derived name. Cucumber's
+`testdata/good/misc.feature.md` demonstrates this known AST change. Avoid
+Setext headings in MDG, or disable MD003 when preserving that parsed feature
+name is more important than normalizing headings.
 
 Rules that can turn a line into a tag line:
 

--- a/docs/flavors/mdg.md
+++ b/docs/flavors/mdg.md
@@ -1,0 +1,344 @@
+# Markdown with Gherkin Flavor
+
+For Markdown with Gherkin (`.feature.md`) files used for executable
+specifications.
+
+**Config name**: `mdg`
+**Alias**: `markdown_with_gherkin`
+**Auto-detected suffix**: `.feature.md`
+
+rumdl lints a `.feature.md` as ordinary Markdown. This flavor changes a rule
+only where the correction it would make can stop the document from parsing as
+Gherkin. Where Gherkin accepts a construct in more than one spelling, the
+document is steered toward the one spelling that is both accepted and
+unambiguous rather than left alone; where no correction is safe, the correction
+is withheld.
+
+## Recognized Lines
+
+Gherkin is line-oriented, and this flavor has three shared Gherkin-specific
+line shapes. The rules that use them apply the same shape consistently.
+
+### Structure Heading
+
+An ATX heading whose text splits at its first colon, provided no backtick
+precedes that colon:
+
+```markdown
+# Feature: Checkout
+## Rule: Registered customers
+### Scenario Outline: Buy an item
+#### Examples: Valid cards
+```
+
+The colon alone marks the structure. Keywords are localized, so no list of
+them can name them all, and rumdl matches the colon rather than a keyword
+table. A backtick before the colon disqualifies it: dialect keywords are one or
+two plain words, so such a colon sits inside a code span. `` # See `x: y` Notes ``
+names no structure and is treated as ordinary prose. A later colon belongs to
+the name — `## Scenario: ratio: two to one` splits after `Scenario:` only.
+
+### Tag Line
+
+A line holding nothing but backtick-wrapped tags:
+
+```markdown
+`@billing` `@critical`
+## Scenario: Reject an expired card
+```
+
+Each token must open with `@`, be longer than that `@` alone, and contain no
+whitespace. Leading and trailing whitespace on the line is ignored, and tags may
+be written with or without a space between them. Anything else on the line —
+prose, or a trailing `#` comment, which MDG has no syntax for — means the line
+is not a tag line.
+
+### Table Row
+
+Two to five whitespace characters, spaces or tabs, followed directly by a pipe:
+
+```markdown
+#### Examples:
+
+  | start | eat | left |
+  | ----- | --- | ---- |
+  | 12    | 5   | 7    |
+```
+
+A tab counts as one whitespace character, exactly as a space does. Anything
+else in that position — a blockquote marker, a list marker, text — makes the
+line ordinary Markdown.
+
+## Supported Patterns
+
+### Headings
+
+MDG parses ATX headings only — one to six `#` characters followed by a space. A
+Setext heading never becomes a Gherkin node, and a closing sequence leaks into
+the node's name: `# Feature: F #` is named `F #`. MD003 therefore steers every
+heading to plain ATX under this flavor, whichever style is configured — the one
+spelling a Gherkin structure can carry.
+
+Heading *levels* carry no meaning in the Gherkin syntax tree, so a document can
+always satisfy the level rules. MD025's fix demotes a second H1 to an H2 and
+MD041's fix relevels the first heading where it stands; the keywords survive
+either way.
+
+### Trailing Punctuation
+
+The colon after a keyword is what makes the keyword a keyword, so MD026 must
+never be able to delete it. Under this flavor the ASCII colon leaves that
+rule's `punctuation` set, whether it arrived from the default or from an
+explicit configuration.
+
+Because MD026 matches punctuation only at the very end of a heading, dropping
+the colon from the set is complete: no heading whose last character is a colon
+is inspected at all. `## Scenario!:` is left exactly as written — it names no
+Gherkin structure, but repairing it is not this rule's business.
+
+Only the ASCII colon leaves the set. A full-width `：` carries no structural
+meaning, so a `punctuation` value that lists one keeps enforcing it and
+`## Scenario：` is flagged.
+
+### Unique Headings
+
+Every keyword accepts a name after the colon, so a repeated structure can
+always be given a distinct heading:
+
+```markdown
+#### Examples: Valid cards
+
+#### Examples: Expired cards
+```
+
+Because uniqueness is achievable without losing a Gherkin node, MD024 is not
+relaxed by this flavor. Name your `Examples:` and `Background:` blocks rather
+than repeating a bare keyword.
+
+### Heading Capitalization
+
+A keyword only counts when it is spelled exactly, and `Scenario Outline` is two
+words. Recasing a heading wholesale therefore destroys structures: sentence
+case lowercases the second word and all caps rewrites `Feature:` itself.
+
+Under this flavor MD063 copies the keyword and its colon through verbatim and
+recases only the part after it, so `## Scenario Outline: add two numbers`
+becomes `## Scenario Outline: Add two numbers`. The split happens before the
+heading is parsed into segments, so the keyword keeps its own spacing and never
+counts as the heading's first or last word. A heading with no colon, or whose
+first colon has a backtick before it, is recased exactly as it is elsewhere,
+and a trailing `{#custom-id}` is preserved.
+
+### Tags
+
+rumdl does not insert a blank line between a tag line and the structure heading
+directly below it. A tag line binds to whatever follows it immediately, so an
+inserted blank detaches the tags; above a document-leading tag line the
+inserted blank is parsed as the Feature line besides, collapsing the Feature
+into an unnamed node.
+
+The exemption is limited to a heading that names a structure. An ordinary
+heading such as `## Notes` keeps the usual blank-line requirement even when the
+line above it holds nothing but tags, and the requirement *below* a heading is
+never waived.
+
+### Steps
+
+Steps are unordered Markdown list items. Gherkin keywords are localized, so the
+word after the marker cannot be recognized without the complete dialect table;
+rather than guess, this flavor treats every unordered list item as a possible
+step.
+
+Even with MD013 `reflow` enabled, rumdl keeps such an item on one physical
+line: the over-long line is still reported, but no fix is offered, because a
+wrapped continuation would change the step's Gherkin text. Ordered list items
+are reflowed as usual.
+
+### Doc Strings
+
+A Doc String is a backtick-fenced code block. A tilde fence and an indented
+block are not Doc Strings, so MD046 always uses `fenced` and MD048 always uses
+`backtick` here. `consistent` resolves to those forms rather than to whichever
+form happens to be more prevalent in the document.
+
+Closing an unclosed fence is a repair rather than a style conversion, so it
+still happens under this flavor whatever `style` is configured.
+
+An info string on the fence becomes the Doc String's media type rather than
+dissolving the Doc String, so labelling a fence does not disturb the Gherkin
+structure and MD040 applies normally.
+
+### Data and Examples Tables
+
+Two spaces is always inside the range Gherkin accepts, so MD060 indents a table
+whose every line is a table row to `max(2, the enclosing list item's content
+indent)` while formatting its cells and delimiters: two spaces at the top
+level, and enough to stay inside a nested or ordered list item when the table
+sits in one. Tab indentation is recognized and normalized the same way.
+
+Past five whitespace characters no indentation both keeps the rows inside the
+list item and keeps them a table, so MD060 falls back to its ordinary Markdown
+handling there. It also falls back when any line of the table is not a table
+row — rows carrying a blockquote or list marker are ordinary Markdown, and
+re-indenting them would corrupt the construct around them.
+
+Because a row is an indent followed *directly* by a pipe, MD055 always uses
+`leading_and_trailing` here, and it preserves the row's existing indent while
+restyling it. MD060 owns the indent's width.
+
+An indented run that consists entirely of table rows is withheld from MD046's
+indented-code detection, so such a table is never converted into a fence. The
+decision is made per blank-line-delimited run, before runs are joined, and it
+requires every line of the run to be a row — see [Limitations](#limitations).
+
+### Placeholders
+
+`<https://example.com>` is Gherkin placeholder syntax, not an autolink. Inside
+a Scenario Outline it is substituted from the `Examples` column of that name,
+so wrapping a bare URL in angle brackets can replace the surrounding text with
+whatever that column holds.
+
+MD034 is therefore disabled entirely for this flavor. The angle-bracket form
+carries Gherkin meaning wherever it lands, so the rule is not applied to prose
+either.
+
+## Rule Behavior Changes
+
+Rules steered toward the form Gherkin accepts:
+
+| Rule  | Standard behavior            | MDG behavior                                                                                            |
+| ----- | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
+| MD003 | Enforce the configured style | Steer every heading to plain ATX                                                                        |
+| MD046 | Enforce the configured style | Always `fenced`; an incompatible configured style is overridden                                         |
+| MD048 | Enforce the configured style | Always `backtick`; an incompatible configured style is overridden                                       |
+| MD055 | Enforce the configured style | Always `leading_and_trailing`, keeping the row's indent; an incompatible configured style is overridden |
+
+Rules whose correction is adjusted so it cannot break the Gherkin syntax:
+
+| Rule  | Standard behavior                        | MDG behavior                                                   |
+| ----- | ---------------------------------------- | -------------------------------------------------------------- |
+| MD013 | Reflow long prose when `reflow` is on    | Report an over-long unordered list item without offering a fix |
+| MD022 | Require blank lines around headings      | Keep a tag line against the structure heading below it         |
+| MD026 | Remove configured trailing punctuation   | Drop the ASCII colon from the `punctuation` set                |
+| MD034 | Wrap a bare URL in angle brackets        | Disabled — `<…>` is Gherkin placeholder syntax                 |
+| MD046 | Treat an indented block as code          | Exclude a run made entirely of table rows                      |
+| MD060 | Format table delimiters and cell spacing | Indent a Gherkin table to `max(2, list item content indent)`   |
+| MD063 | Recase the whole heading                 | Recase only the part after the keyword's colon                 |
+
+Rules deliberately left unchanged, because a document can always satisfy them
+while staying valid Gherkin:
+
+| Rule  | Why it still applies                                                      |
+| ----- | ------------------------------------------------------------------------- |
+| MD024 | Every keyword accepts a name, so duplicate headings are always avoidable  |
+| MD025 | Heading levels carry no meaning in the Gherkin syntax tree                |
+| MD040 | A language label becomes the Doc String's media type                      |
+| MD041 | `# Feature: X` is always writable, and the fix relevels in place          |
+
+All other enabled rules lint the Markdown normally.
+
+## Configuration Overrides
+
+Four rules enforce a form this flavor requires over a configured value that
+cannot express it. When the value was set explicitly — a defaulted value is
+never reported — and the rule reaches relevant content, rumdl prints one line
+on stderr:
+
+```text
+[config warning] MD046: Markdown with Gherkin flavor requires style="fenced" (a Gherkin Doc String is only ever a backtick fence). Overriding style="indented" to style="fenced".
+```
+
+| Rule  | Overridden value                                                          | Enforced value                   |
+| ----- | ------------------------------------------------------------------------- | -------------------------------- |
+| MD026 | a `punctuation` set holding the ASCII colon                               | the same set without it          |
+| MD046 | `style = "indented"`                                                      | `style = "fenced"`               |
+| MD048 | `style = "tilde"`                                                         | `style = "backtick"`             |
+| MD055 | `style = "no_leading_or_trailing"`, `"leading_only"` or `"trailing_only"` | `style = "leading_and_trailing"` |
+
+`consistent` asks for no particular form and is never reported, even though the
+flavor resolves it to the enforced value rather than by prevalence.
+
+Because the flavor is detected per file, the override is only knowable once a
+`.feature.md` is checked, not when the configuration is read. Each rule reports
+at most one line per process however many files trigger it.
+
+## Limitations
+
+Some rules can still rewrite `.feature.md` content. Each entry below was
+reproduced against the current build.
+
+Rules that can turn a line into a tag line:
+
+| Rule  | What happens                                                                                                                      | How to avoid it                                 |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| MD038 | Padding that CommonMark would not strip is removed, so `` `@wip ` `` becomes `` `@wip` ``, a tag line binding to whatever follows | Do not put a tag in a code span on its own line |
+
+Rules that can move a table out of the two-to-five whitespace window:
+
+| Rule  | What happens                                                                                                                        | How to avoid it                                    |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| MD010 | With `code-blocks = true`, a tab-indented table expands to spaces beyond the window; the default skips it as an indented code block | Use spaces, or leave `code-blocks` at its default  |
+| MD030 | A wider marker gap can push a table continuation indent past five                                                                   | Leave `ul-multi` and `ul-single` at their defaults |
+| MD046 | An indented run mixing table rows with any other line is fenced whole, dedenting the rows                                           | Separate the note with a blank line                |
+
+Rules that can break the link between a placeholder and its column:
+
+| Rule  | What happens                                                                                                           | How to avoid it                                |
+| ----- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| MD044 | A configured name recases an `Examples` heading or column but not the matching `<placeholder>`, and rewrites a keyword | Do not put keywords or column names in `names` |
+| MD063 | Title case recases a `<placeholder>` inside a structure's name but not the one in the step below it                    | Do not rely on placeholder case                |
+| MD054 | `url-inline = false` rewrites an inline link as an autolink, which is placeholder syntax                               | Leave `url-inline` at its default              |
+
+Rules that can fabricate or rewrite Gherkin text:
+
+| Rule                                                   | What happens                                                                                    | How to avoid it                         |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------------- |
+| MD036                                                  | With `fix = true`, `**Scenario: X**` is promoted into `## Scenario: X`, fabricating a structure | Leave MD036's fix disabled              |
+| MD009, MD011, MD014, MD037, MD039, MD049, MD062, MD064 | Step and Doc String text can be rewritten by spacing, link, emphasis, or shell-prompt fixes     | Review these fixes before applying them |
+
+## Configuration
+
+The flavor is selected automatically for a file whose name ends in
+`.feature.md`, matched without regard to case. `.feature.markdown` is not
+matched.
+
+It can also be configured explicitly:
+
+```toml
+[global]
+flavor = "mdg"
+```
+
+Or for selected files:
+
+```toml
+[per-file-flavor]
+"features/**/*.md" = "mdg"
+```
+
+The `markdown_with_gherkin` alias is accepted anywhere `mdg` is.
+
+A configured flavor wins over the suffix: a `per-file-flavor` pattern matching
+a `.feature.md` decides that file's flavor, and an explicit non-standard
+`[global] flavor` applies to `.feature.md` files too.
+
+## CLI Usage
+
+```bash
+rumdl check --flavor mdg features/
+rumdl fmt --flavor markdown_with_gherkin features/login.feature.md
+```
+
+## When to Use
+
+Use the Markdown with Gherkin flavor when:
+
+- Writing executable specifications as `.feature.md` files
+- A repository mixes feature files with ordinary documentation and both should
+  be linted in one run
+
+## See Also
+
+- [Flavors Overview](../flavors.md) — compare all flavors
+- [Standard Flavor](standard.md) — the base flavor this one adjusts
+- [Markdown with Gherkin specification](https://github.com/cucumber/gherkin/blob/main/MARKDOWN_WITH_GHERKIN.md)

--- a/docs/global-settings.md
+++ b/docs/global-settings.md
@@ -76,7 +76,7 @@ respect-gitignore = false
 # Set global line length (used by MD013 and other line-length rules)
 line-length = 120
 
-# Set markdown flavor (standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops)
+# Set markdown flavor (standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, mdg)
 flavor = "mkdocs"
 
 # Per-file flavor overrides (pattern → flavor)
@@ -914,8 +914,9 @@ flavor = "mkdocs"  # Use MkDocs flavor
 - `"mdx"`: MDX with JSX components, attributes, expressions, and ESM imports
 - `"quarto"`: Quarto/RMarkdown for scientific publishing (citations, shortcodes, div blocks)
 - `"azure_devops"`: Azure DevOps wikis — treats `:::mermaid` blocks as opaque code fences
+- `"mdg"`: Markdown with Gherkin — steers headings, Doc String fences, and Gherkin tables toward the one spelling Gherkin accepts, and withholds corrections that are not safe
 
-**Aliases**: `"commonmark"` is an alias for `"standard"`, `"github"` is an alias for `"gfm"`, `"azure"` and `"ado"` are aliases for `"azure_devops"`
+**Aliases**: `"commonmark"` is an alias for `"standard"`, `"github"` for `"gfm"`, `"azure"` and `"ado"` for `"azure_devops"`, and `"markdown_with_gherkin"` for `"mdg"`
 
 **Behavior**:
 
@@ -932,6 +933,7 @@ flavor = "mkdocs"  # Use MkDocs flavor
 - Use `mdx` for React/Next.js documentation with JSX components
 - Use `quarto` for scientific documents with R/Python code execution
 - Use `azure_devops` (or `azure` / `ado`) for Azure DevOps wiki content with `:::mermaid` blocks
+- Use `mdg` (or `markdown_with_gherkin`) for Markdown with Gherkin; files whose name ends in `.feature.md` are detected automatically
 
 **Example CLI usage**:
 
@@ -964,13 +966,14 @@ Specifies Markdown flavors for specific files or file patterns. This allows diff
 - `"mkdocs"`: MkDocs-specific extensions (auto-references, admonitions)
 - `"mdx"`: MDX flavor with JSX and ESM support
 - `"quarto"`: Quarto/RMarkdown for scientific publishing
+- `"mdg"` or `"markdown_with_gherkin"`: Markdown with Gherkin feature files (`.feature.md`)
 
 **Behavior**:
 
 - Uses "first match wins" semantics - order matters in the configuration
 - Patterns are matched against relative paths from the project root
 - Falls back to global `flavor` setting if no pattern matches
-- Falls back to auto-detection by file extension if no global flavor is set
+- Falls back to auto-detection by file name if no global flavor is set
 
 **Pattern Syntax**:
 
@@ -984,7 +987,7 @@ Specifies Markdown flavors for specific files or file patterns. This allows diff
 
 - Useful for projects with mixed documentation (e.g., MkDocs site + MDX components)
 - Order patterns from most specific to least specific
-- Auto-detection works for common extensions: `.mdx` → MDX, `.qmd`/`.Rmd` → Quarto
+- Auto-detection works for common file names: `.mdx` → MDX, `.qmd`/`.Rmd` → Quarto, and the compound suffix `.feature.md` → MDG; a matching pattern above takes precedence over it
 
 **Example: Mixed Documentation Project**:
 

--- a/docs/md003.md
+++ b/docs/md003.md
@@ -111,6 +111,10 @@ characters followed by a space — so a Setext heading never becomes a Gherkin
 node, and a closing sequence leaks into the node's name, making `# Feature: F #`
 a node named `F #`.
 
+When a fixed style other than `atx` was configured explicitly and the override
+applies in MDG, rumdl prints one `[config warning]` per process. The default
+`consistent` style and an explicit `atx` do not warn.
+
 ### ❌ Incorrect
 
 ```markdown
@@ -129,6 +133,16 @@ Feature: Checkout
 ```
 
 Under any other flavor the configured style is applied as usual.
+
+### Limitation
+
+Converting a Setext heading changes its source text, not just its Markdown
+presentation. In an MDG document without an explicit `# Feature:` heading,
+Cucumber may derive the feature name from the leading Markdown content; adding
+the ATX marker can therefore add a literal `#` and following space to that
+parsed feature name.
+This occurs in Cucumber's `testdata/good/misc.feature.md`. Avoid Setext headings
+in MDG, or disable MD003 when that AST must remain unchanged.
 
 See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
 specification.

--- a/docs/md003.md
+++ b/docs/md003.md
@@ -103,6 +103,36 @@ style = "consistent"  # Options: "consistent", "atx", "atx-closed", "setext", "s
 
 This rule can automatically convert all headings to match your configured style or the most prevalent style in the document.
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, MD003 steers every heading to plain ATX whatever `style`
+is configured. Markdown with Gherkin parses ATX headings only — one to six `#`
+characters followed by a space — so a Setext heading never becomes a Gherkin
+node, and a closing sequence leaks into the node's name, making `# Feature: F #`
+a node named `F #`.
+
+### ❌ Incorrect
+
+```markdown
+Feature: Checkout
+=================
+
+## Scenario: Purchase ##
+```
+
+### ✅ Correct
+
+```markdown
+# Feature: Checkout
+
+## Scenario: Purchase
+```
+
+Under any other flavor the configured style is applied as usual.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [CommonMark specification for headings](https://spec.commonmark.org/0.31.2/#atx-headings) - Technical details about heading syntax

--- a/docs/md013.md
+++ b/docs/md013.md
@@ -430,6 +430,19 @@ With this configuration, long lines will be automatically wrapped to fit within 
 
 **Note**: When `reflow` is `false` (default), automatic fixes are not available and you'll need to manually wrap long lines.
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor with `reflow` enabled, MD013 reports an over-long
+unordered list item but offers no fix for it. Gherkin steps are unordered
+Markdown list items, and Gherkin keywords are localized, so the word after the
+marker cannot be recognized without the complete dialect table; rather than
+guess, the flavor withholds reflow from every unordered item, because wrapping
+one would change the step's Gherkin text. Ordered list items are reflowed as
+usual.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [Line length best practices](https://en.wikipedia.org/wiki/Line_length)

--- a/docs/md022.md
+++ b/docs/md022.md
@@ -121,6 +121,29 @@ A thematic break is not one of those constructs, so a heading directly above one
 still needs its blank line, whichever way the break is written (`---`, `***`,
 `* * *`, `- - -`).
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, MD022 does not require a blank line above a heading that
+names a Gherkin structure when the line directly above it is a tag line — a line
+holding nothing but backtick-wrapped tags:
+
+```markdown
+`@billing` `@critical`
+## Scenario: Reject an expired card
+```
+
+A tag line binds to whatever follows it immediately, so an inserted blank
+detaches the tags; above a document-leading tag line the blank is parsed as the
+Feature line besides, collapsing the Feature into an unnamed node.
+
+The exemption needs both halves. An ordinary heading such as `## Notes` names no
+structure and keeps the requirement even below a tag line, a line carrying
+anything besides tags is not a tag line, and the requirement *below* a heading
+is never waived.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [CommonMark specification for headings](https://spec.commonmark.org/0.31.2/#atx-headings)

--- a/docs/md022.md
+++ b/docs/md022.md
@@ -125,21 +125,25 @@ still needs its blank line, whichever way the break is written (`---`, `***`,
 
 Under the `mdg` flavor, MD022 does not require a blank line above a heading that
 names a Gherkin structure when the line directly above it is a tag line — a line
-holding nothing but backtick-wrapped tags:
+containing a backtick-wrapped tag:
 
 ```markdown
-`@billing` `@critical`
+`@billing` `@critical` # checkout tags
 ## Scenario: Reject an expired card
 ```
+
+Recognition follows Cucumber's `` `(@[^`]+)` `` scan. A matching tag may occur
+anywhere on the line, and surrounding text or a trailing comment does not
+disqualify it.
 
 A tag line binds to whatever follows it immediately, so an inserted blank
 detaches the tags; above a document-leading tag line the blank is parsed as the
 Feature line besides, collapsing the Feature into an unnamed node.
 
 The exemption needs both halves. An ordinary heading such as `## Notes` names no
-structure and keeps the requirement even below a tag line, a line carrying
-anything besides tags is not a tag line, and the requirement *below* a heading
-is never waived.
+structure and keeps the requirement even below a tag line, a line without a
+matching tag is not a tag line, and the requirement *below* a heading is never
+waived.
 
 See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
 specification.

--- a/docs/md026.md
+++ b/docs/md026.md
@@ -83,6 +83,26 @@ This rule will:
 - Preserve question marks for FAQ-style headings ("What is Markdown?")
 - You can customize the punctuation list if you want to allow certain characters
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, the ASCII colon leaves the `punctuation` set, whether it
+arrived from the default or from an explicit configuration. A Gherkin structure
+is an ATX heading spelled `Keyword: name`, so the colon after the keyword is
+what makes the keyword a keyword, and this rule must never be able to delete it.
+
+Because MD026 matches punctuation only at the very end of a heading, dropping
+the colon from the set is complete: no heading whose last character is a colon
+is inspected at all, so `## Scenario!:` is left exactly as written. Only the
+ASCII colon leaves the set — a full-width `：` carries no structural meaning, so
+a `punctuation` value that lists one keeps enforcing it.
+
+When MD026 reaches relevant content with an explicit `punctuation` value
+containing a colon, it prints one `[config warning]` line on stderr; the colon
+is dropped either way.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [CommonMark Spec: ATX headings](https://spec.commonmark.org/0.31.2/#atx-headings)

--- a/docs/md034.md
+++ b/docs/md034.md
@@ -56,7 +56,9 @@ This rule has no configuration options.
 
 ## Automatic fixes
 
-This rule automatically wraps plain URLs, email addresses, and XMPP URIs in angle brackets (`<` and `>`).
+Outside the `mdg` flavor, this rule automatically wraps plain URLs, email
+addresses, and XMPP URIs in angle brackets (`<` and `>`). Under `mdg`, it
+reports without fixing; see below.
 
 ## GFM extended autolinks
 
@@ -70,10 +72,16 @@ This rule supports GFM (GitHub Flavored Markdown) extended autolinks, including:
 
 ## Markdown with Gherkin
 
-Under the `mdg` flavor, MD034 is disabled entirely. `<https://example.com>` is
-Gherkin placeholder syntax rather than an autolink: inside a Scenario Outline it
-is substituted from the `Examples` column of that name, so the angle brackets
-this rule adds carry meaning wherever they land — in prose as much as in a step.
+Under the `mdg` flavor, MD034 reports bare URLs and email addresses but does not
+offer a fix. `<https://example.com>` is Gherkin placeholder syntax rather than
+an autolink: inside a Scenario Outline it is substituted from the `Examples`
+column of that name, so the standard angle-bracket fix could change the parsed
+scenario.
+
+The safe response depends on context. An explicit Markdown link may be suitable
+for prose, but changing a step to Markdown link syntax also changes its step
+text. Format the link manually when that change is intended, or disable MD034
+for content where a bare URL or email address is the required spelling.
 
 See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
 specification.

--- a/docs/md034.md
+++ b/docs/md034.md
@@ -68,6 +68,16 @@ This rule supports GFM (GitHub Flavored Markdown) extended autolinks, including:
 - XMPP URIs: `xmpp:user@example.com` or `xmpp:user@example.com/resource`
 - WWW URLs without protocol: `www.example.com`
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, MD034 is disabled entirely. `<https://example.com>` is
+Gherkin placeholder syntax rather than an autolink: inside a Scenario Outline it
+is substituted from the `Examples` column of that name, so the angle brackets
+this rule adds carry meaning wherever they land — in prose as much as in a step.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [CommonMark autolinks](https://spec.commonmark.org/0.31.2/#autolinks) - Technical specification for URL formatting

--- a/docs/md040.md
+++ b/docs/md040.md
@@ -206,8 +206,24 @@ Common language mappings:
 
 ## Automatic fixes
 
-- Missing language: Adds `text` as the default
-- Inconsistent labels (when `style = "consistent"`): Normalizes to the preferred/prevalent label
+- Missing language: Adds `text` as the default outside the `mdg` flavor
+- Inconsistent labels (when `style = "consistent"`): Normalizes to the preferred/prevalent label outside the `mdg` flavor
+
+## Markdown with Gherkin
+
+Under the `mdg` flavor, a backtick-fenced code block is a Gherkin Doc String and
+its language label is the Doc String's media type. MD040 still reports missing
+and inconsistent labels, but offers no fix: adding the standard `text` fallback
+would change the parsed media type from absent (`null`) to `text`, while
+normalizing an existing label would replace an explicitly chosen media type.
+Step definitions can observe either change.
+
+Add the intended media type manually when the Doc String has one, or disable
+MD040 when an absent media type is intentional. Under other flavors, the
+standard `text` fix remains available.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
 
 ## Learn more
 

--- a/docs/md046.md
+++ b/docs/md046.md
@@ -200,6 +200,38 @@ detection.
 See [Azure DevOps Flavor](flavors/azure_devops.md) for the full colon fence
 specification.
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, MD046 always uses `fenced`. A Gherkin Doc String is only
+ever a backtick fence, so an indented block can never be one: `consistent`
+resolves to fenced rather than by prevalence, and a configured
+`style = "indented"` is not adopted — the rule enforces fenced anyway and prints
+one `[config warning]` line on stderr when the rule reaches relevant content.
+
+A run of indented lines that consists *entirely* of Gherkin table rows — two to
+five whitespace characters, spaces or tabs, followed directly by a pipe — is
+withheld from indented-code detection, so a Data Table or Examples table is
+never converted into a fence. The decision is made per blank-line-delimited run,
+and the run must hold nothing else:
+
+```markdown
+#### Examples:
+
+    | start | eat |
+    | ----- | --- |
+
+    a note about the data
+```
+
+Here the table is left alone and only the note is fenced. Without the blank line
+the two would form a single run, which is fenced whole.
+
+Closing an unclosed fence is a repair rather than a style conversion, so it
+still happens whatever `style` is configured.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [CommonMark fenced code blocks](https://spec.commonmark.org/0.31.2/#fenced-code-blocks)

--- a/docs/md048.md
+++ b/docs/md048.md
@@ -123,6 +123,20 @@ style detection.
 See [Azure DevOps Flavor](flavors/azure_devops.md) for the full colon fence
 specification.
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, MD048 always uses `backtick`. A Gherkin Doc String is
+only ever a backtick fence, so a tilde fence can never be one: `consistent`
+resolves to backtick rather than by prevalence, and a configured
+`style = "tilde"` is not adopted — the rule enforces backtick anyway and prints
+one `[config warning]` line on stderr when the rule reaches relevant content.
+
+The fence-length arithmetic that keeps a converted outer fence from being closed
+by an interior one is unaffected.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [CommonMark code fences](https://spec.commonmark.org/0.31.2/#fenced-code-blocks) - Technical specification

--- a/docs/md055.md
+++ b/docs/md055.md
@@ -79,6 +79,24 @@ This rule can automatically fix issues by:
 - Removing extra pipes when not allowed
 - Making all rows match the configured style
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, MD055 always uses `leading_and_trailing`. Gherkin
+recognizes a Data Table or Examples row only when an indent is followed directly
+by a pipe, so `no_leading_or_trailing`, `leading_only` and `trailing_only` would
+not express the required form: `no_leading_or_trailing` and `trailing_only`
+remove the leading pipe, while `leading_only` omits the trailing pipe. None of
+the three is adopted: the rule enforces `leading_and_trailing` anyway and
+prints one `[config warning]` line on stderr when the rule reaches relevant
+content. `consistent` resolves to the same form rather than by prevalence, and
+is never reported.
+
+A restyled row keeps the indentation it was written with, because that indent is
+half of what makes it a Gherkin row. [MD060](md060.md) owns the indent's width.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Learn more
 
 - [Markdown Guide: Tables](https://www.markdownguide.org/extended-syntax/#tables)

--- a/docs/md060.md
+++ b/docs/md060.md
@@ -485,6 +485,28 @@ MD060 is disabled by default because:
 
 We recommend enabling MD060 for new projects or when doing a formatting cleanup pass.
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, a table whose every line is a Gherkin table row — two to
+five whitespace characters, spaces or tabs, followed directly by a pipe — is
+re-indented while its cells and delimiters are formatted, to
+`max(2, the enclosing list item's content indent)` spaces.
+
+Two spaces is always inside the range Gherkin accepts, so a table written
+anywhere in that range is normalized to two rather than left as written. Inside
+a list item the rows must also reach the item's content column to stay part of
+that item, so the deeper column wins there. Tab indentation is recognized and
+normalized the same way.
+
+Past five whitespace characters no indentation both keeps the rows in the list
+item and keeps them a Gherkin table, so the table falls back to the ordinary
+Markdown handling. So does a table any of whose lines is not a table row — rows
+carrying a blockquote or list marker are ordinary Markdown, and re-indenting
+them would corrupt the construct around them.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## See Also
 
 - [MD056](md056.md) - Table Column Count (validates table structure)

--- a/docs/md063.md
+++ b/docs/md063.md
@@ -277,6 +277,27 @@ This rule can automatically fix capitalization issues. Run:
 rumdl check --fix yourfile.md
 ```
 
+## Markdown with Gherkin
+
+Under the `mdg` flavor, MD063 copies a Gherkin keyword and its colon through
+verbatim and recases only the part after it, so
+`## Scenario Outline: add two numbers` becomes
+`## Scenario Outline: Add two numbers` rather than losing its keyword. A keyword
+counts only when it is spelled exactly, and `Scenario Outline` is two words, so
+recasing a heading wholesale would turn the structure into prose.
+
+The split takes the heading's first colon, provided no backtick precedes it: a
+dialect keyword is one or two plain words, so a colon behind a backtick sits
+inside a code span and `` # See `x: y` Notes `` is recased as it would be under
+any other flavor. A later colon belongs to the name and is recased with it.
+
+Because the split happens before the heading is parsed into segments, the
+keyword keeps its own spacing and never counts as the heading's first or last
+word, and a trailing `{#custom-id}` is preserved.
+
+See [Markdown with Gherkin Flavor](flavors/mdg.md) for the full flavor
+specification.
+
 ## Related Rules
 
 - [MD025 - Single H1 heading](md025.md)

--- a/docs/mdformat-comparison.md
+++ b/docs/mdformat-comparison.md
@@ -73,7 +73,7 @@ pip install mdformat-gfm mdformat-frontmatter
 
 ```toml
 [global]
-flavor = "gfm"  # or: mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops
+flavor = "gfm"  # or: mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, mdg
 ```
 
 | Syntax              | mdformat             | rumdl               |

--- a/rumdl.schema.json
+++ b/rumdl.schema.json
@@ -195,7 +195,7 @@
       "minimum": 0
     },
     "MarkdownFlavor": {
-      "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, hugo. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops, mystmd maps to myst, goldmark maps to hugo.",
+      "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, hugo, mdg. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops, mystmd maps to myst, goldmark maps to hugo, markdown_with_gherkin maps to mdg.",
       "type": "string",
       "enum": [
         "standard",
@@ -218,7 +218,9 @@
         "myst",
         "mystmd",
         "hugo",
-        "goldmark"
+        "goldmark",
+        "mdg",
+        "markdown_with_gherkin"
       ]
     },
     "CodeBlockToolsConfig": {

--- a/src/cli_types.rs
+++ b/src/cli_types.rs
@@ -177,7 +177,7 @@ pub struct CheckArgs {
     #[arg(
         long,
         value_enum,
-        help = "Markdown flavor to use: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops (also accepts azure/ado), or myst (also accepts mystmd)"
+        help = "Markdown flavor to use: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops (also accepts azure/ado), or myst (also accepts mystmd), or mdg (also accepts markdown_with_gherkin)"
     )]
     pub flavor: Option<Flavor>,
 
@@ -284,7 +284,7 @@ pub struct FmtArgs {
     #[arg(
         long,
         value_enum,
-        help = "Markdown flavor to use while formatting: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, or azure_devops (also accepts azure/ado)"
+        help = "Markdown flavor to use while formatting: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops (also accepts azure/ado), or mdg (also accepts markdown_with_gherkin)"
     )]
     pub flavor: Option<Flavor>,
 
@@ -448,6 +448,9 @@ pub enum Flavor {
     MyST,
     #[value(alias("goldmark"))]
     Hugo,
+    #[allow(clippy::upper_case_acronyms)]
+    #[value(name = "mdg", alias("markdown_with_gherkin"))]
+    MDG,
 }
 
 impl From<Flavor> for rumdl_lib::config::MarkdownFlavor {
@@ -463,6 +466,7 @@ impl From<Flavor> for rumdl_lib::config::MarkdownFlavor {
             Flavor::AzureDevOps => Self::AzureDevOps,
             Flavor::MyST => Self::MyST,
             Flavor::Hugo => Self::Hugo,
+            Flavor::MDG => Self::MDG,
         }
     }
 }

--- a/src/cli_types.rs
+++ b/src/cli_types.rs
@@ -177,7 +177,7 @@ pub struct CheckArgs {
     #[arg(
         long,
         value_enum,
-        help = "Markdown flavor to use: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops (also accepts azure/ado), or myst (also accepts mystmd), or mdg (also accepts markdown_with_gherkin)"
+        help = "Markdown flavor to use: standard (also accepts gfm/github/commonmark), mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops (also accepts azure/ado), myst (also accepts mystmd), or mdg (also accepts markdown_with_gherkin)"
     )]
     pub flavor: Option<Flavor>,
 

--- a/src/config/flavor.rs
+++ b/src/config/flavor.rs
@@ -52,14 +52,17 @@ pub enum MarkdownFlavor {
     /// Hugo flavor — GFM plus Goldmark block attribute lists (`{class="a" id="b"}`)
     #[serde(rename = "hugo", alias = "goldmark")]
     Hugo,
+    /// Markdown with Gherkin (MDG) flavor for executable specifications (`.feature.md` files)
+    #[serde(rename = "mdg", alias = "markdown_with_gherkin")]
+    MDG,
 }
 
 /// Custom JSON schema for MarkdownFlavor that includes all accepted values and aliases
 fn markdown_flavor_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({
-        "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, hugo. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops, mystmd maps to myst, goldmark maps to hugo.",
+        "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, hugo, mdg. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto, jekyll maps to kramdown, azure/ado map to azure_devops, mystmd maps to myst, goldmark maps to hugo, markdown_with_gherkin maps to mdg.",
         "type": "string",
-        "enum": ["standard", "gfm", "github", "commonmark", "mkdocs", "mdx", "pandoc", "quarto", "qmd", "rmd", "rmarkdown", "obsidian", "kramdown", "jekyll", "azure_devops", "azure", "ado", "myst", "mystmd", "hugo", "goldmark"]
+        "enum": ["standard", "gfm", "github", "commonmark", "mkdocs", "mdx", "pandoc", "quarto", "qmd", "rmd", "rmarkdown", "obsidian", "kramdown", "jekyll", "azure_devops", "azure", "ado", "myst", "mystmd", "hugo", "goldmark", "mdg", "markdown_with_gherkin"]
     })
 }
 
@@ -86,6 +89,7 @@ impl fmt::Display for MarkdownFlavor {
             MarkdownFlavor::AzureDevOps => write!(f, "azure_devops"),
             MarkdownFlavor::MyST => write!(f, "myst"),
             MarkdownFlavor::Hugo => write!(f, "hugo"),
+            MarkdownFlavor::MDG => write!(f, "mdg"),
         }
     }
 }
@@ -109,6 +113,7 @@ impl FromStr for MarkdownFlavor {
             // (pulldown-cmark) already supports GFM extensions (tables, task lists,
             // strikethrough, autolinks, etc.) which are a superset of CommonMark
             "gfm" | "github" | "commonmark" => Ok(MarkdownFlavor::Standard),
+            "mdg" | "markdown_with_gherkin" => Ok(MarkdownFlavor::MDG),
             _ => Err(format!("Unknown markdown flavor: {s}")),
         }
     }
@@ -128,6 +133,14 @@ impl MarkdownFlavor {
 
     /// Detect flavor from file path
     pub fn from_path(path: &std::path::Path) -> Self {
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.to_ascii_lowercase().ends_with(".feature.md"))
+        {
+            return Self::MDG;
+        }
+
         path.extension()
             .and_then(|e| e.to_str())
             .map_or(Self::Standard, Self::from_extension)
@@ -186,6 +199,7 @@ impl MarkdownFlavor {
             Self::AzureDevOps => "AzureDevOps",
             Self::MyST => "MyST",
             Self::Hugo => "Hugo",
+            Self::MDG => "Markdown with Gherkin",
         }
     }
 
@@ -260,6 +274,7 @@ mod tests {
             (MarkdownFlavor::AzureDevOps, "azure_devops"),
             (MarkdownFlavor::MyST, "myst"),
             (MarkdownFlavor::Hugo, "hugo"),
+            (MarkdownFlavor::MDG, "mdg"),
         ];
         for (variant, expected) in cases {
             let displayed = variant.to_string();
@@ -290,6 +305,7 @@ mod tests {
             MarkdownFlavor::AzureDevOps,
             MarkdownFlavor::MyST,
             MarkdownFlavor::Hugo,
+            MarkdownFlavor::MDG,
         ];
         for variant in variants {
             let displayed = variant.to_string();
@@ -320,6 +336,50 @@ mod tests {
         // Pandoc files use .md — must NOT auto-detect to Pandoc.
         assert_eq!(MarkdownFlavor::from_extension("md"), MarkdownFlavor::Standard);
         assert_eq!(MarkdownFlavor::from_extension("markdown"), MarkdownFlavor::Standard);
+    }
+
+    #[test]
+    fn test_mdg_aliases_and_name() {
+        assert_eq!("MDG".parse::<MarkdownFlavor>().unwrap(), MarkdownFlavor::MDG);
+        assert_eq!(
+            "markdown_with_gherkin".parse::<MarkdownFlavor>().unwrap(),
+            MarkdownFlavor::MDG
+        );
+        assert_eq!(MarkdownFlavor::MDG.name(), "Markdown with Gherkin");
+    }
+
+    #[test]
+    fn test_mdg_serde_names() {
+        assert_eq!(
+            MarkdownFlavor::deserialize(toml::Value::String("markdown_with_gherkin".to_string())).unwrap(),
+            MarkdownFlavor::MDG
+        );
+        assert_eq!(
+            toml::Value::try_from(MarkdownFlavor::MDG).unwrap().as_str(),
+            Some("mdg")
+        );
+    }
+
+    #[test]
+    fn test_from_path_detects_feature_md_compound_suffix() {
+        use std::path::Path;
+
+        assert_eq!(
+            MarkdownFlavor::from_path(Path::new("features/login.feature.md")),
+            MarkdownFlavor::MDG
+        );
+        assert_eq!(
+            MarkdownFlavor::from_path(Path::new("features/login.FEATURE.MD")),
+            MarkdownFlavor::MDG
+        );
+        assert_eq!(
+            MarkdownFlavor::from_path(Path::new("README.md")),
+            MarkdownFlavor::Standard
+        );
+        assert_eq!(
+            MarkdownFlavor::from_path(Path::new("features/login.feature.markdown")),
+            MarkdownFlavor::Standard
+        );
     }
 
     #[test]

--- a/src/config/parsers.rs
+++ b/src/config/parsers.rs
@@ -191,11 +191,11 @@ pub(super) fn parse_pyproject_toml(
                     let pattern = display_path.quote(pattern);
                     if display_path.may_quote_contents() {
                         log::warn!(
-                            "[WARN] Invalid flavor for per-file-flavor pattern '{pattern}' in {display_path}, found {flavor_value:?}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst"
+                            "[WARN] Invalid flavor for per-file-flavor pattern '{pattern}' in {display_path}, found {flavor_value:?}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, mdg"
                         );
                     } else {
                         log::warn!(
-                            "[WARN] Invalid flavor for per-file-flavor pattern '{pattern}' in {display_path}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst"
+                            "[WARN] Invalid flavor for per-file-flavor pattern '{pattern}' in {display_path}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, mdg"
                         );
                     }
                 }
@@ -763,7 +763,7 @@ pub(super) fn parse_rumdl_toml(
                         let flavor_str = display_path.quote(flavor_str);
                         let pattern = display_path.quote(pattern);
                         log::warn!(
-                            "[WARN] Invalid flavor '{flavor_str}' for pattern '{pattern}' in {display_path}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst"
+                            "[WARN] Invalid flavor '{flavor_str}' for pattern '{pattern}' in {display_path}. Valid values: standard, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, mdg"
                         );
                     }
                 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1502,6 +1502,52 @@ fn test_per_file_flavor_extension_detection_interaction() {
 }
 
 #[test]
+fn test_mdg_compound_extension_detection_and_flavor_overrides() {
+    use std::path::PathBuf;
+
+    let default_config = Config::default();
+    assert_eq!(
+        default_config.get_flavor_for_file(&PathBuf::from("features/login.feature.md")),
+        MarkdownFlavor::MDG
+    );
+    assert_eq!(
+        default_config.get_flavor_for_file(&PathBuf::from("features/README.md")),
+        MarkdownFlavor::Standard
+    );
+
+    let temp_dir = tempdir().unwrap();
+    let config_path = temp_dir.path().join(".rumdl.toml");
+    let config_content = r#"
+[global]
+flavor = "mkdocs"
+
+[per-file-flavor]
+"plain/**" = "standard"
+"mdg/**" = "markdown_with_gherkin"
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let sourced = SourcedConfig::load_with_discovery(Some(config_path.to_str().unwrap()), None, true).unwrap();
+    let config: Config = sourced.into_validated_unchecked().into();
+
+    assert_eq!(
+        config.get_flavor_for_file(&PathBuf::from("plain/login.feature.md")),
+        MarkdownFlavor::Standard,
+        "a per-file Standard override must win over compound-suffix detection"
+    );
+    assert_eq!(
+        config.get_flavor_for_file(&PathBuf::from("mdg/login.md")),
+        MarkdownFlavor::MDG,
+        "the markdown_with_gherkin alias must work in per-file flavor configuration"
+    );
+    assert_eq!(
+        config.get_flavor_for_file(&PathBuf::from("other/login.feature.md")),
+        MarkdownFlavor::MkDocs,
+        "an explicit non-Standard global flavor must win over auto-detection"
+    );
+}
+
+#[test]
 fn test_per_file_flavor_standard_alias_none() {
     use std::path::PathBuf;
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -894,7 +894,7 @@ exclude = [
 respect-gitignore = true
 
 # Markdown flavor/dialect (uncomment to enable)
-# Options: standard (default), gfm, commonmark, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst
+# Options: standard (default), gfm, commonmark, mkdocs, mdx, pandoc, quarto, obsidian, kramdown, azure_devops, myst, mdg
 # flavor = "mkdocs"
 
 # Rule-specific configurations (uncomment and modify as needed)

--- a/src/rule_config_serde.rs
+++ b/src/rule_config_serde.rs
@@ -4,6 +4,7 @@
 /// It eliminates manual TOML construction and provides automatic serialization/deserialization.
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Trait for rule configurations
 pub trait RuleConfig: Serialize + DeserializeOwned + Default + Clone {
@@ -78,6 +79,74 @@ pub fn compile_config_regex(pattern: &str, rule: &str, option: &str, values_with
             log::warn!("Invalid {option} for {rule}: {detail}. The option is ignored.");
             None
         }
+    }
+}
+
+/// Whether `option` was set in the configuration for `rule` rather than defaulted.
+///
+/// A rule reads this once, in `from_config`, because it is the only place that still
+/// sees the raw config: [`load_rule_config`] fills the gaps with defaults, after which
+/// a configured value and a defaulted one are indistinguishable. The answer only ever
+/// decides what the user is told, never what the rule enforces.
+pub fn option_is_explicit(config: &crate::config::Config, rule: &str, option: &str) -> bool {
+    config
+        .rules
+        .get(rule)
+        .is_some_and(|rule_config| rule_config.values.contains_key(option))
+}
+
+/// Reports, at most once per process, that a flavor did not adopt a configured value.
+///
+/// The report belongs in `from_config` with the rest of the house style, but a flavor
+/// is also auto-detected per file (MDG for `*.feature.md`), so the override is only
+/// knowable at check/fix time. That makes it reachable once per matching file rather
+/// than once per run, and a repository of feature files would bury the terminal in
+/// repeats. Each rule holds one notice in a `static`, so process-wide state keeps it
+/// to a single line per rule.
+///
+/// A caller reports only what it cannot satisfy: it decides which configured values
+/// are incompatible and supplies the reason, and calls [`report`](Self::report) only
+/// for those. Reaching `report` is what marks the notice as spent.
+///
+/// MD007 warns in the same voice but does not fit here: it reports `indent >= 4`
+/// rather than an `option="value"` the flavor enforces, and it emits a second warning
+/// about a contradictory `indent` plus `style` combination that has nothing to do with
+/// a flavor. Leave it as it is.
+pub struct FlavorOverrideNotice(AtomicBool);
+
+impl FlavorOverrideNotice {
+    pub const fn new() -> Self {
+        Self(AtomicBool::new(false))
+    }
+
+    /// Report that `rule`'s `option` was configured as `configured` but the flavor
+    /// enforces `enforced`, because of `reason` — a bare clause, without the
+    /// surrounding parentheses or trailing punctuation.
+    pub fn report(&self, rule: &str, option: &str, configured: &str, enforced: &str, reason: &str) {
+        if self.0.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        eprintln!("{}", Self::message(rule, option, configured, enforced, reason));
+    }
+
+    /// The reported line. Separate from [`report`](Self::report) so a test can read
+    /// the text that only a spent notice would otherwise print.
+    ///
+    /// MDG is the only flavor that overrides a configured value this way, so it is the
+    /// only one the line can name; taking the name from the enum keeps the two in step.
+    /// A second such flavor would have to be passed in.
+    fn message(rule: &str, option: &str, configured: &str, enforced: &str, reason: &str) -> String {
+        format!(
+            "\x1b[33m[config warning]\x1b[0m {rule}: {flavor} flavor requires {option}=\"{enforced}\" \
+             ({reason}). Overriding {option}=\"{configured}\" to {option}=\"{enforced}\".",
+            flavor = crate::config::MarkdownFlavor::MDG.name()
+        )
+    }
+}
+
+impl Default for FlavorOverrideNotice {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1243,6 +1312,75 @@ mod tests {
             Some(crate::rule::Severity::Error)
         );
         assert!(config.rules.get("MD013").unwrap().severity.is_none());
+    }
+
+    #[test]
+    fn test_option_is_explicit() {
+        let mut values = BTreeMap::new();
+        values.insert("style".to_string(), toml::Value::String("indented".to_string()));
+        let mut config = crate::config::Config::default();
+        config.rules.insert(
+            "MD046".to_string(),
+            crate::config::RuleConfig { severity: None, values },
+        );
+
+        assert!(option_is_explicit(&config, "MD046", "style"));
+        // A rule with a section but not this option, and a rule with no section at all.
+        assert!(!option_is_explicit(&config, "MD046", "language_required"));
+        assert!(!option_is_explicit(&config, "MD048", "style"));
+    }
+
+    #[test]
+    fn test_flavor_override_notice_reports_once() {
+        let notice = FlavorOverrideNotice::new();
+        notice.report("MD046", "style", "indented", "fenced", "reason");
+        assert!(notice.0.load(Ordering::Relaxed));
+
+        // Spent: a second report is a no-op, and a fresh notice is untouched by it.
+        notice.report("MD046", "style", "indented", "fenced", "reason");
+        assert!(!FlavorOverrideNotice::new().0.load(Ordering::Relaxed));
+    }
+
+    /// The reported lines are user-facing text this refactor must not have changed.
+    #[test]
+    fn test_flavor_override_notice_message_text() {
+        assert_eq!(
+            FlavorOverrideNotice::message(
+                "MD046",
+                "style",
+                "indented",
+                "fenced",
+                "a Gherkin Doc String is only ever a backtick fence"
+            ),
+            "\x1b[33m[config warning]\x1b[0m MD046: Markdown with Gherkin flavor requires style=\"fenced\" \
+             (a Gherkin Doc String is only ever a backtick fence). \
+             Overriding style=\"indented\" to style=\"fenced\"."
+        );
+        assert_eq!(
+            FlavorOverrideNotice::message(
+                "MD048",
+                "style",
+                "tilde",
+                "backtick",
+                "a Gherkin Doc String is only ever a backtick fence"
+            ),
+            "\x1b[33m[config warning]\x1b[0m MD048: Markdown with Gherkin flavor requires style=\"backtick\" \
+             (a Gherkin Doc String is only ever a backtick fence). \
+             Overriding style=\"tilde\" to style=\"backtick\"."
+        );
+        assert_eq!(
+            FlavorOverrideNotice::message(
+                "MD055",
+                "style",
+                "no_leading_or_trailing",
+                "leading_and_trailing",
+                "a Gherkin table row is an indent followed directly by a pipe"
+            ),
+            "\x1b[33m[config warning]\x1b[0m MD055: Markdown with Gherkin flavor requires \
+             style=\"leading_and_trailing\" \
+             (a Gherkin table row is an indent followed directly by a pipe). \
+             Overriding style=\"no_leading_or_trailing\" to style=\"leading_and_trailing\"."
+        );
     }
 
     // ========== End-to-end integration tests ==========

--- a/src/rules/md003_heading_style.rs
+++ b/src/rules/md003_heading_style.rs
@@ -4,6 +4,7 @@
 //! See [docs/md003.md](../../docs/md003.md) for full documentation, configuration, and examples.
 
 use crate::rule::{LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::rule_config_serde::{FlavorOverrideNotice, option_is_explicit};
 use crate::rules::heading_utils::HeadingStyle;
 use crate::utils::range_utils::calculate_heading_range;
 use toml;
@@ -11,21 +12,30 @@ use toml;
 mod md003_config;
 use md003_config::MD003Config;
 
+/// Reports an explicit MDG style override once per process.
+static MDG_STYLE_OVERRIDE: FlavorOverrideNotice = FlavorOverrideNotice::new();
+
 /// Rule MD003: Heading style
 #[derive(Clone, Default)]
 pub struct MD003HeadingStyle {
     config: MD003Config,
+    /// Whether `style` was explicitly configured rather than defaulted.
+    style_explicit: bool,
 }
 
 impl MD003HeadingStyle {
     pub fn new(style: HeadingStyle) -> Self {
         Self {
             config: MD003Config { style },
+            style_explicit: true,
         }
     }
 
     pub fn from_config_struct(config: MD003Config) -> Self {
-        Self { config }
+        Self {
+            config,
+            style_explicit: false,
+        }
     }
 
     /// Check if we should use consistent mode (detect first style)
@@ -39,6 +49,7 @@ impl MD003HeadingStyle {
         // MDG recognizes `#{1,6} ` headings only, so plain ATX is the single
         // style a Gherkin document can be steered to.
         if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+            self.warn_once_about_overridden_style();
             return HeadingStyle::Atx;
         }
 
@@ -93,6 +104,24 @@ impl MD003HeadingStyle {
                 }
             })
             .map_or(HeadingStyle::Atx, |(style, _)| style)
+    }
+
+    /// Tell the user when an explicit fixed style cannot be honored by MDG.
+    /// `consistent` asks for no fixed spelling, and `atx` is already the form
+    /// the flavor enforces, so neither is an override worth reporting.
+    fn warn_once_about_overridden_style(&self) {
+        if !self.style_explicit || matches!(self.config.style, HeadingStyle::Atx | HeadingStyle::Consistent) {
+            return;
+        }
+
+        let configured = self.config.style.to_string();
+        MDG_STYLE_OVERRIDE.report(
+            "MD003",
+            "style",
+            &configured,
+            "atx",
+            "Markdown with Gherkin recognizes structure headings only in plain ATX form",
+        );
     }
 }
 
@@ -313,7 +342,20 @@ impl Rule for MD003HeadingStyle {
         self
     }
 
-    crate::impl_rule_config_methods!(MD003Config);
+    crate::impl_rule_config_sections!(MD003Config);
+
+    fn from_config(config: &crate::config::Config) -> Box<dyn Rule>
+    where
+        Self: Sized,
+    {
+        let rule_config = crate::rule_config_serde::load_rule_config::<MD003Config>(config);
+        let style_explicit = option_is_explicit(config, "MD003", "style");
+
+        Box::new(Self {
+            config: rule_config,
+            style_explicit,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -516,5 +558,36 @@ mod tests {
             assert!(rule.check(&fixed_ctx).unwrap().is_empty());
             assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
         }
+    }
+
+    #[test]
+    fn test_mdg_tracks_only_an_explicit_style_for_override_notices() {
+        let direct = MD003HeadingStyle::new(HeadingStyle::Setext1);
+        assert!(direct.style_explicit);
+
+        let defaulted = MD003HeadingStyle::from_config_struct(MD003Config {
+            style: HeadingStyle::Setext1,
+        });
+        assert!(!defaulted.style_explicit);
+
+        let mut config = crate::config::Config::default();
+        let mut rule_config = crate::config::RuleConfig::default();
+        rule_config
+            .values
+            .insert("style".to_string(), toml::Value::String("setext".to_string()));
+        config.rules.insert("MD003".to_string(), rule_config);
+        let configured = MD003HeadingStyle::from_config(&config);
+        let configured = configured
+            .as_any()
+            .downcast_ref::<MD003HeadingStyle>()
+            .expect("MD003::from_config builds MD003HeadingStyle");
+        assert!(configured.style_explicit);
+
+        let default_configured = MD003HeadingStyle::from_config(&crate::config::Config::default());
+        let default_configured = default_configured
+            .as_any()
+            .downcast_ref::<MD003HeadingStyle>()
+            .expect("MD003::from_config builds MD003HeadingStyle");
+        assert!(!default_configured.style_explicit);
     }
 }

--- a/src/rules/md003_heading_style.rs
+++ b/src/rules/md003_heading_style.rs
@@ -36,6 +36,12 @@ impl MD003HeadingStyle {
 
     /// Gets the target heading style based on configuration and document content
     fn get_target_style(&self, ctx: &crate::lint_context::LintContext) -> HeadingStyle {
+        // MDG recognizes `#{1,6} ` headings only, so plain ATX is the single
+        // style a Gherkin document can be steered to.
+        if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+            return HeadingStyle::Atx;
+        }
+
         if !self.is_consistent_mode() {
             return self.config.style;
         }
@@ -173,6 +179,17 @@ impl Rule for MD003HeadingStyle {
                         }
                     }
                     _ => target_style,
+                };
+
+                // MDG only recognizes plain ATX headings: a setext heading never
+                // becomes a Gherkin node and a closing sequence leaks into the
+                // node's name (`# Feature: F #` is named "F #"). Steering every
+                // heading to plain ATX keeps MD003 enforcing a style while never
+                // emitting a form Gherkin cannot parse.
+                let expected_style = if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+                    HeadingStyle::Atx
+                } else {
+                    expected_style
                 };
 
                 if current_style != expected_style {
@@ -455,5 +472,49 @@ mod tests {
             2,
             "Should flag non-closed ATX headings for h3+ with setext_with_atx_closed style"
         );
+    }
+
+    #[test]
+    fn test_mdg_steers_every_heading_to_plain_atx() {
+        // MDG parses `#{1,6} ` headings only, so setext headings are corrected
+        // into ATX and closing sequences are dropped rather than preserved.
+        let cases = [
+            (
+                MD003HeadingStyle::new(HeadingStyle::Atx),
+                "Checkout\n========\n\n## Scenario: Buy an item\n",
+                "# Checkout\n\n## Scenario: Buy an item\n",
+            ),
+            (
+                MD003HeadingStyle::new(HeadingStyle::AtxClosed),
+                "# Feature: Checkout\n\n## Scenario: Buy an item ##\n",
+                "# Feature: Checkout\n\n## Scenario: Buy an item\n",
+            ),
+            (
+                MD003HeadingStyle::new(HeadingStyle::Setext1),
+                "# Feature: Checkout\n\nScenario: Documentation\n-----------------------\n",
+                "# Feature: Checkout\n\n## Scenario: Documentation\n",
+            ),
+            (
+                MD003HeadingStyle::default(),
+                "Checkout\n========\n\nGuide\n-----\n\n## Scenario: Buy an item\n",
+                "# Checkout\n\n## Guide\n\n## Scenario: Buy an item\n",
+            ),
+        ];
+
+        for (rule, content, expected) in cases {
+            let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+
+            assert!(!rule.should_skip(&mdg_ctx));
+            assert!(
+                !rule.check(&mdg_ctx).unwrap().is_empty(),
+                "MDG must still report non-ATX headings in {content:?}"
+            );
+            let fixed = rule.fix(&mdg_ctx).unwrap();
+            assert_eq!(fixed, expected, "MDG must steer {content:?} to plain ATX");
+
+            let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+            assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+            assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+        }
     }
 }

--- a/src/rules/md013_line_length.rs
+++ b/src/rules/md013_line_length.rs
@@ -50,6 +50,19 @@ struct CollectedBlockquoteLine {
     data: BlockquoteLineData,
 }
 
+/// A deliberately conservative MDG step candidate.
+///
+/// Gherkin keywords are localized, so recognizing the word after the marker is
+/// not reliable without the complete dialect table. MDG represents steps as
+/// unordered Markdown list items; withholding reflow from all such items in the
+/// flavor is safer than splitting a step and changing its Gherkin text.
+fn is_potential_mdg_step(ctx: &crate::lint_context::LintContext, line_num: usize) -> bool {
+    let Some(item) = ctx.list_item_on_line(line_num) else {
+        return false;
+    };
+    !item.is_ordered() && matches!(item.marker_char(), Some('*' | '-' | '+'))
+}
+
 impl MD013LineLength {
     pub fn new(line_length: usize, code_blocks: bool, tables: bool, headings: bool, strict: bool) -> Self {
         Self {
@@ -651,7 +664,14 @@ impl Rule for MD013LineLength {
         if effective_config.reflow {
             let paragraph_warnings = self.generate_paragraph_fixes(ctx, &effective_config, lines);
             // Merge paragraph warnings with line warnings, removing duplicates
-            for pw in paragraph_warnings {
+            for mut pw in paragraph_warnings {
+                if ctx.flavor == crate::config::MarkdownFlavor::MDG
+                    && (pw.line..=pw.end_line).any(|line_number| is_potential_mdg_step(ctx, line_number))
+                {
+                    // Keep reporting the excessive line, but do not offer a fix
+                    // whose replacement would split a Gherkin step across lines.
+                    pw.fix = None;
+                }
                 // Remove any line warnings that overlap with this paragraph
                 warnings.retain(|w| w.line < pw.line || w.line > pw.end_line);
                 warnings.push(pw);

--- a/src/rules/md013_line_length/tests.rs
+++ b/src/rules/md013_line_length/tests.rs
@@ -9748,3 +9748,56 @@ fn test_reflow_wraps_a_blockquoted_paragraph_holding_an_obsidian_wikilink() {
         "the wikilink must survive: {fixed:?}"
     );
 }
+
+#[test]
+fn test_mdg_reports_long_step_without_reflowing_it() {
+    let config = MD013Config {
+        line_length: crate::types::LineLength::from_const(50),
+        strict: true,
+        reflow: true,
+        ..Default::default()
+    };
+    let rule = MD013LineLength::from_config_struct(config);
+    let content = "* Given a customer with a completed order and an active account requests a detailed receipt\n";
+
+    let standard_ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+    let standard_warnings = rule.check(&standard_ctx).unwrap();
+    assert!(standard_warnings.iter().any(|warning| warning.fix.is_some()));
+    assert_ne!(rule.fix(&standard_ctx).unwrap(), content);
+
+    let mdg_ctx = LintContext::new(content, MarkdownFlavor::MDG, None);
+    let mdg_warnings = rule.check(&mdg_ctx).unwrap();
+    assert!(!mdg_warnings.is_empty(), "the long MDG step should still be reported");
+    assert!(
+        mdg_warnings.iter().all(|warning| warning.fix.is_none()),
+        "MDG step warnings must not offer destructive reflow: {mdg_warnings:?}"
+    );
+    let fixed = rule.fix(&mdg_ctx).unwrap();
+    assert_eq!(fixed, content);
+
+    let fixed_ctx = LintContext::new(&fixed, MarkdownFlavor::MDG, None);
+    assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+}
+
+#[test]
+fn test_mdg_preserves_all_unordered_step_markers() {
+    let config = MD013Config {
+        line_length: crate::types::LineLength::from_const(50),
+        strict: true,
+        reflow: true,
+        ..Default::default()
+    };
+    let rule = MD013LineLength::from_config_struct(config);
+
+    for marker in ['*', '-', '+'] {
+        let content = format!(
+            "{marker} Given a customer with a completed order and an active account requests a detailed receipt\n"
+        );
+        let ctx = LintContext::new(&content, MarkdownFlavor::MDG, None);
+
+        let warnings = rule.check(&ctx).unwrap();
+        assert!(!warnings.is_empty(), "long {marker}-marker step should be reported");
+        assert!(warnings.iter().all(|warning| warning.fix.is_none()));
+        assert_eq!(rule.fix(&ctx).unwrap(), content);
+    }
+}

--- a/src/rules/md022_blanks_around_headings.rs
+++ b/src/rules/md022_blanks_around_headings.rs
@@ -2200,21 +2200,31 @@ More content."#;
     }
 
     #[test]
-    fn test_mdg_tag_line_must_hold_only_tags() {
-        // MDG has no `#` comment syntax, so a trailing comment does not make a
-        // line a tag line for the purpose of this exemption.
+    fn test_mdg_tag_line_matches_gherkin_reference_scan() {
+        // The reference matcher scans for wrapped tags anywhere on the line,
+        // including the comment-bearing examples in Cucumber's own fixture.
         let rule = MD022BlanksAroundHeadings::default();
 
-        for above in ["`@browser` #a comment", "`@browser` and prose", "plain prose"] {
+        for above in [
+            "`@comment_tag1` #a comment",
+            "`@comment_tag#2` #a comment",
+            "`@browser` and prose",
+            "prose `@browser`",
+            "`@a b`",
+        ] {
             let content = format!("{above}\n# Feature: Checkout\n");
             let ctx = LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
-            assert!(
-                rule.check(&ctx)
-                    .unwrap()
-                    .iter()
-                    .any(|warning| warning.message.contains("above heading")),
-                "{above:?} must not be treated as a Gherkin tag line"
-            );
+            assert!(rule.check(&ctx).unwrap().is_empty(), "{above:?} is a Gherkin tag line");
+            assert_eq!(rule.fix(&ctx).unwrap(), content);
         }
+
+        let prose = "plain prose\n# Feature: Checkout\n";
+        let ctx = LintContext::new(prose, crate::config::MarkdownFlavor::MDG, None);
+        assert!(
+            rule.check(&ctx)
+                .unwrap()
+                .iter()
+                .any(|warning| warning.message.contains("above heading"))
+        );
     }
 }

--- a/src/rules/md022_blanks_around_headings.rs
+++ b/src/rules/md022_blanks_around_headings.rs
@@ -3,6 +3,7 @@ use crate::lint_context::is_horizontal_rule_content;
 ///
 /// See [docs/md022.md](../../docs/md022.md) for full documentation, configuration, and examples.
 use crate::rule::{Fix, LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::utils::mdg;
 use crate::utils::mkdocs_attr_list::is_block_attribute_line;
 use crate::utils::pandoc;
 use crate::utils::range_utils::calculate_heading_range;
@@ -41,6 +42,27 @@ fn starts_with_list_marker(trimmed: &str) -> bool {
         }
         _ => false,
     }
+}
+
+/// Whether the heading on `heading_idx` is a Gherkin structure annotated by the
+/// tag line directly above it.
+///
+/// A tag line binds to whatever follows it immediately, so a blank line
+/// inserted between the two detaches the tags. Above a document-leading tag
+/// line the inserted blank is parsed as the Feature line besides, collapsing
+/// the Feature into an unnamed node.
+///
+/// Gherkin tags attach to structures, and MDG spells every structure as a
+/// `Keyword: name` heading, so a heading that names none is ordinary prose that
+/// keeps the normal blank-line requirement.
+fn follows_mdg_tag_line(
+    ctx: &crate::lint_context::LintContext,
+    heading_idx: usize,
+    heading: &crate::lint_context::HeadingInfo,
+) -> bool {
+    heading_idx > 0
+        && mdg::keyword_split(&heading.text).is_some()
+        && mdg::is_tag_line(ctx.lines[heading_idx - 1].content(ctx.content))
 }
 
 ///
@@ -151,6 +173,7 @@ impl MD022BlanksAroundHeadings {
         let line_ending = "\n";
         let had_trailing_newline = ctx.content.ends_with('\n');
         let is_pandoc = ctx.flavor.is_pandoc_compatible();
+        let is_mdg = ctx.flavor == crate::config::MarkdownFlavor::MDG;
         let mut result = Vec::new();
         let mut skip_count: usize = 0;
 
@@ -246,7 +269,8 @@ impl MD022BlanksAroundHeadings {
 
                 // Determine how many blank lines we need above
                 let requirement_above = self.config.lines_above.get_for_level(heading_level);
-                let needed_blanks_above = if is_first_heading && self.config.allowed_at_start {
+                let follows_mdg_tags = is_mdg && follows_mdg_tag_line(ctx, i, heading);
+                let needed_blanks_above = if follows_mdg_tags || (is_first_heading && self.config.allowed_at_start) {
                     0
                 } else {
                     requirement_above.required_count().unwrap_or(0)
@@ -377,6 +401,7 @@ impl Rule for MD022BlanksAroundHeadings {
         // conform_fix_line_endings rewrites them for a CRLF document.
         let line_ending = "\n";
         let is_pandoc = ctx.flavor.is_pandoc_compatible();
+        let is_mdg = ctx.flavor == crate::config::MarkdownFlavor::MDG;
 
         let heading_at_start_idx = {
             let mut found_non_transparent = false;
@@ -442,8 +467,10 @@ impl Rule for MD022BlanksAroundHeadings {
             let required_below_count = self.config.lines_below.get_for_level(heading_level).required_count();
 
             // Count blank lines above if needed
-            let should_check_above =
-                required_above_count.is_some() && line_num > 0 && (!is_first_heading || !self.config.allowed_at_start);
+            let should_check_above = required_above_count.is_some()
+                && line_num > 0
+                && (!is_first_heading || !self.config.allowed_at_start)
+                && !(is_mdg && follows_mdg_tag_line(ctx, line_num, heading));
             if should_check_above {
                 let mut blank_lines_above = 0;
                 let mut hit_frontmatter_end = false;
@@ -2105,5 +2132,89 @@ More content."#;
             warnings_std.iter().any(|w| w.message.contains("below heading")),
             "MD022 must flag the missing blank below the heading under Standard: {warnings_std:?}"
         );
+    }
+
+    #[test]
+    fn test_mdg_keeps_tags_attached_only_to_structure_headings() {
+        let rule = MD022BlanksAroundHeadings::default();
+
+        // A `Keyword: name` heading is a Gherkin structure, so its tag line stays attached.
+        let attached = "`@browser`\n`@checkout` `@smoke`\n# Feature: Checkout\n";
+        let mdg_ctx = LintContext::new(attached, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&mdg_ctx).unwrap().is_empty());
+        let fixed = rule.fix(&mdg_ctx).unwrap();
+        assert_eq!(fixed, attached);
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+
+        let standard_ctx = LintContext::new(attached, crate::config::MarkdownFlavor::Standard, None);
+        assert!(
+            rule.check(&standard_ctx)
+                .unwrap()
+                .iter()
+                .any(|warning| warning.message.contains("above heading"))
+        );
+    }
+
+    #[test]
+    fn test_mdg_requires_blank_line_above_a_non_structure_heading() {
+        // Without a colon the heading is ordinary prose, so the exemption must
+        // not apply even though the line above looks like a tag line.
+        let rule = MD022BlanksAroundHeadings::default();
+        let content = "`@browser`\n# Notes\n";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+
+        assert!(
+            rule.check(&ctx)
+                .unwrap()
+                .iter()
+                .any(|warning| warning.message.contains("above heading")),
+            "a non-Gherkin heading keeps the normal requirement"
+        );
+        assert_eq!(rule.fix(&ctx).unwrap(), "`@browser`\n\n# Notes\n");
+    }
+
+    #[test]
+    fn test_mdg_colon_inside_a_code_span_names_no_structure() {
+        // A keyword is a plain dialect term, so a colon behind a backtick sits
+        // inside a code span and names nothing. MD063 already read it that way;
+        // MD022 now shares the split so the two cannot drift apart.
+        let rule = MD022BlanksAroundHeadings::default();
+        let content = "`@browser`\n# See `x: y` Notes\n";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+
+        assert!(
+            rule.check(&ctx)
+                .unwrap()
+                .iter()
+                .any(|warning| warning.message.contains("above heading")),
+            "the code span holds the only colon, so the heading is ordinary prose"
+        );
+        assert_eq!(rule.fix(&ctx).unwrap(), "`@browser`\n\n# See `x: y` Notes\n");
+
+        // A colon outside the span still names a structure, backtick or not.
+        let structure = "`@browser`\n# Scenario: use `a: b` here\n";
+        let structure_ctx = LintContext::new(structure, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&structure_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&structure_ctx).unwrap(), structure);
+    }
+
+    #[test]
+    fn test_mdg_tag_line_must_hold_only_tags() {
+        // MDG has no `#` comment syntax, so a trailing comment does not make a
+        // line a tag line for the purpose of this exemption.
+        let rule = MD022BlanksAroundHeadings::default();
+
+        for above in ["`@browser` #a comment", "`@browser` and prose", "plain prose"] {
+            let content = format!("{above}\n# Feature: Checkout\n");
+            let ctx = LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
+            assert!(
+                rule.check(&ctx)
+                    .unwrap()
+                    .iter()
+                    .any(|warning| warning.message.contains("above heading")),
+                "{above:?} must not be treated as a Gherkin tag line"
+            );
+        }
     }
 }

--- a/src/rules/md024_no_duplicate_heading.rs
+++ b/src/rules/md024_no_duplicate_heading.rs
@@ -1126,4 +1126,37 @@ All same text, different levels."#;
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].message, "Duplicate heading: 'Foo#bar'.");
     }
+
+    #[test]
+    fn test_mdg_flags_repeated_structural_headings() {
+        // Every MDG keyword accepts a name after the colon, so a duplicate
+        // heading is always avoidable while staying valid Gherkin. MD024 must
+        // therefore keep enforcing uniqueness under this flavor.
+        let rule = MD024NoDuplicateHeading::default();
+        let content = "# Feature: Checkout\n\n## Scenario: Purchase\n\n## Scenario: Purchase\n\n#### Examples:\n\n#### Examples:\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        let warnings = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(warnings.len(), 2, "MDG duplicates must be reported: {warnings:?}");
+        assert_eq!(warnings[0].message, "Duplicate heading: 'Scenario: Purchase'.");
+        assert_eq!(warnings[1].message, "Duplicate heading: 'Examples:'.");
+
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(
+            rule.check(&standard_ctx).unwrap().len(),
+            warnings.len(),
+            "MDG must not differ from Standard"
+        );
+    }
+
+    #[test]
+    fn test_mdg_accepts_uniquely_named_structural_headings() {
+        // `Examples: valid cards` keeps the Examples keyword and gains a name,
+        // so naming the blocks resolves the duplication without losing nodes.
+        let rule = MD024NoDuplicateHeading::default();
+        let content = "# Feature: Checkout\n\n## Scenario Outline: Purchase\n\n#### Examples: valid cards\n\n#### Examples: expired cards\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&mdg_ctx).unwrap().is_empty());
+    }
 }

--- a/src/rules/md025_single_title.rs
+++ b/src/rules/md025_single_title.rs
@@ -1015,4 +1015,32 @@ mod tests {
             assert!(result.is_empty(), "Should allow section indicator heading: {case}");
         }
     }
+
+    #[test]
+    fn test_mdg_enforces_single_title() {
+        // Heading levels carry no meaning in the Gherkin AST, so demoting an
+        // extra H1 keeps the document valid and MD025 stays enforced.
+        let rule = MD025SingleTitle::strict();
+        let content = "# Feature: Checkout\n\n# Rule: Registered customers\n\n# Scenario: Purchase\n";
+
+        let standard_ctx =
+            crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let mdg_ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+
+        assert_eq!(rule.check(&mdg_ctx).unwrap().len(), 2);
+        assert_eq!(
+            rule.check(&mdg_ctx).unwrap().len(),
+            rule.check(&standard_ctx).unwrap().len(),
+            "MDG must not differ from Standard"
+        );
+
+        let fixed = rule.fix(&mdg_ctx).unwrap();
+        assert_eq!(
+            fixed, "# Feature: Checkout\n\n## Rule: Registered customers\n\n## Scenario: Purchase\n",
+            "the Gherkin keywords must survive the demotion"
+        );
+
+        let fixed_ctx = crate::lint_context::LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+    }
 }

--- a/src/rules/md026_no_trailing_punctuation.rs
+++ b/src/rules/md026_no_trailing_punctuation.rs
@@ -7,6 +7,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 mod md026_config;
 use md026_config::{DEFAULT_PUNCTUATION, MD026Config};
@@ -24,41 +25,101 @@ static PUNCTUATION_REGEX_CACHE: LazyLock<RwLock<HashMap<String, Regex>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Rule MD026: Trailing punctuation in heading
-#[derive(Clone, Default)]
 pub struct MD026NoTrailingPunctuation {
     config: MD026Config,
+    // A Gherkin structure is an ATX heading spelled `Keyword: name`, so the colon after the
+    // keyword is what makes the keyword a keyword. Dropping it from the punctuation set for
+    // that flavor keeps the rule from ever deleting it, however `punctuation` is configured.
+    mdg_punctuation: String,
+    // Whether the colon the Gherkin flavor drops was asked for rather than inherited from
+    // the default.
+    colon_configured_explicitly: bool,
+    colon_override_reported: AtomicBool,
+}
+
+impl Clone for MD026NoTrailingPunctuation {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            mdg_punctuation: self.mdg_punctuation.clone(),
+            colon_configured_explicitly: self.colon_configured_explicitly,
+            colon_override_reported: AtomicBool::new(self.colon_override_reported.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl Default for MD026NoTrailingPunctuation {
+    fn default() -> Self {
+        Self::new(None)
+    }
 }
 
 impl MD026NoTrailingPunctuation {
     pub fn new(punctuation: Option<String>) -> Self {
-        Self {
-            config: MD026Config {
+        let explicit = punctuation.is_some();
+        Self::build(
+            MD026Config {
                 punctuation: punctuation.unwrap_or_else(|| DEFAULT_PUNCTUATION.to_string()),
             },
-        }
+            explicit,
+        )
     }
 
     pub fn from_config_struct(config: MD026Config) -> Self {
-        Self { config }
+        Self::build(config, false)
+    }
+
+    fn build(config: MD026Config, punctuation_explicit: bool) -> Self {
+        let colon_configured_explicitly = punctuation_explicit && config.punctuation.contains(':');
+        let mdg_punctuation = config.punctuation.replace(':', "");
+
+        Self {
+            config,
+            mdg_punctuation,
+            colon_configured_explicitly,
+            colon_override_reported: AtomicBool::new(false),
+        }
+    }
+
+    /// The punctuation set the flavor actually enforces.
+    #[inline]
+    fn effective_punctuation(&self, flavor: crate::config::MarkdownFlavor) -> &str {
+        if flavor == crate::config::MarkdownFlavor::MDG {
+            &self.mdg_punctuation
+        } else {
+            &self.config.punctuation
+        }
+    }
+
+    /// Whether this call owns reporting that the Gherkin flavor dropped an explicitly
+    /// configured colon.
+    ///
+    /// The flavor is detected per file, so the override cannot be reported from
+    /// `from_config` the way other rules do; it is claimed by the first Gherkin document
+    /// that reaches the rule, and every later one stays quiet.
+    fn claim_mdg_colon_override_report(&self, flavor: crate::config::MarkdownFlavor) -> bool {
+        flavor == crate::config::MarkdownFlavor::MDG
+            && self.colon_configured_explicitly
+            && !self.colon_override_reported.swap(true, Ordering::Relaxed)
     }
 
     #[inline]
-    fn get_punctuation_regex(&self) -> Result<Regex, regex::Error> {
+    fn get_punctuation_regex(&self, punctuation: &str) -> Result<Regex, regex::Error> {
         // Check cache first
         {
             let cache = PUNCTUATION_REGEX_CACHE.read().unwrap();
-            if let Some(cached_regex) = cache.get(&self.config.punctuation) {
+            if let Some(cached_regex) = cache.get(punctuation) {
                 return Ok(cached_regex.clone());
             }
         }
 
         // Compile and cache the regex
-        let pattern = format!(r"([{}]+)$", regex::escape(&self.config.punctuation));
+        let pattern = format!(r"([{}]+)$", regex::escape(punctuation));
         let regex = Regex::new(&pattern)?;
 
         {
             let mut cache = PUNCTUATION_REGEX_CACHE.write().unwrap();
-            cache.insert(self.config.punctuation.clone(), regex.clone());
+            cache.insert(punctuation.to_string(), regex.clone());
         }
 
         Ok(regex)
@@ -175,12 +236,22 @@ impl Rule for MD026NoTrailingPunctuation {
             return true;
         }
         // Skip if none of the configured punctuation exists
-        let punctuation = &self.config.punctuation;
+        let punctuation = self.effective_punctuation(ctx.flavor);
         !punctuation.chars().any(|p| ctx.content.contains(p))
     }
 
     fn check(&self, ctx: &crate::lint_context::LintContext) -> LintResult {
         let content = ctx.content;
+        let punctuation = self.effective_punctuation(ctx.flavor);
+
+        if self.claim_mdg_colon_override_report(ctx.flavor) {
+            eprintln!(
+                "\x1b[33m[config warning]\x1b[0m MD026: Markdown with Gherkin flavor requires the ASCII colon \
+                 to stay in headings (a Gherkin structure is spelled `Keyword: name`). \
+                 Overriding punctuation=\"{}\" to punctuation=\"{}\".",
+                self.config.punctuation, self.mdg_punctuation
+            );
+        }
 
         // Early returns for performance
         if content.is_empty() {
@@ -189,13 +260,13 @@ impl Rule for MD026NoTrailingPunctuation {
 
         // Quick check for any punctuation we care about
         // For custom punctuation, we need to check differently
-        if self.config.punctuation == DEFAULT_PUNCTUATION {
+        if punctuation == DEFAULT_PUNCTUATION {
             if !QUICK_PUNCTUATION_CHECK.is_match(content) {
                 return Ok(Vec::new());
             }
         } else {
             // For custom punctuation, check if any of those characters exist
-            let has_custom_punctuation = self.config.punctuation.chars().any(|c| content.contains(c));
+            let has_custom_punctuation = punctuation.chars().any(|c| content.contains(c));
             if !has_custom_punctuation {
                 return Ok(Vec::new());
             }
@@ -208,7 +279,7 @@ impl Rule for MD026NoTrailingPunctuation {
         }
 
         let mut warnings = Vec::new();
-        let Ok(re) = self.get_punctuation_regex() else {
+        let Ok(re) = self.get_punctuation_regex(punctuation) else {
             return Ok(warnings);
         };
 
@@ -228,11 +299,11 @@ impl Rule for MD026NoTrailingPunctuation {
                 // LintContext already strips Kramdown IDs from heading.text
                 // So we just check the heading text directly for trailing punctuation
                 // This correctly flags "# Heading." even if it has {#id}
-                let text_to_check = heading.text.clone();
+                let text_to_check = heading.text.as_str();
 
-                if self.has_trailing_punctuation(&text_to_check, &re) {
+                if self.has_trailing_punctuation(text_to_check, &re) {
                     // Find the trailing punctuation
-                    if let Some(punctuation_match) = re.find(&text_to_check) {
+                    if let Some(punctuation_match) = re.find(text_to_check) {
                         let line = line_info.content(ctx.content);
 
                         // For ATX headings, find the punctuation position in the line
@@ -292,7 +363,23 @@ impl Rule for MD026NoTrailingPunctuation {
         self
     }
 
-    crate::impl_rule_config_methods!(MD026Config);
+    crate::impl_rule_config_sections!(MD026Config);
+
+    fn from_config(config: &crate::config::Config) -> Box<dyn Rule>
+    where
+        Self: Sized,
+    {
+        let rule_config = crate::rule_config_serde::load_rule_config::<MD026Config>(config);
+
+        // Check if punctuation was explicitly set in the config; the Gherkin flavor drops
+        // the colon from it, and an override the user asked for is worth reporting.
+        let punctuation_explicit = config
+            .rules
+            .get("MD026")
+            .is_some_and(|rule_cfg| rule_cfg.values.contains_key("punctuation"));
+
+        Box::new(Self::build(rule_config, punctuation_explicit))
+    }
 }
 
 #[cfg(test)]
@@ -462,7 +549,7 @@ mod tests {
     #[test]
     fn test_get_punctuation_regex() {
         let rule = MD026NoTrailingPunctuation::new(Some("!?".to_string()));
-        let regex = rule.get_punctuation_regex().unwrap();
+        let regex = rule.get_punctuation_regex(&rule.config.punctuation).unwrap();
         assert!(regex.is_match("text!"));
         assert!(regex.is_match("text?"));
         assert!(!regex.is_match("text."));
@@ -474,8 +561,8 @@ mod tests {
         let rule2 = MD026NoTrailingPunctuation::new(Some("!".to_string()));
 
         // Both should get the same cached regex
-        let _regex1 = rule1.get_punctuation_regex().unwrap();
-        let _regex2 = rule2.get_punctuation_regex().unwrap();
+        let _regex1 = rule1.get_punctuation_regex(&rule1.config.punctuation).unwrap();
+        let _regex2 = rule2.get_punctuation_regex(&rule2.config.punctuation).unwrap();
 
         // Check cache has the entry
         let cache = PUNCTUATION_REGEX_CACHE.read().unwrap();
@@ -520,5 +607,176 @@ mod tests {
         let ctx2 = LintContext::new(content_no_newline, crate::config::MarkdownFlavor::Standard, None);
         let fixed2 = rule.fix(&ctx2).unwrap();
         assert_eq!(fixed2, "# Title");
+    }
+
+    /// The whole MDG matrix in one place, against the Standard behavior it departs from.
+    ///
+    /// The rule's pattern is `([<punctuation>]+)$`, so taking the colon out of the set is
+    /// the entire flavor difference: no heading whose last character is a colon can match
+    /// any more, and `## Scenario!:` is left exactly as its author wrote it.
+    #[test]
+    fn test_mdg_punctuation_matrix() {
+        let rule = MD026NoTrailingPunctuation::new(None);
+        // (input, standard warnings, standard fix, MDG warnings, MDG fix)
+        let cases = [
+            ("## Notes:\n", 1, "## Notes\n", 0, "## Notes:\n"),
+            ("## Scenario!:\n", 1, "## Scenario\n", 0, "## Scenario!:\n"),
+            ("# Scenario! :\n", 1, "# Scenario\n", 0, "# Scenario! :\n"),
+            ("## Scenario!\n", 1, "## Scenario\n", 1, "## Scenario\n"),
+            ("## Notes::\n", 1, "## Notes\n", 0, "## Notes::\n"),
+            (
+                "# Feature: Checkout:\n",
+                1,
+                "# Feature: Checkout\n",
+                0,
+                "# Feature: Checkout:\n",
+            ),
+            ("### Rule.:\n", 1, "### Rule\n", 0, "### Rule.:\n"),
+        ];
+
+        for (input, standard_count, standard_fixed, mdg_count, mdg_fixed) in cases {
+            for (flavor, count, expected) in [
+                (crate::config::MarkdownFlavor::Standard, standard_count, standard_fixed),
+                (crate::config::MarkdownFlavor::MDG, mdg_count, mdg_fixed),
+            ] {
+                let ctx = LintContext::new(input, flavor, None);
+                assert_eq!(
+                    rule.check(&ctx).unwrap().len(),
+                    count,
+                    "{flavor:?} warning count for {input:?}"
+                );
+
+                let fixed = rule.fix(&ctx).unwrap();
+                assert_eq!(fixed, expected, "{flavor:?} fix for {input:?}");
+
+                let fixed_ctx = LintContext::new(&fixed, flavor, None);
+                assert!(
+                    rule.check(&fixed_ctx).unwrap().is_empty(),
+                    "{flavor:?} left a warning on the fixed {input:?}"
+                );
+                assert_eq!(
+                    rule.fix(&fixed_ctx).unwrap(),
+                    fixed,
+                    "{flavor:?} fix for {input:?} should be idempotent"
+                );
+            }
+        }
+    }
+
+    /// The colon leaves the effective set whatever `punctuation` says, so a future change
+    /// to the default cannot put it back; only an explicit setting is worth reporting.
+    #[test]
+    fn test_mdg_reports_an_explicitly_configured_colon_once() {
+        fn configured(punctuation: &str) -> MD026NoTrailingPunctuation {
+            let mut config = crate::config::Config::default();
+            let mut rule_config = crate::config::RuleConfig::default();
+            rule_config
+                .values
+                .insert("punctuation".to_string(), toml::Value::String(punctuation.to_string()));
+            config.rules.insert("MD026".to_string(), rule_config);
+
+            MD026NoTrailingPunctuation::from_config(&config)
+                .as_any()
+                .downcast_ref::<MD026NoTrailingPunctuation>()
+                .expect("MD026::from_config builds an MD026NoTrailingPunctuation")
+                .clone()
+        }
+
+        let explicit = configured(".,;:!");
+        assert_eq!(
+            explicit.effective_punctuation(crate::config::MarkdownFlavor::Standard),
+            ".,;:!"
+        );
+        assert_eq!(
+            explicit.effective_punctuation(crate::config::MarkdownFlavor::MDG),
+            ".,;!"
+        );
+        assert!(
+            !explicit.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::Standard),
+            "a non-Gherkin file never reports the override"
+        );
+        assert!(explicit.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG));
+        assert!(
+            !explicit.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
+            "the override is reported at most once"
+        );
+
+        let emitted_by_check = configured(".,;:!");
+        let ctx = LintContext::new("## Scenario!\n", crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(emitted_by_check.check(&ctx).unwrap().len(), 1);
+        assert!(
+            !emitted_by_check.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
+            "checking a Gherkin file is what emits the warning"
+        );
+
+        let explicit_without_colon = configured(".,;!");
+        assert!(
+            !explicit_without_colon.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
+            "nothing is overridden when the configured set has no colon"
+        );
+
+        let default = MD026NoTrailingPunctuation::new(None);
+        assert_eq!(
+            default.effective_punctuation(crate::config::MarkdownFlavor::MDG),
+            ".,;!",
+            "the colon leaves the default set too"
+        );
+        assert!(
+            !default.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
+            "the default set is not an explicit configuration, so it is silent"
+        );
+    }
+
+    #[test]
+    fn test_mdg_exempts_a_lone_colon_behind_whitespace() {
+        // The colon is not punctuation under MDG, and it is the last character here, so
+        // there is nothing for the `$`-anchored pattern to match. Standard still strips it,
+        // keeping the whitespace that preceded it.
+        let rule = MD026NoTrailingPunctuation::new(None);
+        let content = "# Scenario :\n## Notes:\n";
+
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let standard = rule.check(&standard_ctx).unwrap();
+        assert_eq!(standard.len(), 2);
+        assert_eq!((standard[0].line, standard[0].column), (1, 12));
+        assert_eq!((standard[1].line, standard[1].column), (2, 9));
+        let standard_fixed = rule.fix(&standard_ctx).unwrap();
+        assert_eq!(standard_fixed, "# Scenario \n## Notes\n");
+        let standard_fixed_ctx = LintContext::new(&standard_fixed, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(
+            rule.fix(&standard_fixed_ctx).unwrap(),
+            standard_fixed,
+            "Standard fix should be idempotent"
+        );
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&mdg_ctx).unwrap().is_empty());
+        assert_eq!(
+            rule.fix(&mdg_ctx).unwrap(),
+            content,
+            "MDG leaves headings whose only trailing punctuation is the colon untouched"
+        );
+    }
+
+    #[test]
+    fn test_mdg_does_not_exempt_a_full_width_colon() {
+        // Gherkin only recognizes the ASCII colon, so a full-width one carries
+        // no structural meaning and stays in the punctuation set.
+        let rule = MD026NoTrailingPunctuation::new(Some(".,;:!?：".to_string()));
+        assert_eq!(
+            rule.effective_punctuation(crate::config::MarkdownFlavor::MDG),
+            ".,;!?：",
+            "only the ASCII colon leaves the set"
+        );
+
+        let content = "## Scenario：\n";
+        for flavor in [
+            crate::config::MarkdownFlavor::MDG,
+            crate::config::MarkdownFlavor::Standard,
+        ] {
+            let ctx = LintContext::new(content, flavor, None);
+            assert_eq!(rule.check(&ctx).unwrap().len(), 1, "{flavor:?} must flag the `：`");
+            assert_eq!(rule.fix(&ctx).unwrap(), "## Scenario\n");
+        }
     }
 }

--- a/src/rules/md026_no_trailing_punctuation.rs
+++ b/src/rules/md026_no_trailing_punctuation.rs
@@ -2,12 +2,12 @@
 ///
 /// See [docs/md026.md](../../docs/md026.md) for full documentation, configuration, and examples.
 use crate::rule::{Fix, LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::rule_config_serde::FlavorOverrideNotice;
 use crate::utils::range_utils::calculate_match_range;
 use regex::Regex;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 mod md026_config;
 use md026_config::{DEFAULT_PUNCTUATION, MD026Config};
@@ -24,7 +24,11 @@ static QUICK_PUNCTUATION_CHECK: LazyLock<Regex> =
 static PUNCTUATION_REGEX_CACHE: LazyLock<RwLock<HashMap<String, Regex>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// Reports the MDG punctuation override once per process, across every config group.
+static MDG_PUNCTUATION_OVERRIDE: FlavorOverrideNotice = FlavorOverrideNotice::new();
+
 /// Rule MD026: Trailing punctuation in heading
+#[derive(Clone)]
 pub struct MD026NoTrailingPunctuation {
     config: MD026Config,
     // A Gherkin structure is an ATX heading spelled `Keyword: name`, so the colon after the
@@ -34,18 +38,6 @@ pub struct MD026NoTrailingPunctuation {
     // Whether the colon the Gherkin flavor drops was asked for rather than inherited from
     // the default.
     colon_configured_explicitly: bool,
-    colon_override_reported: AtomicBool,
-}
-
-impl Clone for MD026NoTrailingPunctuation {
-    fn clone(&self) -> Self {
-        Self {
-            config: self.config.clone(),
-            mdg_punctuation: self.mdg_punctuation.clone(),
-            colon_configured_explicitly: self.colon_configured_explicitly,
-            colon_override_reported: AtomicBool::new(self.colon_override_reported.load(Ordering::Relaxed)),
-        }
-    }
 }
 
 impl Default for MD026NoTrailingPunctuation {
@@ -77,7 +69,6 @@ impl MD026NoTrailingPunctuation {
             config,
             mdg_punctuation,
             colon_configured_explicitly,
-            colon_override_reported: AtomicBool::new(false),
         }
     }
 
@@ -91,16 +82,25 @@ impl MD026NoTrailingPunctuation {
         }
     }
 
-    /// Whether this call owns reporting that the Gherkin flavor dropped an explicitly
-    /// configured colon.
-    ///
-    /// The flavor is detected per file, so the override cannot be reported from
-    /// `from_config` the way other rules do; it is claimed by the first Gherkin document
-    /// that reaches the rule, and every later one stays quiet.
-    fn claim_mdg_colon_override_report(&self, flavor: crate::config::MarkdownFlavor) -> bool {
-        flavor == crate::config::MarkdownFlavor::MDG
-            && self.colon_configured_explicitly
-            && !self.colon_override_reported.swap(true, Ordering::Relaxed)
+    /// Whether MDG is overriding a colon that came from explicit configuration.
+    fn mdg_colon_override_applies(&self, flavor: crate::config::MarkdownFlavor) -> bool {
+        flavor == crate::config::MarkdownFlavor::MDG && self.colon_configured_explicitly
+    }
+
+    /// Report the effective punctuation override before any content-based
+    /// shortcut can skip this rule. Direct `check` callers also pass through
+    /// here; the shared notice keeps it process-local and one-shot even when a
+    /// run creates separate rule instances for multiple config groups.
+    fn warn_once_about_mdg_colon_override(&self, flavor: crate::config::MarkdownFlavor) {
+        if self.mdg_colon_override_applies(flavor) {
+            MDG_PUNCTUATION_OVERRIDE.report(
+                "MD026",
+                "punctuation",
+                &self.config.punctuation,
+                &self.mdg_punctuation,
+                "the ASCII colon after a Gherkin keyword is structural",
+            );
+        }
     }
 
     #[inline]
@@ -231,6 +231,8 @@ impl Rule for MD026NoTrailingPunctuation {
     }
 
     fn should_skip(&self, ctx: &crate::lint_context::LintContext) -> bool {
+        self.warn_once_about_mdg_colon_override(ctx.flavor);
+
         // Skip if no heading markers
         if !ctx.likely_has_headings() {
             return true;
@@ -244,14 +246,7 @@ impl Rule for MD026NoTrailingPunctuation {
         let content = ctx.content;
         let punctuation = self.effective_punctuation(ctx.flavor);
 
-        if self.claim_mdg_colon_override_report(ctx.flavor) {
-            eprintln!(
-                "\x1b[33m[config warning]\x1b[0m MD026: Markdown with Gherkin flavor requires the ASCII colon \
-                 to stay in headings (a Gherkin structure is spelled `Keyword: name`). \
-                 Overriding punctuation=\"{}\" to punctuation=\"{}\".",
-                self.config.punctuation, self.mdg_punctuation
-            );
-        }
+        self.warn_once_about_mdg_colon_override(ctx.flavor);
 
         // Early returns for performance
         if content.is_empty() {
@@ -692,26 +687,25 @@ mod tests {
             ".,;!"
         );
         assert!(
-            !explicit.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::Standard),
+            !explicit.mdg_colon_override_applies(crate::config::MarkdownFlavor::Standard),
             "a non-Gherkin file never reports the override"
         );
-        assert!(explicit.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG));
-        assert!(
-            !explicit.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
-            "the override is reported at most once"
-        );
+        assert!(explicit.mdg_colon_override_applies(crate::config::MarkdownFlavor::MDG));
 
         let emitted_by_check = configured(".,;:!");
         let ctx = LintContext::new("## Scenario!\n", crate::config::MarkdownFlavor::MDG, None);
         assert_eq!(emitted_by_check.check(&ctx).unwrap().len(), 1);
+
+        let emitted_before_skip = configured(".,;:!");
+        let only_protected_punctuation = LintContext::new("#### Examples:\n", crate::config::MarkdownFlavor::MDG, None);
         assert!(
-            !emitted_by_check.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
-            "checking a Gherkin file is what emits the warning"
+            emitted_before_skip.should_skip(&only_protected_punctuation),
+            "the post-override punctuation set has nothing to inspect"
         );
 
         let explicit_without_colon = configured(".,;!");
         assert!(
-            !explicit_without_colon.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
+            !explicit_without_colon.mdg_colon_override_applies(crate::config::MarkdownFlavor::MDG),
             "nothing is overridden when the configured set has no colon"
         );
 
@@ -722,7 +716,7 @@ mod tests {
             "the colon leaves the default set too"
         );
         assert!(
-            !default.claim_mdg_colon_override_report(crate::config::MarkdownFlavor::MDG),
+            !default.mdg_colon_override_applies(crate::config::MarkdownFlavor::MDG),
             "the default set is not an explicit configuration, so it is silent"
         );
     }

--- a/src/rules/md034_no_bare_urls.rs
+++ b/src/rules/md034_no_bare_urls.rs
@@ -347,7 +347,13 @@ impl MD034NoBareUrls {
                     column: start_col,
                     end_line,
                     end_column: end_col,
-                    message: format!("URL without angle brackets or link formatting: '{trimmed_url}'"),
+                    message: if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+                        format!(
+                            "URL without link formatting: '{trimmed_url}' (angle brackets are Gherkin placeholder syntax; use explicit link formatting where appropriate, or disable MD034)"
+                        )
+                    } else {
+                        format!("URL without angle brackets or link formatting: '{trimmed_url}'")
+                    },
                     severity: Severity::Warning,
                     fix: Some(Fix::new(
                         {
@@ -421,7 +427,13 @@ impl MD034NoBareUrls {
                             column: start_col,
                             end_line,
                             end_column: end_col,
-                            message: format!("Email address without angle brackets or link formatting: '{email}'"),
+                            message: if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+                                format!(
+                                    "Email address without link formatting: '{email}' (angle brackets are Gherkin placeholder syntax; use explicit link formatting where appropriate, or disable MD034)"
+                                )
+                            } else {
+                                format!("Email address without angle brackets or link formatting: '{email}'")
+                            },
                             severity: Severity::Warning,
                             fix: Some(Fix::new(
                                 (line_start_byte + start)..(line_start_byte + end),
@@ -459,14 +471,15 @@ impl Rule for MD034NoBareUrls {
         RuleCategory::Link
     }
 
+    fn skippable_by_category(&self) -> bool {
+        // Bare email addresses and `xmpp:` URIs are MD034 findings, but the
+        // document-wide Link prefilter deliberately recognizes only Markdown
+        // links and common URL forms. Let MD034's own cheap `should_skip`
+        // predicate decide so email/XMPP-only documents are still checked.
+        false
+    }
+
     fn should_skip(&self, ctx: &crate::lint_context::LintContext) -> bool {
-        // `<...>` is Gherkin placeholder syntax, substituted from `Examples` data, so the
-        // autolink this rule asks for carries meaning in a Gherkin document no matter which
-        // line it lands on: a URL wrapped in angle brackets anywhere in the tree's text
-        // silently becomes a placeholder. The rule has nothing safe to say about MDG.
-        if ctx.flavor == crate::config::MarkdownFlavor::MDG {
-            return true;
-        }
         !ctx.likely_has_links_or_images() && self.should_skip_content(ctx.content)
     }
 
@@ -481,12 +494,6 @@ impl Rule for MD034NoBareUrls {
 
         // Quick skip for content without URLs
         if self.should_skip_content(content) {
-            return Ok(warnings);
-        }
-
-        // `fix` reaches `check` directly instead of consulting `should_skip`, so the flavor
-        // exemption has to be honoured here as well.
-        if ctx.flavor == crate::config::MarkdownFlavor::MDG {
             return Ok(warnings);
         }
 
@@ -563,6 +570,15 @@ impl Rule for MD034NoBareUrls {
             line_warnings.retain(|warning| !ctx.is_position_in_obsidian_comment(warning.line, warning.column));
 
             warnings.extend(line_warnings);
+        }
+
+        // The generated ranges are needed by the filters above. Strip fixes only
+        // after filtering: under MDG `<...>` is placeholder syntax, so the
+        // standard automatic correction is not semantics-preserving.
+        if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+            for warning in &mut warnings {
+                warning.fix = None;
+            }
         }
 
         Ok(warnings)
@@ -1040,13 +1056,10 @@ Some trailing content with no closing fence.
         assert!(result2[0].message.contains("bare.com"));
     }
 
-    /// `<...>` is Gherkin placeholder syntax, substituted from `Examples` data: an
-    /// `Examples` column named `https://example.com` turns `Given I go to
-    /// <https://example.com>` into that column's value. The autolink this rule asks for
-    /// therefore carries meaning anywhere in a `.feature.md`, prose included, so the rule
-    /// is disabled wholesale for the flavor.
+    /// `<...>` is Gherkin placeholder syntax, substituted from `Examples` data. MD034
+    /// still reports bare URLs under MDG, but withholds that unsafe automatic fix.
     #[test]
-    fn test_mdg_disables_the_rule_entirely() {
+    fn test_mdg_reports_bare_urls_without_fixing_them() {
         let rule = MD034NoBareUrls;
         let content = "\
 # Feature: Visit https://feature.example.com
@@ -1084,13 +1097,30 @@ Prose about https://prose.example.com for background.
         );
 
         let mdg_ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
-        assert!(rule.should_skip(&mdg_ctx), "MDG must not even reach the line scan");
+        assert!(!rule.should_skip(&mdg_ctx), "MDG must still run the diagnostic");
         let mdg = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(mdg.iter().map(|w| w.line).collect::<Vec<_>>(), standard_lines);
+        assert!(mdg.iter().all(|warning| warning.fix.is_none()));
         assert!(
-            mdg.is_empty(),
-            "MDG must flag nothing, not even prose or a blockquoted step: {mdg:?}"
+            mdg.iter()
+                .all(|warning| warning.message.contains("Gherkin placeholder"))
         );
+        assert!(mdg.iter().all(|warning| warning.message.contains("disable MD034")));
         assert_eq!(rule.fix(&mdg_ctx).unwrap(), content, "MDG must rewrite nothing");
+    }
+
+    #[test]
+    fn test_mdg_reports_bare_email_without_fixing_it() {
+        let rule = MD034NoBareUrls;
+        let content = "# Feature: Contact\n\n* Given I email user@example.com\n";
+        let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+
+        let warnings = rule.check(&ctx).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("Gherkin placeholder"));
+        assert!(warnings[0].message.contains("disable MD034"));
+        assert!(warnings[0].fix.is_none());
+        assert_eq!(rule.fix(&ctx).unwrap(), content);
     }
 
     /// The exemption is confined to MDG: every other flavor still rewrites the same

--- a/src/rules/md034_no_bare_urls.rs
+++ b/src/rules/md034_no_bare_urls.rs
@@ -460,6 +460,13 @@ impl Rule for MD034NoBareUrls {
     }
 
     fn should_skip(&self, ctx: &crate::lint_context::LintContext) -> bool {
+        // `<...>` is Gherkin placeholder syntax, substituted from `Examples` data, so the
+        // autolink this rule asks for carries meaning in a Gherkin document no matter which
+        // line it lands on: a URL wrapped in angle brackets anywhere in the tree's text
+        // silently becomes a placeholder. The rule has nothing safe to say about MDG.
+        if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+            return true;
+        }
         !ctx.likely_has_links_or_images() && self.should_skip_content(ctx.content)
     }
 
@@ -474,6 +481,12 @@ impl Rule for MD034NoBareUrls {
 
         // Quick skip for content without URLs
         if self.should_skip_content(content) {
+            return Ok(warnings);
+        }
+
+        // `fix` reaches `check` directly instead of consulting `should_skip`, so the flavor
+        // exemption has to be honoured here as well.
+        if ctx.flavor == crate::config::MarkdownFlavor::MDG {
             return Ok(warnings);
         }
 
@@ -1025,5 +1038,120 @@ Some trailing content with no closing fence.
             "Should flag exactly 1 URL (the bare one): {result2:?}"
         );
         assert!(result2[0].message.contains("bare.com"));
+    }
+
+    /// `<...>` is Gherkin placeholder syntax, substituted from `Examples` data: an
+    /// `Examples` column named `https://example.com` turns `Given I go to
+    /// <https://example.com>` into that column's value. The autolink this rule asks for
+    /// therefore carries meaning anywhere in a `.feature.md`, prose included, so the rule
+    /// is disabled wholesale for the flavor.
+    #[test]
+    fn test_mdg_disables_the_rule_entirely() {
+        let rule = MD034NoBareUrls;
+        let content = "\
+# Feature: Visit https://feature.example.com
+
+Prose about https://prose.example.com for background.
+
+## Scenario Outline: Open https://outline.example.com
+
+* Given I go to https://step.example.com
+  | site                          |
+  | https://datatable.example.com |
+
+> * Given I go to https://blockquoted.example.com
+
+1. Given I go to https://ordered.example.com
+
+| url                            |
+| ------------------------------ |
+| https://unindented.example.com |
+
+### Examples:
+
+  | url                          |
+  | ---------------------------- |
+  | https://examples.example.com |
+";
+
+        let standard_ctx =
+            crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let standard_lines: Vec<usize> = rule.check(&standard_ctx).unwrap().iter().map(|w| w.line).collect();
+        assert_eq!(
+            standard_lines,
+            vec![1, 3, 5, 7, 9, 11, 13, 17, 23],
+            "Standard flavor flags every bare URL"
+        );
+
+        let mdg_ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.should_skip(&mdg_ctx), "MDG must not even reach the line scan");
+        let mdg = rule.check(&mdg_ctx).unwrap();
+        assert!(
+            mdg.is_empty(),
+            "MDG must flag nothing, not even prose or a blockquoted step: {mdg:?}"
+        );
+        assert_eq!(rule.fix(&mdg_ctx).unwrap(), content, "MDG must rewrite nothing");
+    }
+
+    /// The exemption is confined to MDG: every other flavor still rewrites the same
+    /// document, at every position.
+    #[test]
+    fn test_mdg_exemption_does_not_affect_other_flavors() {
+        let rule = MD034NoBareUrls;
+        let content = "\
+# Feature: Visit https://feature.example.com
+
+Prose about https://prose.example.com for background.
+
+## Scenario Outline: Open https://outline.example.com
+
+* Given I go to https://step.example.com
+  | site                          |
+  | https://datatable.example.com |
+
+### Examples:
+
+  | url                          |
+  | ---------------------------- |
+  | https://examples.example.com |
+";
+        let expected = "\
+# Feature: Visit <https://feature.example.com>
+
+Prose about <https://prose.example.com> for background.
+
+## Scenario Outline: Open <https://outline.example.com>
+
+* Given I go to <https://step.example.com>
+  | site                          |
+  | <https://datatable.example.com> |
+
+### Examples:
+
+  | url                          |
+  | ---------------------------- |
+  | <https://examples.example.com> |
+";
+
+        for flavor in [
+            crate::config::MarkdownFlavor::Standard,
+            crate::config::MarkdownFlavor::MkDocs,
+            crate::config::MarkdownFlavor::MyST,
+        ] {
+            let ctx = crate::lint_context::LintContext::new(content, flavor, None);
+            assert!(!rule.should_skip(&ctx), "{flavor:?} must still run the rule");
+            assert_eq!(rule.check(&ctx).unwrap().len(), 6, "{flavor:?} must flag all six URLs");
+
+            let fixed = rule.fix(&ctx).unwrap();
+            assert_eq!(fixed, expected, "{flavor:?} must wrap all six URLs");
+
+            let fixed_ctx = crate::lint_context::LintContext::new(&fixed, flavor, None);
+            assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+            assert_eq!(
+                rule.fix(&fixed_ctx).unwrap(),
+                fixed,
+                "{flavor:?} fix must be idempotent"
+            );
+        }
     }
 }

--- a/src/rules/md040_fenced_code_language.rs
+++ b/src/rules/md040_fenced_code_language.rs
@@ -1985,4 +1985,30 @@ echo hi
             "MD040 under Pandoc should flag ```{{}}``` (no language declared)"
         );
     }
+
+    #[test]
+    fn test_mdg_requires_a_language_for_doc_string_fences() {
+        use crate::config::MarkdownFlavor;
+
+        // A language label becomes the Doc String media type rather than
+        // dissolving the Doc String, so MD040 keeps applying under MDG.
+        let rule = MD040FencedCodeLanguage::default();
+
+        for content in [
+            "* Given the following message:\n\n  ```\n  hello\n  ```\n",
+            "* Given the following message:\n\n  ~~~\n  hello\n  ~~~\n",
+        ] {
+            let mdg_ctx = LintContext::new(content, MarkdownFlavor::MDG, None);
+            let standard_ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+
+            let warnings = rule.check(&mdg_ctx).unwrap();
+            assert_eq!(warnings.len(), 1, "MDG must still flag {content:?}");
+            assert!(warnings[0].message.contains("missing language"));
+            assert_eq!(
+                rule.fix(&mdg_ctx).unwrap(),
+                rule.fix(&standard_ctx).unwrap(),
+                "MDG must not differ from Standard"
+            );
+        }
+    }
 }

--- a/src/rules/md040_fenced_code_language.rs
+++ b/src/rules/md040_fenced_code_language.rs
@@ -422,6 +422,15 @@ impl Rule for MD040FencedCodeLanguage {
             }
         }
 
+        // In Markdown with Gherkin an info string is the Doc String media type.
+        // Keep every MD040 diagnostic, but never invent or normalize that
+        // domain value during formatting.
+        if ctx.flavor == crate::config::MarkdownFlavor::MDG {
+            for warning in &mut warnings {
+                warning.fix = None;
+            }
+        }
+
         Ok(warnings)
     }
 
@@ -1987,11 +1996,12 @@ echo hi
     }
 
     #[test]
-    fn test_mdg_requires_a_language_for_doc_string_fences() {
+    fn test_mdg_reports_doc_string_media_type_without_fixing_it() {
         use crate::config::MarkdownFlavor;
 
-        // A language label becomes the Doc String media type rather than
-        // dissolving the Doc String, so MD040 keeps applying under MDG.
+        // A language label becomes the Doc String media type. MD040 still
+        // reports an omitted value under MDG, but must not invent `text` and
+        // change the Gherkin AST.
         let rule = MD040FencedCodeLanguage::default();
 
         for content in [
@@ -2004,11 +2014,45 @@ echo hi
             let warnings = rule.check(&mdg_ctx).unwrap();
             assert_eq!(warnings.len(), 1, "MDG must still flag {content:?}");
             assert!(warnings[0].message.contains("missing language"));
+            assert!(warnings[0].fix.is_none(), "MDG must not offer a media-type fix");
+            assert_eq!(rule.fix(&mdg_ctx).unwrap(), content, "MDG must preserve {content:?}");
+
+            let standard_warnings = rule.check(&standard_ctx).unwrap();
+            assert_eq!(standard_warnings.len(), 1);
+            assert!(standard_warnings[0].fix.is_some(), "Standard keeps the existing fix");
             assert_eq!(
-                rule.fix(&mdg_ctx).unwrap(),
                 rule.fix(&standard_ctx).unwrap(),
-                "MDG must not differ from Standard"
+                content
+                    .replacen("```\n", "```text\n", 1)
+                    .replacen("~~~\n", "~~~text\n", 1),
+                "Standard still adds its default language label"
             );
         }
+    }
+
+    #[test]
+    fn test_mdg_reports_inconsistent_media_type_without_normalizing_it() {
+        use crate::config::MarkdownFlavor;
+
+        let config = MD040Config {
+            style: LanguageStyle::Consistent,
+            preferred_aliases: HashMap::from([("JavaScript".to_string(), "javascript".to_string())]),
+            ..MD040Config::default()
+        };
+        let rule = MD040FencedCodeLanguage::with_config(config);
+        let content = "* Given this script:\n\n  ```js\n  alert('ok')\n  ```\n";
+
+        let mdg_ctx = LintContext::new(content, MarkdownFlavor::MDG, None);
+        let mdg = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(mdg.len(), 1);
+        assert!(mdg[0].message.contains("Inconsistent language label"));
+        assert!(mdg[0].fix.is_none());
+        assert_eq!(rule.fix(&mdg_ctx).unwrap(), content);
+
+        let standard_ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
+        let standard = rule.check(&standard_ctx).unwrap();
+        assert_eq!(standard.len(), 1);
+        assert!(standard[0].fix.is_some());
+        assert!(rule.fix(&standard_ctx).unwrap().contains("```javascript"));
     }
 }

--- a/src/rules/md041_first_line_heading.rs
+++ b/src/rules/md041_first_line_heading.rs
@@ -2684,4 +2684,40 @@ mod tests {
             "HTML comment should still be treated as preamble (regression test)"
         );
     }
+
+    #[test]
+    fn test_mdg_requires_first_h1() {
+        // `# Feature: X` is always writable, so the MD041 policy stays in force
+        // for MDG and must match Standard.
+        let rule = MD041FirstLineHeading::default();
+        let content = "### Feature: Checkout\n\n##### Scenario: Purchase\n";
+
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+
+        assert!(!rule.check(&mdg_ctx).unwrap().is_empty());
+        assert_eq!(
+            rule.check(&mdg_ctx).unwrap().len(),
+            rule.check(&standard_ctx).unwrap().len(),
+            "MDG must not differ from Standard"
+        );
+    }
+
+    #[test]
+    fn test_mdg_fix_relevels_without_relocating_content() {
+        // With fixes enabled the only change must be an in-place relevel; the
+        // Feature tag line and the document order have to survive untouched.
+        let rule = MD041FirstLineHeading {
+            fix_enabled: true,
+            ..MD041FirstLineHeading::default()
+        };
+        let content = "### Feature: Checkout\n\n##### Scenario: Purchase\n";
+        let ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(fixed, "# Feature: Checkout\n\n##### Scenario: Purchase\n");
+
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+    }
 }

--- a/src/rules/md046_code_block_style.rs
+++ b/src/rules/md046_code_block_style.rs
@@ -1,5 +1,7 @@
 use crate::rule::{Fix, LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::rule_config_serde::{FlavorOverrideNotice, option_is_explicit};
 use crate::utils::calculate_indentation_width_default;
+use crate::utils::mdg;
 use crate::utils::mkdocs_admonitions;
 use crate::utils::mkdocs_tabs;
 use crate::utils::range_utils::calculate_line_range;
@@ -8,6 +10,9 @@ use toml;
 mod md046_config;
 pub use md046_config::CodeBlockStyle;
 use md046_config::MD046Config;
+
+/// Reports the MDG style override once per process; see [`FlavorOverrideNotice`].
+static MDG_STYLE_OVERRIDE: FlavorOverrideNotice = FlavorOverrideNotice::new();
 
 /// Pre-computed context arrays for indented code block detection.
 struct IndentContext<'a> {
@@ -66,17 +71,28 @@ impl OwnedIndentContext {
 #[derive(Clone)]
 pub struct MD046CodeBlockStyle {
     config: MD046Config,
+    /// Whether `style` came from the configuration rather than from the
+    /// default. MDG enforces fenced either way; this only decides whether the
+    /// user is told that the style they asked for was not adopted.
+    style_explicit: bool,
 }
 
 impl MD046CodeBlockStyle {
+    /// The fence `fix` opens when it converts an indented block.
+    const FENCE: &'static str = "```";
+
     pub fn new(style: CodeBlockStyle) -> Self {
         Self {
             config: MD046Config { style },
+            style_explicit: true,
         }
     }
 
     pub fn from_config_struct(config: MD046Config) -> Self {
-        Self { config }
+        Self {
+            config,
+            style_explicit: false,
+        }
     }
 
     /// Check if line has valid fence indentation per CommonMark spec (0-3 spaces)
@@ -429,6 +445,25 @@ impl MD046CodeBlockStyle {
         has_blank_line_before || prev_is_code
     }
 
+    /// First line at or after `start` that `block_lines` still counts as
+    /// indented code, bounded by the byte offset `block_end`, or `None` when
+    /// the block holds no such line.
+    ///
+    /// Under MDG a Gherkin table row is dropped from the block even though
+    /// CommonMark counts it as indented code, so a block reported by the
+    /// parser can start on a line the fix will leave alone. `check` reports
+    /// the first line the fix actually converts, which keeps the two in step.
+    fn first_code_block_line(
+        ctx: &crate::lint_context::LintContext,
+        block_lines: &[bool],
+        start: usize,
+        block_end: usize,
+    ) -> Option<usize> {
+        (start..block_lines.len())
+            .take_while(|&idx| ctx.line_offsets.get(idx).is_some_and(|&offset| offset < block_end))
+            .find(|&idx| block_lines[idx])
+    }
+
     /// Per-line membership of the indented code blocks that style detection,
     /// block categorization and the fix all operate on.
     ///
@@ -439,11 +474,45 @@ impl MD046CodeBlockStyle {
     /// block and leaves the blank lines before and after it outside. So
     /// `    a`, an empty line and `    b` form one block, and a whitespace-only
     /// line on its own is no block at all.
-    fn indented_block_lines(&self, lines: &[&str], is_mkdocs: bool, ictx: &IndentContext<'_>) -> Vec<bool> {
+    ///
+    /// Under MDG, Gherkin tables are dropped from the result. This is the only
+    /// place that decision is made: `check`, `detect_style` and `fix` all read
+    /// the array returned here, so they cannot disagree about what MD046
+    /// converts.
+    fn indented_block_lines(
+        &self,
+        lines: &[&str],
+        is_mkdocs: bool,
+        ictx: &IndentContext<'_>,
+        flavor: crate::config::MarkdownFlavor,
+    ) -> Vec<bool> {
         let mut member = vec![false; lines.len()];
         for i in 0..lines.len() {
             let prev_is_code = i > 0 && member[i - 1];
             member[i] = self.is_indented_code_block_with_context(lines, i, is_mkdocs, ictx, prev_is_code);
+        }
+
+        // Fencing a run of Gherkin table rows would delete the table from the
+        // Gherkin document, so they are withheld from indented-code detection.
+        // That happens before blank lines are folded in, so each
+        // blank-line-delimited run is judged on its own rows: an Examples table
+        // followed by a blank line and a paragraph must keep the table out of
+        // the block instead of being outvoted by the paragraph.
+        if flavor == crate::config::MarkdownFlavor::MDG {
+            let mut i = 0;
+            while i < member.len() {
+                if !member[i] {
+                    i += 1;
+                    continue;
+                }
+                let start = i;
+                while i < member.len() && member[i] {
+                    i += 1;
+                }
+                if lines[start..i].iter().all(|line| mdg::is_table_row(line)) {
+                    member[start..i].fill(false);
+                }
+            }
         }
 
         let mut i = 0;
@@ -793,6 +862,48 @@ impl MD046CodeBlockStyle {
         warnings
     }
 
+    /// Resolve the style MD046 should converge on.
+    ///
+    /// A Gherkin Doc String is only ever a backtick fence, so an indented block
+    /// can never be one, and a configuration demanding indented code cannot be
+    /// satisfied in this flavor. MDG therefore always converges on fenced:
+    /// `consistent` resolves to fenced rather than to whichever style happens
+    /// to be more common, and an explicit `indented` is not adopted.
+    fn effective_target_style(
+        &self,
+        flavor: crate::config::MarkdownFlavor,
+        detect: impl FnOnce() -> CodeBlockStyle,
+    ) -> CodeBlockStyle {
+        if flavor == crate::config::MarkdownFlavor::MDG {
+            self.warn_once_about_overridden_style();
+            return CodeBlockStyle::Fenced;
+        }
+
+        match self.config.style {
+            CodeBlockStyle::Consistent => detect(),
+            style => style,
+        }
+    }
+
+    /// Tell the user once that MDG did not adopt the style they configured.
+    ///
+    /// Only `indented` is worth reporting: it is the one setting MDG cannot
+    /// satisfy. `consistent` asks for no particular form, and fenced is what
+    /// MDG picks for it anyway.
+    fn warn_once_about_overridden_style(&self) {
+        if !self.style_explicit || self.config.style != CodeBlockStyle::Indented {
+            return;
+        }
+
+        MDG_STYLE_OVERRIDE.report(
+            "MD046",
+            "style",
+            "indented",
+            "fenced",
+            "a Gherkin Doc String is only ever a backtick fence",
+        );
+    }
+
     fn detect_style(
         &self,
         ctx: &crate::lint_context::LintContext,
@@ -804,7 +915,7 @@ impl MD046CodeBlockStyle {
             return None;
         }
 
-        let block_lines = self.indented_block_lines(lines, is_mkdocs, ictx);
+        let block_lines = self.indented_block_lines(lines, is_mkdocs, ictx, ctx.flavor);
 
         let mut fenced_count = 0;
         let mut indented_count = 0;
@@ -918,14 +1029,22 @@ impl Rule for MD046CodeBlockStyle {
         let is_mkdocs = ctx.flavor == crate::config::MarkdownFlavor::MkDocs;
 
         // Determine the target style
-        let target_style = match self.config.style {
-            CodeBlockStyle::Consistent => {
-                let owned = self.build_indent_context(ctx, lines, is_mkdocs);
-                self.detect_style(ctx, lines, is_mkdocs, &owned.borrow())
-                    .unwrap_or(CodeBlockStyle::Fenced)
-            }
-            _ => self.config.style,
-        };
+        let target_style = self.effective_target_style(ctx.flavor, || {
+            let owned = self.build_indent_context(ctx, lines, is_mkdocs);
+            let detected = self.detect_style(ctx, lines, is_mkdocs, &owned.borrow());
+            detected.unwrap_or(CodeBlockStyle::Fenced)
+        });
+
+        // Under MDG, `indented_block_lines` is the single source of truth for
+        // which indented lines are code and which are Gherkin Data/Examples
+        // table rows. Reading the array `fix` converts from — rather than
+        // re-deciding it here — is what keeps the two paths in agreement.
+        let mdg_block_lines = (ctx.flavor == crate::config::MarkdownFlavor::MDG
+            && ctx.code_block_details.iter().any(|detail| !detail.is_fenced))
+        .then(|| {
+            let owned = self.build_indent_context(ctx, lines, is_mkdocs);
+            self.indented_block_lines(lines, is_mkdocs, &owned.borrow(), ctx.flavor)
+        });
 
         // Iterate code_block_details directly (O(k) where k is number of blocks)
         let mut reported_indented_lines: std::collections::HashSet<usize> = std::collections::HashSet::new();
@@ -966,7 +1085,25 @@ impl Rule for MD046CodeBlockStyle {
                 }
             } else {
                 // Indented code block
-                if target_style == CodeBlockStyle::Fenced && !reported_indented_lines.contains(&start_line_idx) {
+                if target_style == CodeBlockStyle::Fenced {
+                    // Under MDG the block may open on Gherkin table rows that
+                    // are not code; the line to report is the first one the fix
+                    // will fence, and a block of nothing but rows is no code
+                    // block at all.
+                    let start_line_idx = match &mdg_block_lines {
+                        Some(block_lines) => {
+                            match Self::first_code_block_line(ctx, block_lines, start_line_idx, detail.end) {
+                                Some(idx) => idx,
+                                None => continue,
+                            }
+                        }
+                        None => start_line_idx,
+                    };
+
+                    if reported_indented_lines.contains(&start_line_idx) {
+                        continue;
+                    }
+
                     let line = lines.get(start_line_idx).unwrap_or(&"");
 
                     // Skip blocks in contexts that aren't real indented code blocks
@@ -1030,14 +1167,16 @@ impl Rule for MD046CodeBlockStyle {
         let owned = self.build_indent_context(ctx, lines, is_mkdocs);
         let ictx = owned.borrow();
 
-        let target_style = match self.config.style {
-            CodeBlockStyle::Consistent => self
-                .detect_style(ctx, lines, is_mkdocs, &ictx)
-                .unwrap_or(CodeBlockStyle::Fenced),
-            _ => self.config.style,
-        };
+        // The unclosed-fence repair at the end of this function is a repair
+        // rather than a style conversion: `check` reports it before any style is
+        // resolved, so the loop below has to run even when no block needs
+        // converting.
+        let target_style = self.effective_target_style(ctx.flavor, || {
+            self.detect_style(ctx, lines, is_mkdocs, &ictx)
+                .unwrap_or(CodeBlockStyle::Fenced)
+        });
 
-        let block_lines = self.indented_block_lines(lines, is_mkdocs, &ictx);
+        let block_lines = self.indented_block_lines(lines, is_mkdocs, &ictx, ctx.flavor);
 
         // Categorize indented blocks:
         // - misplaced_fence_lines: complete fenced blocks that were over-indented (safe to dedent)
@@ -1181,7 +1320,8 @@ impl Rule for MD046CodeBlockStyle {
                         // Start of a new indented block that should be fenced
                         current_block_fence_indent = " ".repeat(baseline);
                         result.push_str(&current_block_fence_indent);
-                        result.push_str("```\n");
+                        result.push_str(Self::FENCE);
+                        result.push('\n');
                         result.push_str(body);
                         result.push('\n');
                         in_indented_block = true;
@@ -1200,7 +1340,8 @@ impl Rule for MD046CodeBlockStyle {
                         && !unsafe_fence_lines[i]
                     {
                         result.push_str(&current_block_fence_indent);
-                        result.push_str("```\n");
+                        result.push_str(Self::FENCE);
+                        result.push('\n');
                         in_indented_block = false;
                         current_block_fence_indent.clear();
                     }
@@ -1213,7 +1354,8 @@ impl Rule for MD046CodeBlockStyle {
                 // Regular line
                 if in_indented_block && target_style == CodeBlockStyle::Fenced {
                     result.push_str(&current_block_fence_indent);
-                    result.push_str("```\n");
+                    result.push_str(Self::FENCE);
+                    result.push('\n');
                     in_indented_block = false;
                     current_block_fence_indent.clear();
                 }
@@ -1226,7 +1368,8 @@ impl Rule for MD046CodeBlockStyle {
         // Close any remaining blocks
         if in_indented_block && target_style == CodeBlockStyle::Fenced {
             result.push_str(&current_block_fence_indent);
-            result.push_str("```\n");
+            result.push_str(Self::FENCE);
+            result.push('\n');
         }
 
         // Close any unclosed fenced blocks.
@@ -1269,7 +1412,20 @@ impl Rule for MD046CodeBlockStyle {
         self
     }
 
-    crate::impl_rule_config_methods!(MD046Config);
+    crate::impl_rule_config_sections!(MD046Config);
+
+    fn from_config(config: &crate::config::Config) -> Box<dyn Rule>
+    where
+        Self: Sized,
+    {
+        let rule_config = crate::rule_config_serde::load_rule_config::<MD046Config>(config);
+        let style_explicit = option_is_explicit(config, "MD046", "style");
+
+        Box::new(Self {
+            config: rule_config,
+            style_explicit,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -3045,5 +3201,262 @@ More text
         let ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
         let fixed = rule.fix(&ctx).unwrap();
         assert_eq!(fixed, "# T\n\nPara\n\n```python\nx = 1\n\ny = 2\n```\n\nAfter\n");
+    }
+    #[test]
+    fn test_mdg_overrides_indented_style_to_fenced() {
+        // A Gherkin Doc String is only ever a backtick fence, so a
+        // configuration demanding indented code cannot be satisfied in this
+        // flavor. MDG does not adopt it: the Doc String keeps its fence instead
+        // of being unwrapped into an indented block that deletes it.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Indented);
+        let content = "# Feature: Payloads\n\n## Scenario: JSON payload\n\n* Given this payload\n\n  ```json\n  {\"ok\": true}\n  ```\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&mdg_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&mdg_ctx).unwrap(), content);
+
+        // Standard adopts `indented` exactly as before and unwraps the fence.
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let standard_warnings = rule.check(&standard_ctx).unwrap();
+        assert_eq!(standard_warnings.len(), 1);
+        assert_eq!(standard_warnings[0].message, "Use indented code blocks");
+        assert!(!rule.fix(&standard_ctx).unwrap().contains("```"));
+    }
+
+    #[test]
+    fn test_mdg_indented_style_still_fences_indented_blocks() {
+        // The override is not merely a refusal to unwrap fences: MDG enforces
+        // fenced, so an indented block is converted even though the
+        // configuration asked for indented code.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Indented);
+        let content =
+            "# Feature: Payloads\n\n## Scenario: Plain payload\n\nSome description.\n\n      ordinary indented code\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        let warnings = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].message, "Use fenced code blocks");
+
+        let fixed = rule.fix(&mdg_ctx).unwrap();
+        assert_eq!(
+            fixed,
+            "# Feature: Payloads\n\n## Scenario: Plain payload\n\nSome description.\n\n```\n  ordinary indented code\n```\n"
+        );
+
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+
+        // Standard honours `indented`: the block is already indented, so there
+        // is nothing to report and nothing to change.
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert!(rule.check(&standard_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&standard_ctx).unwrap(), content);
+    }
+
+    #[test]
+    fn test_mdg_steers_indented_code_to_fenced() {
+        // Under MDG a code block is expected to be a backtick fence, so an
+        // indented block is corrected rather than preserved — whichever style
+        // the configuration names.
+        let content = "# Feature: Payloads\n\n## Scenario: Plain payload\n\n* Given this payload\n\n      ordinary indented code\n";
+
+        for rule in [
+            MD046CodeBlockStyle::new(CodeBlockStyle::Fenced),
+            MD046CodeBlockStyle::new(CodeBlockStyle::Consistent),
+            MD046CodeBlockStyle::new(CodeBlockStyle::Indented),
+        ] {
+            let ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+            let warnings = rule.check(&ctx).unwrap();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(warnings[0].message, "Use fenced code blocks");
+
+            let fixed = rule.fix(&ctx).unwrap();
+            assert!(fixed.contains("```"), "MDG must fence the block: {fixed:?}");
+
+            let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+            assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+            assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+        }
+    }
+
+    #[test]
+    fn test_mdg_consistent_style_ignores_indented_prevalence() {
+        // Standard resolves `consistent` by prevalence; MDG always resolves it
+        // to fenced because only a backtick fence can be a Doc String.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Consistent);
+        let indented_majority = "# Feature: Payloads\n\n## Scenario: Mixed payloads\n\n* Given this payload\n\n```json\n{\"ok\": true}\n```\n\nFirst ordinary example:\n\n    one\n\nSecond ordinary example:\n\n    two\n";
+
+        let standard_ctx = LintContext::new(indented_majority, crate::config::MarkdownFlavor::Standard, None);
+        let standard_warnings = rule.check(&standard_ctx).unwrap();
+        assert_eq!(standard_warnings.len(), 1);
+        assert_eq!(standard_warnings[0].message, "Use indented code blocks");
+
+        let mdg_ctx = LintContext::new(indented_majority, crate::config::MarkdownFlavor::MDG, None);
+        let mdg_warnings = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(mdg_warnings.len(), 2);
+        assert!(
+            mdg_warnings
+                .iter()
+                .all(|warning| warning.message == "Use fenced code blocks")
+        );
+    }
+
+    #[test]
+    fn test_mdg_repairs_unclosed_fence_like_standard() {
+        // The unclosed-fence repair is flavor independent now that MDG no
+        // longer takes a bespoke fix path.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Fenced);
+        let content = "# Feature: Payloads\n\n```json\n{\"ok\": true}\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        let warnings = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("never closed"));
+
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(
+            rule.fix(&mdg_ctx).unwrap(),
+            rule.fix(&standard_ctx).unwrap(),
+            "MDG must not differ from Standard"
+        );
+    }
+
+    #[test]
+    fn test_mdg_table_above_prose_is_never_fenced() {
+        // The Examples table and the paragraph below it sit in one CommonMark
+        // indented code block, split by a blank line. `check` and `fix` read
+        // the same per-line membership, so the table stays a table and only the
+        // paragraph is fenced — reporting the block and fencing all of it (or
+        // skipping the block and fencing it anyway) would delete the table.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Fenced);
+        let content = "# Feature: Eating\n\n#### Examples:\n\n    | start | eat | left |\n    | ----- | --- | ---- |\n\n    a note about the data\n\n## Scenario: Other\n\n      unrelated indented code\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        let reported: Vec<usize> = rule.check(&mdg_ctx).unwrap().iter().map(|w| w.line).collect();
+        assert_eq!(reported, vec![8, 12]);
+
+        let fixed = rule.fix(&mdg_ctx).unwrap();
+        assert_eq!(
+            fixed,
+            "# Feature: Eating\n\n#### Examples:\n\n    | start | eat | left |\n    | ----- | --- | ---- |\n\n```\na note about the data\n```\n\n## Scenario: Other\n\n```\n  unrelated indented code\n```\n"
+        );
+
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert!(
+            rule.check(&fixed_ctx).unwrap().is_empty(),
+            "MDG check must have nothing left to report after its own fix"
+        );
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+
+        // Standard has no Gherkin tables, so the whole block is code there.
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let standard_reported: Vec<usize> = rule.check(&standard_ctx).unwrap().iter().map(|w| w.line).collect();
+        assert_eq!(standard_reported, vec![5, 12]);
+        assert!(rule.fix(&standard_ctx).unwrap().contains("```\n| start | eat | left |"));
+    }
+
+    #[test]
+    fn test_mdg_repairs_unclosed_fence_under_indented_style() {
+        // MDG does not adopt the configured `indented` style, but closing an
+        // unclosed fence is a repair rather than a conversion: `check` reports
+        // it before any style is resolved, so `fix` has to resolve it too.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Indented);
+        let content = "# Feature: Payloads\n\n```json\n{\"ok\": true}\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        let warnings = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("never closed"));
+
+        let fixed = rule.fix(&mdg_ctx).unwrap();
+        assert_eq!(fixed, "# Feature: Payloads\n\n```json\n{\"ok\": true}\n```\n");
+
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+
+        // Standard converts the block instead of preserving the Doc String.
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert!(rule.fix(&standard_ctx).unwrap().contains("\n    {\"ok\": true}\n"));
+    }
+
+    #[test]
+    fn test_mdg_tab_indented_table_is_not_code() {
+        // Gherkin matches table rows on `\s`, so two tabs — or a space and a
+        // tab — indent a table just as two spaces do, even though both expand
+        // past the 4-column indented-code threshold.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Fenced);
+        for indent in ["\t\t", " \t"] {
+            let content = format!(
+                "# Feature: Eating\n\n#### Examples:\n\n{indent}| start | eat |\n{indent}| ----- | --- |\n\n## Scenario: Other\n\n      code here\n"
+            );
+
+            let mdg_ctx = LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
+            let reported: Vec<usize> = rule.check(&mdg_ctx).unwrap().iter().map(|w| w.line).collect();
+            assert_eq!(reported, vec![10], "tab-indented rows are a table, not code");
+
+            let fixed = rule.fix(&mdg_ctx).unwrap();
+            assert!(
+                fixed.contains(&format!("{indent}| start | eat |\n{indent}| ----- | --- |")),
+                "MDG must leave the tab-indented table alone: {fixed:?}"
+            );
+
+            let standard_ctx = LintContext::new(&content, crate::config::MarkdownFlavor::Standard, None);
+            let standard_reported: Vec<usize> = rule.check(&standard_ctx).unwrap().iter().map(|w| w.line).collect();
+            assert_eq!(standard_reported, vec![5, 10]);
+        }
+    }
+
+    #[test]
+    fn test_from_config_records_whether_style_was_configured() {
+        // The MDG override applies either way, but the warning is only for a
+        // style the user actually asked for, so a configured style has to be
+        // told apart from a defaulted one.
+        use crate::config::Config;
+        use std::collections::BTreeMap;
+
+        let mut values = BTreeMap::new();
+        values.insert("style".to_string(), toml::Value::String("indented".to_string()));
+        let mut config = Config::default();
+        config.rules.insert(
+            "MD046".to_string(),
+            crate::config::RuleConfig { severity: None, values },
+        );
+
+        let configured = MD046CodeBlockStyle::from_config(&config);
+        let configured = configured.as_any().downcast_ref::<MD046CodeBlockStyle>().unwrap();
+        assert_eq!(configured.config.style, CodeBlockStyle::Indented);
+        assert!(configured.style_explicit);
+
+        let defaulted = MD046CodeBlockStyle::from_config(&Config::default());
+        let defaulted = defaulted.as_any().downcast_ref::<MD046CodeBlockStyle>().unwrap();
+        assert!(!defaulted.style_explicit);
+
+        // The override does not depend on the warning: a defaulted `indented`
+        // is enforced as fenced just the same.
+        let indented = MD046CodeBlockStyle::from_config_struct(MD046Config {
+            style: CodeBlockStyle::Indented,
+        });
+        let content = "# Feature: F\n\nText.\n\n      code here\n";
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        assert!(indented.fix(&mdg_ctx).unwrap().contains("```\n  code here\n```"));
+    }
+
+    #[test]
+    fn test_mdg_indented_style_keeps_tables_out_of_code() {
+        // Enforcing fenced does not widen what MDG counts as code: a
+        // Data/Examples table is still not an indented code block.
+        let rule = MD046CodeBlockStyle::new(CodeBlockStyle::Indented);
+        let content = "# Feature: Eating\n\n#### Examples:\n\n    | start | eat | left |\n    | ----- | --- | ---- |\n";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&mdg_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&mdg_ctx).unwrap(), content);
+
+        // Standard has no Gherkin tables, so the rows are code — and `indented`
+        // is honoured there, so they are already in the requested form.
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert!(rule.check(&standard_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&standard_ctx).unwrap(), content);
     }
 }

--- a/src/rules/md048_code_fence_style.rs
+++ b/src/rules/md048_code_fence_style.rs
@@ -1,11 +1,16 @@
+use crate::config::MarkdownFlavor;
 use crate::filtered_lines::FilteredLinesExt;
 use crate::rule::{Fix, LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::rule_config_serde::{FlavorOverrideNotice, option_is_explicit};
 use crate::rules::code_fence_utils::CodeFenceStyle;
 use crate::utils::range_utils::calculate_match_range;
 use toml;
 
 mod md048_config;
 use md048_config::MD048Config;
+
+/// Reports the MDG style override once per process; see [`FlavorOverrideNotice`].
+static MDG_STYLE_OVERRIDE: FlavorOverrideNotice = FlavorOverrideNotice::new();
 
 /// Parsed fence marker candidate on a single line.
 #[derive(Debug, Clone, Copy)]
@@ -65,23 +70,75 @@ fn is_closing_fence(marker: FenceMarker<'_>, opening_fence_char: char, opening_f
     marker.fence_char == opening_fence_char && marker.fence_len >= opening_fence_len && marker.rest.trim().is_empty()
 }
 
+#[inline]
+fn needs_fence_conversion(fence_char: char, target_style: CodeFenceStyle) -> bool {
+    (fence_char == '`' && target_style == CodeFenceStyle::Tilde)
+        || (fence_char == '~' && target_style == CodeFenceStyle::Backtick)
+}
+
 /// Rule MD048: Code fence style
 ///
 /// See [docs/md048.md](../../docs/md048.md) for full documentation, configuration, and examples.
 #[derive(Clone)]
 pub struct MD048CodeFenceStyle {
     config: MD048Config,
+    /// Whether `style` came from the configuration rather than from the
+    /// default. MDG enforces backtick either way; this only decides whether the
+    /// user is told that the style they asked for was not adopted.
+    style_explicit: bool,
 }
 
 impl MD048CodeFenceStyle {
     pub fn new(style: CodeFenceStyle) -> Self {
         Self {
             config: MD048Config { style },
+            style_explicit: true,
         }
     }
 
     pub fn from_config_struct(config: MD048Config) -> Self {
-        Self { config }
+        Self {
+            config,
+            style_explicit: false,
+        }
+    }
+
+    /// Resolve the fence style MD048 should converge on.
+    ///
+    /// A Gherkin Doc String is only ever a backtick fence, so a tilde fence can
+    /// never be one, and a configuration demanding tilde fences cannot be
+    /// satisfied in this flavor. MDG therefore always converges on backtick:
+    /// `consistent` resolves to backtick rather than to whichever marker
+    /// happens to be more common, and an explicit `tilde` is not adopted.
+    fn effective_target_style(&self, ctx: &crate::lint_context::LintContext) -> CodeFenceStyle {
+        if ctx.flavor == MarkdownFlavor::MDG {
+            self.warn_once_about_overridden_style();
+            return CodeFenceStyle::Backtick;
+        }
+
+        match self.config.style {
+            CodeFenceStyle::Consistent => self.detect_style(ctx).unwrap_or(CodeFenceStyle::Backtick),
+            style => style,
+        }
+    }
+
+    /// Tell the user once that MDG did not adopt the style they configured.
+    ///
+    /// Only `tilde` is worth reporting: it is the one setting MDG cannot
+    /// satisfy. `consistent` asks for no particular marker, and backtick is
+    /// what MDG picks for it anyway.
+    fn warn_once_about_overridden_style(&self) {
+        if !self.style_explicit || self.config.style != CodeFenceStyle::Tilde {
+            return;
+        }
+
+        MDG_STYLE_OVERRIDE.report(
+            "MD048",
+            "style",
+            "tilde",
+            "backtick",
+            "a Gherkin Doc String is only ever a backtick fence",
+        );
     }
 
     fn detect_style(&self, ctx: &crate::lint_context::LintContext) -> Option<CodeFenceStyle> {
@@ -208,10 +265,7 @@ impl Rule for MD048CodeFenceStyle {
     fn check(&self, ctx: &crate::lint_context::LintContext) -> LintResult {
         let mut warnings = Vec::new();
 
-        let target_style = match self.config.style {
-            CodeFenceStyle::Consistent => self.detect_style(ctx).unwrap_or(CodeFenceStyle::Backtick),
-            _ => self.config.style,
-        };
+        let target_style = self.effective_target_style(ctx);
 
         let lines = ctx.raw_lines();
         let mut in_code_block = false;
@@ -257,8 +311,7 @@ impl Rule for MD048CodeFenceStyle {
                 code_block_fence_char = fence_char;
                 code_block_fence_len = fence_len;
 
-                let needs_conversion = (fence_char == '`' && target_style == CodeFenceStyle::Tilde)
-                    || (fence_char == '~' && target_style == CodeFenceStyle::Backtick);
+                let needs_conversion = needs_fence_conversion(fence_char, target_style);
 
                 if needs_conversion {
                     let target_char = if target_style == CodeFenceStyle::Backtick {
@@ -304,7 +357,8 @@ impl Rule for MD048CodeFenceStyle {
                         )),
                     });
                 } else {
-                    // Already the correct style. Check for fence-length ambiguity:
+                    // No character conversion is required.
+                    // Check for fence-length ambiguity:
                     // if the interior contains same-style bare fences of equal or greater
                     // length, the outer fence cannot be distinguished from an inner
                     // closing fence and must be made longer.
@@ -351,8 +405,7 @@ impl Rule for MD048CodeFenceStyle {
                 let is_closing = is_closing_fence(marker, code_block_fence_char, code_block_fence_len);
 
                 if is_closing {
-                    let needs_conversion = (fence_char == '`' && target_style == CodeFenceStyle::Tilde)
-                        || (fence_char == '~' && target_style == CodeFenceStyle::Backtick);
+                    let needs_conversion = needs_fence_conversion(fence_char, target_style);
 
                     if needs_conversion || needs_lengthening {
                         let target_char = if needs_conversion {
@@ -446,7 +499,20 @@ impl Rule for MD048CodeFenceStyle {
         self
     }
 
-    crate::impl_rule_config_methods!(MD048Config);
+    crate::impl_rule_config_sections!(MD048Config);
+
+    fn from_config(config: &crate::config::Config) -> Box<dyn Rule>
+    where
+        Self: Sized,
+    {
+        let rule_config = crate::rule_config_serde::load_rule_config::<MD048Config>(config);
+        let style_explicit = option_is_explicit(config, "MD048", "style");
+
+        Box::new(Self {
+            config: rule_config,
+            style_explicit,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -496,6 +562,146 @@ mod tests {
 
         assert_eq!(result.len(), 2); // Opening and closing fence
         assert!(result[0].message.contains("use ~~~ instead of ```"));
+    }
+
+    #[test]
+    fn test_mdg_overrides_tilde_style_to_backtick() {
+        // A Gherkin Doc String is only ever a backtick fence, so a
+        // configuration demanding tilde fences cannot be satisfied in this
+        // flavor. MDG does not adopt it: a Doc String keeps its backticks and a
+        // tilde fence is still corrected into one.
+        let backticks = "# Feature: Checkout\n\n## Scenario: Purchase\n\n* Given a JSON payload\n\n  ```json\n  {\"ok\": true}\n  ```";
+        let tildes =
+            "# Feature: Checkout\n\n## Scenario: Purchase\n\n* Given a rendered example\n\n  ~~~text\n  example\n  ~~~";
+
+        let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Tilde);
+        let ctx = LintContext::new(backticks, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&ctx).unwrap(), backticks);
+
+        let ctx = LintContext::new(tildes, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(rule.check(&ctx).unwrap().len(), 2, "the opening and closing fence");
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(
+            fixed,
+            "# Feature: Checkout\n\n## Scenario: Purchase\n\n* Given a rendered example\n\n  ```text\n  example\n  ```"
+        );
+
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
+
+        // Standard honours `tilde` exactly as before, in both directions.
+        let standard_ctx = LintContext::new(backticks, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(rule.check(&standard_ctx).unwrap().len(), 2);
+        assert!(rule.fix(&standard_ctx).unwrap().contains("~~~json"));
+
+        let standard_ctx = LintContext::new(tildes, crate::config::MarkdownFlavor::Standard, None);
+        assert!(rule.check(&standard_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&standard_ctx).unwrap(), tildes);
+    }
+
+    #[test]
+    fn test_mdg_applies_backtick_style() {
+        // The explicit backtick style is the one MDG can satisfy, so it is
+        // applied unchanged.
+        let tildes =
+            "# Feature: Checkout\n\n## Scenario: Purchase\n\n* Given a rendered example\n\n  ~~~text\n  example\n  ~~~";
+
+        let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Backtick);
+        let ctx = LintContext::new(tildes, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(rule.check(&ctx).unwrap().len(), 2, "the opening and closing fence");
+        assert_eq!(
+            rule.fix(&ctx).unwrap(),
+            "# Feature: Checkout\n\n## Scenario: Purchase\n\n* Given a rendered example\n\n  ```text\n  example\n  ```"
+        );
+    }
+
+    #[test]
+    fn test_mdg_tilde_style_still_disambiguates_fence_length() {
+        // The override decides which marker MD048 converges on; it does not
+        // touch the length arithmetic that keeps a converted outer fence from
+        // being closed by an interior one.
+        let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Tilde);
+        let content = "# Feature: Checkout\n\n## Scenario: Purchase\n\n* Given a rendered example\n\n~~~\n```rust\ncode\n```\n~~~";
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        let fixed = rule.fix(&mdg_ctx).unwrap();
+        assert_eq!(
+            fixed,
+            "# Feature: Checkout\n\n## Scenario: Purchase\n\n* Given a rendered example\n\n````\n```rust\ncode\n```\n````"
+        );
+
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+
+        // Standard honours `tilde`: the outer fence is already a tilde fence,
+        // so nothing is converted or lengthened.
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert!(rule.check(&standard_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&standard_ctx).unwrap(), content);
+    }
+
+    #[test]
+    fn test_from_config_records_whether_style_was_configured() {
+        // The MDG override applies either way, but the warning is only for a
+        // style the user actually asked for, so a configured style has to be
+        // told apart from a defaulted one.
+        use crate::config::Config;
+        use std::collections::BTreeMap;
+
+        let mut values = BTreeMap::new();
+        values.insert("style".to_string(), toml::Value::String("tilde".to_string()));
+        let mut config = Config::default();
+        config.rules.insert(
+            "MD048".to_string(),
+            crate::config::RuleConfig { severity: None, values },
+        );
+
+        let configured = MD048CodeFenceStyle::from_config(&config);
+        let configured = configured.as_any().downcast_ref::<MD048CodeFenceStyle>().unwrap();
+        assert_eq!(configured.config.style, CodeFenceStyle::Tilde);
+        assert!(configured.style_explicit);
+
+        let defaulted = MD048CodeFenceStyle::from_config(&Config::default());
+        let defaulted = defaulted.as_any().downcast_ref::<MD048CodeFenceStyle>().unwrap();
+        assert!(!defaulted.style_explicit);
+
+        // The override does not depend on the warning: a defaulted `tilde` is
+        // enforced as backtick just the same.
+        let tilde = MD048CodeFenceStyle::from_config_struct(MD048Config {
+            style: CodeFenceStyle::Tilde,
+        });
+        let content = "# Feature: F\n\n~~~text\nexample\n~~~";
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(tilde.fix(&mdg_ctx).unwrap(), "# Feature: F\n\n```text\nexample\n```");
+    }
+
+    #[test]
+    fn test_mdg_consistent_fence_style_ignores_tilde_prevalence() {
+        // Standard resolves `consistent` by prevalence (tilde wins here); MDG
+        // always resolves it to backtick.
+        let rule = MD048CodeFenceStyle::new(CodeFenceStyle::Consistent);
+        let content = "# Feature: Checkout\n\n~~~text\nfirst example\n~~~\n\n~~~text\nsecond example\n~~~\n\n## Scenario: Purchase\n\n* Given a JSON payload\n\n  ```json\n  {\"ok\": true}\n  ```";
+
+        let standard_ctx = LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(rule.detect_style(&standard_ctx), Some(CodeFenceStyle::Tilde));
+
+        let mdg_ctx = LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
+        let warnings = rule.check(&mdg_ctx).unwrap();
+        assert_eq!(warnings.len(), 4, "two tilde blocks, each with two fence lines");
+        assert!(
+            warnings
+                .iter()
+                .all(|warning| warning.message.contains("use ``` instead of ~~~"))
+        );
+
+        let fixed = rule.fix(&mdg_ctx).unwrap();
+        assert!(!fixed.contains("~~~"), "MDG must convert every fence: {fixed:?}");
+
+        let fixed_ctx = LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MDG fix should be idempotent");
     }
 
     #[test]

--- a/src/rules/md055_table_pipe_style.rs
+++ b/src/rules/md055_table_pipe_style.rs
@@ -1,9 +1,14 @@
+use crate::config::MarkdownFlavor;
 use crate::rule::{LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::rule_config_serde::{FlavorOverrideNotice, option_is_explicit};
 use crate::utils::range_utils::calculate_line_range;
 use crate::utils::table_utils::{TableBlock, TableUtils};
 
 mod md055_config;
 use md055_config::MD055Config;
+
+/// Reports the MDG style override once per process; see [`FlavorOverrideNotice`].
+static MDG_STYLE_OVERRIDE: FlavorOverrideNotice = FlavorOverrideNotice::new();
 
 /// Rule MD055: Table pipe style
 ///
@@ -80,17 +85,74 @@ use md055_config::MD055Config;
 #[derive(Debug, Default, Clone)]
 pub struct MD055TablePipeStyle {
     config: MD055Config,
+    /// Whether `style` came from the configuration rather than from the
+    /// default. MDG enforces leading-and-trailing either way; this only decides
+    /// whether the user is told that the style they asked for was not adopted.
+    style_explicit: bool,
 }
 
 impl MD055TablePipeStyle {
     pub fn new(style: String) -> Self {
         Self {
             config: MD055Config { style },
+            style_explicit: true,
         }
     }
 
     pub fn from_config_struct(config: MD055Config) -> Self {
-        Self { config }
+        Self {
+            config,
+            style_explicit: false,
+        }
+    }
+
+    /// Resolve the style MD055 should converge on.
+    ///
+    /// Gherkin recognizes a Data Table or Examples table row only when an indent
+    /// is followed directly by a pipe, so a style that strips the leading pipe
+    /// does not restyle the table, it deletes it from the document. MDG
+    /// therefore always converges on leading-and-trailing: `consistent` resolves
+    /// to it rather than to whichever form happens to be more prevalent, and an
+    /// explicit style that drops the leading pipe is not adopted.
+    fn effective_configured_style(&self, ctx: &crate::lint_context::LintContext) -> &str {
+        if ctx.flavor == MarkdownFlavor::MDG {
+            self.warn_once_about_overridden_style();
+            return "leading_and_trailing";
+        }
+
+        match self.config.style.as_str() {
+            "leading_and_trailing" | "no_leading_or_trailing" | "leading_only" | "trailing_only" | "consistent" => {
+                self.config.style.as_str()
+            }
+            _ => {
+                // Invalid style provided, default to "leading_and_trailing"
+                "leading_and_trailing"
+            }
+        }
+    }
+
+    /// Tell the user once that MDG did not adopt the style they configured.
+    ///
+    /// Only the three styles that drop a pipe are worth reporting: they are the
+    /// settings MDG cannot satisfy. `consistent` asks for no particular form,
+    /// and leading-and-trailing is what MDG picks for it anyway.
+    fn warn_once_about_overridden_style(&self) {
+        if !self.style_explicit
+            || !matches!(
+                self.config.style.as_str(),
+                "no_leading_or_trailing" | "leading_only" | "trailing_only"
+            )
+        {
+            return;
+        }
+
+        MDG_STYLE_OVERRIDE.report(
+            "MD055",
+            "style",
+            &self.config.style,
+            "leading_and_trailing",
+            "a Gherkin table row is an indent followed directly by a pipe",
+        );
     }
 
     /// Determine the most prevalent table style in a table block
@@ -161,7 +223,7 @@ impl MD055TablePipeStyle {
             content_lines: vec![],
             list_context: None,
         };
-        self.fix_table_row_with_context(line, target_style, &dummy_block, 0)
+        self.fix_table_row_with_context(line, target_style, &dummy_block, 0, MarkdownFlavor::Standard)
     }
 
     /// Fix a table row to match the target style, with full context for list tables
@@ -174,6 +236,7 @@ impl MD055TablePipeStyle {
         target_style: &str,
         table_block: &TableBlock,
         table_line_index: usize,
+        flavor: MarkdownFlavor,
     ) -> String {
         // Extract blockquote prefix first
         let (bq_prefix, after_bq) = TableUtils::extract_blockquote_prefix(line);
@@ -207,10 +270,18 @@ impl MD055TablePipeStyle {
         } else {
             // No list context, just handle blockquote prefix
             let fixed_content = self.fix_table_content(after_bq.trim(), target_style);
-            if bq_prefix.is_empty() {
+            // Gherkin recognizes a table row by its indent, so left-aligning one
+            // while restyling it would take the table out of the document that
+            // the restyle exists to preserve. MD060 still owns the indent's width.
+            let indent = if flavor == MarkdownFlavor::MDG {
+                &after_bq[..after_bq.len() - after_bq.trim_start().len()]
+            } else {
+                ""
+            };
+            if bq_prefix.is_empty() && indent.is_empty() {
                 fixed_content
             } else {
-                format!("{bq_prefix}{fixed_content}")
+                format!("{bq_prefix}{indent}{fixed_content}")
             }
         }
     }
@@ -319,16 +390,7 @@ impl Rule for MD055TablePipeStyle {
 
         let lines = ctx.raw_lines();
 
-        // Get the configured style explicitly and validate it
-        let configured_style = match self.config.style.as_str() {
-            "leading_and_trailing" | "no_leading_or_trailing" | "leading_only" | "trailing_only" | "consistent" => {
-                self.config.style.as_str()
-            }
-            _ => {
-                // Invalid style provided, default to "leading_and_trailing"
-                "leading_and_trailing"
-            }
-        };
+        let configured_style = self.effective_configured_style(ctx);
 
         // Use pre-computed table blocks from context
         let table_blocks = &ctx.table_blocks;
@@ -383,8 +445,13 @@ impl Rule for MD055TablePipeStyle {
 
                         // Build a per-row fix so inline-disabled rows are not
                         // overwritten by fixes on other rows in the same table.
-                        let fixed_line =
-                            self.fix_table_row_with_context(line, target_style, table_block, table_line_idx);
+                        let fixed_line = self.fix_table_row_with_context(
+                            line,
+                            target_style,
+                            table_block,
+                            table_line_idx,
+                            ctx.flavor,
+                        );
                         let row_range = ctx.line_column_byte_range_with_length(line_idx + 1, 1, line.chars().count());
 
                         warnings.push(LintWarning {
@@ -422,7 +489,20 @@ impl Rule for MD055TablePipeStyle {
         self
     }
 
-    crate::impl_rule_config_methods!(MD055Config);
+    crate::impl_rule_config_sections!(MD055Config);
+
+    fn from_config(config: &crate::config::Config) -> Box<dyn Rule>
+    where
+        Self: Sized,
+    {
+        let rule_config = crate::rule_config_serde::load_rule_config::<MD055Config>(config);
+        let style_explicit = option_is_explicit(config, "MD055", "style");
+
+        Box::new(Self {
+            config: rule_config,
+            style_explicit,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -1005,5 +1085,202 @@ Cell 1     Cell 2     Cell 3
             result_std.is_empty(),
             "MD055 already-valid table with caption should have no warnings under Standard: {result_std:?}"
         );
+    }
+
+    // === MDG: the Gherkin form is enforced over an incompatible style ===
+    //
+    // Gherkin recognizes a Data Table or Examples table row only when an indent
+    // is followed directly by a pipe, so a style that strips the leading pipe
+    // does not restyle the table, it deletes it from the document.
+
+    /// Each style a Gherkin document cannot carry, paired with the rows a table
+    /// written in that style would contain.
+    const MDG_INCOMPATIBLE_STYLES: [(&str, [&str; 3]); 3] = [
+        (
+            "no_leading_or_trailing",
+            ["start | eat | left", "----- | --- | ----", "12 | 5 | 7"],
+        ),
+        (
+            "leading_only",
+            ["| start | eat | left", "| ----- | --- | ----", "| 12 | 5 | 7"],
+        ),
+        (
+            "trailing_only",
+            ["start | eat | left |", "----- | --- | ---- |", "12 | 5 | 7 |"],
+        ),
+    ];
+
+    const MDG_GHERKIN_ROWS: [&str; 3] = ["| start | eat | left |", "| ----- | --- | ---- |", "| 12 | 5 | 7 |"];
+
+    fn examples_table(indent: usize, rows: [&str; 3]) -> String {
+        let spaces = " ".repeat(indent);
+        let [header, delimiter, body] = rows;
+        format!("# Feature: Eating\n\n#### Examples:\n\n{spaces}{header}\n{spaces}{delimiter}\n{spaces}{body}\n")
+    }
+
+    #[test]
+    fn test_mdg_enforces_leading_and_trailing_over_incompatible_styles() {
+        // Two to five whitespace characters are all Gherkin accepts before the
+        // pipe, so the whole range has to survive the correction.
+        for (style, rows) in MDG_INCOMPATIBLE_STYLES {
+            let rule = MD055TablePipeStyle::new(style.to_string());
+
+            for indent in [2, 3, 4, 5] {
+                let content = examples_table(indent, rows);
+                let expected = examples_table(indent, MDG_GHERKIN_ROWS);
+                let ctx = crate::lint_context::LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
+
+                assert_eq!(
+                    rule.check(&ctx).unwrap().len(),
+                    3,
+                    "style '{style}' at indent {indent}: every row is in a form MDG cannot accept"
+                );
+
+                let fixed = rule.fix(&ctx).unwrap();
+                assert_eq!(
+                    fixed, expected,
+                    "style '{style}' at indent {indent}: MDG must enforce the Gherkin form and leave the indent alone"
+                );
+
+                let fixed_ctx = crate::lint_context::LintContext::new(&fixed, crate::config::MarkdownFlavor::MDG, None);
+                assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+                assert_eq!(
+                    rule.fix(&fixed_ctx).unwrap(),
+                    fixed,
+                    "style '{style}' at indent {indent}: MDG fix must be idempotent"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_mdg_leaves_a_table_already_in_the_required_form_alone() {
+        // The reproducing case: rows Gherkin already recognizes must survive
+        // every style the user could have configured.
+        let content = examples_table(2, MDG_GHERKIN_ROWS);
+
+        for style in [
+            "consistent",
+            "leading_and_trailing",
+            "no_leading_or_trailing",
+            "leading_only",
+            "trailing_only",
+        ] {
+            let rule = MD055TablePipeStyle::new(style.to_string());
+            let ctx = crate::lint_context::LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
+
+            assert!(
+                rule.check(&ctx).unwrap().is_empty(),
+                "style '{style}': MDG enforces this form, so it cannot be reported"
+            );
+            assert_eq!(rule.fix(&ctx).unwrap(), content, "style '{style}': nothing to correct");
+        }
+    }
+
+    #[test]
+    fn test_mdg_consistent_ignores_prevalence() {
+        // `consistent` asks for no particular form, so it is never warned about;
+        // MDG still resolves it to the Gherkin form rather than to whichever
+        // form the table happens to be written in.
+        let defaulted = MD055TablePipeStyle::default();
+        assert_eq!(defaulted.config.style, "consistent");
+        let explicit = MD055TablePipeStyle::new("consistent".to_string());
+
+        for (style, rows) in MDG_INCOMPATIBLE_STYLES {
+            let content = examples_table(2, rows);
+            let expected = examples_table(2, MDG_GHERKIN_ROWS);
+
+            for rule in [&defaulted, &explicit] {
+                let standard_ctx =
+                    crate::lint_context::LintContext::new(&content, crate::config::MarkdownFlavor::Standard, None);
+                assert!(
+                    rule.check(&standard_ctx).unwrap().is_empty(),
+                    "Standard resolves `consistent` to the table's own '{style}'"
+                );
+
+                let mdg_ctx = crate::lint_context::LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
+                assert_eq!(
+                    rule.fix(&mdg_ctx).unwrap(),
+                    expected,
+                    "MDG must resolve `consistent` to the Gherkin form over a '{style}' table"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_standard_flavor_is_untouched_by_the_mdg_enforcement() {
+        for (style, rows) in MDG_INCOMPATIBLE_STYLES {
+            let rule = MD055TablePipeStyle::new(style.to_string());
+            let content = examples_table(2, rows);
+            let ctx = crate::lint_context::LintContext::new(&content, crate::config::MarkdownFlavor::Standard, None);
+
+            assert!(
+                rule.check(&ctx).unwrap().is_empty(),
+                "style '{style}': Standard must still honour it"
+            );
+            assert_eq!(rule.fix(&ctx).unwrap(), content, "style '{style}': nothing to correct");
+
+            // And it is still applied to a table written the other way round.
+            let mdg_form = examples_table(2, MDG_GHERKIN_ROWS);
+            let mdg_form_ctx =
+                crate::lint_context::LintContext::new(&mdg_form, crate::config::MarkdownFlavor::Standard, None);
+            assert_eq!(
+                rule.check(&mdg_form_ctx).unwrap().len(),
+                3,
+                "style '{style}': Standard must still correct the leading-and-trailing form away"
+            );
+        }
+
+        // Preserving the indent is a Gherkin concession; Standard keeps
+        // left-aligning the rows it rewrites.
+        let rule = MD055TablePipeStyle::new("leading_and_trailing".to_string());
+        let content = examples_table(2, MDG_INCOMPATIBLE_STYLES[0].1);
+        let ctx = crate::lint_context::LintContext::new(&content, crate::config::MarkdownFlavor::Standard, None);
+        assert_eq!(
+            rule.fix(&ctx).unwrap(),
+            examples_table(0, MDG_GHERKIN_ROWS),
+            "Standard must keep stripping the indent"
+        );
+    }
+
+    #[test]
+    fn test_from_config_records_whether_style_was_configured() {
+        // The MDG override applies either way, but the warning is only for a
+        // style the user actually asked for, so a configured style has to be
+        // told apart from a defaulted one.
+        use crate::config::Config;
+        use std::collections::BTreeMap;
+
+        let mut values = BTreeMap::new();
+        values.insert(
+            "style".to_string(),
+            toml::Value::String("no_leading_or_trailing".to_string()),
+        );
+        let mut config = Config::default();
+        config.rules.insert(
+            "MD055".to_string(),
+            crate::config::RuleConfig { severity: None, values },
+        );
+
+        let configured = MD055TablePipeStyle::from_config(&config);
+        let configured = configured.as_any().downcast_ref::<MD055TablePipeStyle>().unwrap();
+        assert_eq!(configured.config.style, "no_leading_or_trailing");
+        assert!(configured.style_explicit);
+
+        let defaulted = MD055TablePipeStyle::from_config(&Config::default());
+        let defaulted = defaulted.as_any().downcast_ref::<MD055TablePipeStyle>().unwrap();
+        assert_eq!(defaulted.config.style, "consistent");
+        assert!(!defaulted.style_explicit);
+
+        // The override does not depend on the warning: a defaulted incompatible
+        // style is enforced just the same.
+        let unreported = MD055TablePipeStyle::from_config_struct(MD055Config {
+            style: "no_leading_or_trailing".to_string(),
+        });
+        assert!(!unreported.style_explicit);
+        let content = examples_table(2, MDG_INCOMPATIBLE_STYLES[0].1);
+        let ctx = crate::lint_context::LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(unreported.fix(&ctx).unwrap(), examples_table(2, MDG_GHERKIN_ROWS));
     }
 }

--- a/src/rules/md060_table_format.rs
+++ b/src/rules/md060_table_format.rs
@@ -1,4 +1,5 @@
 use crate::rule::{LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::utils::mdg;
 use crate::utils::range_utils::calculate_line_range;
 use crate::utils::regex_cache::BLOCKQUOTE_PREFIX_RE;
 use crate::utils::table_utils::TableUtils;
@@ -290,6 +291,27 @@ impl MD060TableFormat {
         } else {
             ("", line)
         }
+    }
+
+    /// The indentation every row of an MDG Data Table or Examples table is
+    /// rewritten to, or `None` when the table is not one Gherkin recognizes.
+    ///
+    /// Two spaces is always inside Gherkin's range, so rows written anywhere in
+    /// it are normalized to two rather than left as written. Inside a list item
+    /// the rows must also reach the item's content column to stay part of that
+    /// item, and past Gherkin's limit no indentation satisfies both, so the
+    /// table is left to the ordinary Markdown handling.
+    fn mdg_table_indent(
+        table_lines: &[&str],
+        list_content_indent: Option<usize>,
+        flavor: crate::config::MarkdownFlavor,
+    ) -> Option<String> {
+        if flavor != crate::config::MarkdownFlavor::MDG || !table_lines.iter().all(|line| mdg::is_table_row(line)) {
+            return None;
+        }
+
+        let indent = list_content_indent.unwrap_or(0).max(mdg::MIN_TABLE_INDENT);
+        (indent <= mdg::MAX_TABLE_INDENT).then(|| " ".repeat(indent))
     }
 
     fn parse_column_alignments(delimiter_row: &[String]) -> Vec<ColumnAlignment> {
@@ -774,6 +796,11 @@ impl MD060TableFormat {
         } else {
             ("", String::new())
         };
+        let mdg_indent = Self::mdg_table_indent(
+            &table_lines,
+            list_context.as_ref().map(|ctx| ctx.content_indent),
+            flavor,
+        );
 
         // Strip blockquote prefix and list prefix from all lines for processing
         let stripped_lines: Vec<&str> = table_lines
@@ -781,7 +808,9 @@ impl MD060TableFormat {
             .enumerate()
             .map(|(i, line)| {
                 let after_blockquote = Self::extract_blockquote_prefix(line).1;
-                if list_context.is_some() {
+                if mdg_indent.is_some() {
+                    after_blockquote.trim_start_matches([' ', '\t'])
+                } else if list_context.is_some() {
                     if i == 0 {
                         // Header line: strip list prefix (handles both markers and indentation)
                         after_blockquote.strip_prefix(list_prefix).unwrap_or_else(|| {
@@ -963,7 +992,9 @@ impl MD060TableFormat {
             .into_iter()
             .enumerate()
             .map(|(i, line)| {
-                if list_context.is_some() {
+                if let Some(mdg_indent) = &mdg_indent {
+                    format!("{blockquote_prefix}{mdg_indent}{line}")
+                } else if list_context.is_some() {
                     if i == 0 {
                         // Header line: add list prefix
                         format!("{blockquote_prefix}{list_prefix}{line}")
@@ -2745,5 +2776,124 @@ Cell 1     Cell 2
         let ctx2 = LintContext::new(&once, crate::config::MarkdownFlavor::Standard, None);
         let twice = rule.fix(&ctx2).unwrap();
         assert_eq!(once, twice, "MD060 fix must be idempotent with trailing blank lines");
+    }
+
+    /// Indent every line of `block` by `indent` spaces.
+    fn indent_block(block: &str, indent: usize) -> String {
+        let spaces = " ".repeat(indent);
+        block.lines().fold(String::new(), |mut indented, line| {
+            indented.push_str(&spaces);
+            indented.push_str(line);
+            indented.push('\n');
+            indented
+        })
+    }
+
+    #[test]
+    fn test_mdg_table_indent_stays_within_enclosing_list_item() {
+        // Two spaces is Gherkin's canonical table indent, but a table dedented
+        // to it falls below the content column of an ordered or nested item and
+        // is no longer part of that item, so the deeper column wins while it is
+        // still one Gherkin reads as a table.
+        let rule = MD060TableFormat::new(true, "aligned".to_string());
+        let written = "| name | price |\n|---|---|\n| a | b |\n";
+        let formatted = "| name | price |\n| ---- | ----- |\n| a    | b     |\n";
+
+        // (lines opening the item, indent as written, indent after the fix)
+        let cases = [
+            ("* Given", 2, 2),
+            ("* Given", 5, 2),
+            ("1. Given", 3, 3),
+            ("1. Given", 5, 3),
+            ("* Given\n  * Nested", 4, 4),
+            ("* Given\n  * Nested", 5, 4),
+        ];
+
+        for (item, indent, expected_indent) in cases {
+            let input = format!("# Feature: F\n\n{item}\n\n{}", indent_block(written, indent));
+            let expected = format!("# Feature: F\n\n{item}\n\n{}", indent_block(formatted, expected_indent));
+            let ctx = LintContext::new(&input, crate::config::MarkdownFlavor::MDG, None);
+
+            assert_eq!(
+                rule.fix(&ctx).unwrap(),
+                expected,
+                "a {indent}-space table under {item:?} belongs at {expected_indent} spaces"
+            );
+
+            let fixed_ctx = LintContext::new(&expected, crate::config::MarkdownFlavor::MDG, None);
+            assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+            assert_eq!(rule.fix(&fixed_ctx).unwrap(), expected, "MD060 fix must be idempotent");
+        }
+    }
+
+    #[test]
+    fn test_mdg_table_below_a_deep_list_item_keeps_list_indentation() {
+        // The item's content column is past the 5 whitespace characters Gherkin
+        // reads as a table, so no indentation both keeps the rows in the item
+        // and keeps them a Gherkin table: format them as ordinary Markdown.
+        let rule = MD060TableFormat::new(true, "aligned".to_string());
+        let input = "# Feature: F\n\n* A\n  * B\n    * C\n\n      | name | price |\n      |---|---|\n      | a | b |\n";
+        let expected = "# Feature: F\n\n* A\n  * B\n    * C\n\n      | name | price |\n      | ---- | ----- |\n      | a    | b     |\n";
+
+        let mdg = rule
+            .fix(&LintContext::new(input, crate::config::MarkdownFlavor::MDG, None))
+            .unwrap();
+        assert_eq!(mdg, expected);
+        assert_eq!(
+            mdg,
+            rule.fix(&LintContext::new(input, crate::config::MarkdownFlavor::Standard, None))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_mdg_tab_indented_table_is_normalized_not_flattened() {
+        // Gherkin reads a table indent as 2-5 whitespace characters, tabs
+        // included, so tabbed rows are normalized like spaced ones. Flattening
+        // them to column 0 would drop the table from the Gherkin document.
+        let rule = MD060TableFormat::new(true, "aligned".to_string());
+        let input = "# Feature: F\n\n#### Examples:\n\n\t\t| a | bb |\n\t\t|---|---|\n\t\t| 1 | 2 |\n";
+        let expected = "# Feature: F\n\n#### Examples:\n\n  | a   | bb  |\n  | --- | --- |\n  | 1   | 2   |\n";
+
+        let ctx = LintContext::new(input, crate::config::MarkdownFlavor::MDG, None);
+        assert_eq!(rule.fix(&ctx).unwrap(), expected);
+
+        let fixed_ctx = LintContext::new(expected, crate::config::MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+
+        let standard = rule
+            .fix(&LintContext::new(input, crate::config::MarkdownFlavor::Standard, None))
+            .unwrap();
+        assert!(
+            standard.lines().any(|line| line.starts_with("| a")),
+            "tab handling is Gherkin-only, got: {standard:?}"
+        );
+    }
+
+    #[test]
+    fn test_mdg_table_row_needs_a_pipe_behind_its_indent() {
+        // Gherkin reads a table row as 2-5 whitespace characters followed by a
+        // pipe, so a blockquote or list marker in that position makes the rows
+        // ordinary Markdown: re-indenting them would corrupt the enclosing
+        // construct instead of preserving a Gherkin table.
+        let rule = MD060TableFormat::new(true, "aligned".to_string());
+
+        for input in [
+            "# Feature: F\n\n  > | a | b |\n  > |---|---|\n  > | 1 | 2 |\n",
+            "# Feature: F\n\n  - | a | b |\n    |---|---|\n    | 1 | 2 |\n",
+        ] {
+            let mdg = rule
+                .fix(&LintContext::new(input, crate::config::MarkdownFlavor::MDG, None))
+                .unwrap();
+            assert_eq!(
+                mdg,
+                rule.fix(&LintContext::new(input, crate::config::MarkdownFlavor::Standard, None))
+                    .unwrap(),
+                "{input:?} is not a Gherkin table, so both flavors must agree"
+            );
+
+            let fixed_ctx = LintContext::new(&mdg, crate::config::MarkdownFlavor::MDG, None);
+            assert_eq!(rule.fix(&fixed_ctx).unwrap(), mdg, "MD060 fix must converge");
+        }
     }
 }

--- a/src/rules/md063_heading_capitalization.rs
+++ b/src/rules/md063_heading_capitalization.rs
@@ -12,6 +12,7 @@
 /// style = "title_case"
 /// ```
 use crate::rule::{Fix, LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::utils::mdg;
 use crate::utils::range_utils::byte_to_char_count;
 use regex::Regex;
 use std::collections::HashSet;
@@ -728,12 +729,24 @@ impl MD063HeadingCapitalization {
     }
 
     /// Apply capitalization to heading text
-    fn apply_capitalization(&self, text: &str) -> String {
+    fn apply_capitalization(&self, text: &str, flavor: crate::config::MarkdownFlavor) -> String {
         // Strip custom ID if present and re-add later
         let (main_text, custom_id) = if let Some(mat) = CUSTOM_ID_REGEX.find(text) {
             (&text[..mat.start()], Some(mat.as_str()))
         } else {
             (text, None)
+        };
+
+        // Markdown with Gherkin spells every structure as a `Keyword: name` heading, and
+        // a keyword names a structure only when spelled exactly, so recasing starts after
+        // the colon and the keyword is copied through verbatim. The split precedes segment
+        // parsing so the keyword keeps its own spacing and never counts as the heading's
+        // first or last word, and so a code span the split declines stays visible to the
+        // parser below instead of having its contents recased.
+        let (keyword, main_text) = if flavor == crate::config::MarkdownFlavor::MDG {
+            mdg::keyword_split(main_text).unwrap_or(("", main_text))
+        } else {
+            ("", main_text)
         };
 
         // Parse into segments
@@ -828,7 +841,9 @@ impl MD063HeadingCapitalization {
             };
         }
 
-        let mut result = result_parts.join("");
+        let mut result = String::with_capacity(text.len());
+        result.push_str(keyword);
+        result.push_str(&result_parts.join(""));
 
         // Re-add custom ID if present
         if let Some(id) = custom_id {
@@ -906,13 +921,18 @@ impl MD063HeadingCapitalization {
     }
 
     /// Fix an ATX heading line
-    fn fix_atx_heading(&self, _line: &str, heading: &crate::lint_context::HeadingInfo) -> String {
+    fn fix_atx_heading(
+        &self,
+        _line: &str,
+        heading: &crate::lint_context::HeadingInfo,
+        flavor: crate::config::MarkdownFlavor,
+    ) -> String {
         // Parse the line to preserve structure
         let indent = " ".repeat(heading.marker_column);
         let hashes = "#".repeat(heading.level as usize);
 
         // Apply capitalization to the text
-        let fixed_text = self.apply_capitalization(&heading.raw_text);
+        let fixed_text = self.apply_capitalization(&heading.raw_text, flavor);
 
         // Reconstruct with closing sequence if present
         let closing = &heading.closing_sequence;
@@ -924,9 +944,14 @@ impl MD063HeadingCapitalization {
     }
 
     /// Fix a Setext heading line
-    fn fix_setext_heading(&self, line: &str, heading: &crate::lint_context::HeadingInfo) -> String {
+    fn fix_setext_heading(
+        &self,
+        line: &str,
+        heading: &crate::lint_context::HeadingInfo,
+        flavor: crate::config::MarkdownFlavor,
+    ) -> String {
         // Apply capitalization to the text
-        let fixed_text = self.apply_capitalization(&heading.raw_text);
+        let fixed_text = self.apply_capitalization(&heading.raw_text, flavor);
 
         // Preserve leading whitespace from original line
         let leading_ws: String = line.chars().take_while(|c| c.is_whitespace()).collect();
@@ -980,7 +1005,7 @@ impl Rule for MD063HeadingCapitalization {
 
                 // Apply capitalization and compare
                 let original_text = &heading.raw_text;
-                let fixed_text = self.apply_capitalization(original_text);
+                let fixed_text = self.apply_capitalization(original_text, ctx.flavor);
 
                 if original_text != &fixed_text {
                     let line = line_info.content(ctx.content);
@@ -1001,8 +1026,10 @@ impl Rule for MD063HeadingCapitalization {
                         fix: Some(Fix::new(
                             ctx.line_content_byte_range(line_num + 1),
                             match heading.style {
-                                crate::lint_context::HeadingStyle::ATX => self.fix_atx_heading(line, heading),
-                                _ => self.fix_setext_heading(line, heading),
+                                crate::lint_context::HeadingStyle::ATX => {
+                                    self.fix_atx_heading(line, heading, ctx.flavor)
+                                }
+                                _ => self.fix_setext_heading(line, heading, ctx.flavor),
                             },
                         )),
                     });
@@ -1046,13 +1073,13 @@ impl Rule for MD063HeadingCapitalization {
                 }
 
                 let original_text = &heading.raw_text;
-                let fixed_text = self.apply_capitalization(original_text);
+                let fixed_text = self.apply_capitalization(original_text, ctx.flavor);
 
                 if original_text != &fixed_text {
                     let line = line_info.content(ctx.content);
                     fixed_lines[line_num] = match heading.style {
-                        crate::lint_context::HeadingStyle::ATX => self.fix_atx_heading(line, heading),
-                        _ => self.fix_setext_heading(line, heading),
+                        crate::lint_context::HeadingStyle::ATX => self.fix_atx_heading(line, heading, ctx.flavor),
+                        _ => self.fix_setext_heading(line, heading, ctx.flavor),
                     };
                 }
             }
@@ -3292,5 +3319,243 @@ mod tests {
             suggested(&rule, "# Requirement 1: Struct to Logger Slice Conversion\n").as_deref(),
             Some("Requirement 1: struct to logger slice conversion")
         );
+    }
+
+    // Markdown with Gherkin
+
+    const STYLES: [HeadingCapStyle; 3] = [
+        HeadingCapStyle::TitleCase,
+        HeadingCapStyle::SentenceCase,
+        HeadingCapStyle::AllCaps,
+    ];
+
+    /// Every Gherkin structure keyword, each with a name all three styles rewrite:
+    /// (heading, title case, sentence case, all caps).
+    const GHERKIN_STRUCTURES: [(&str, &str, &str, &str); 6] = [
+        (
+            "# Feature: the system under test",
+            "# Feature: The System Under Test",
+            "# Feature: The system under test",
+            "# Feature: THE SYSTEM UNDER TEST",
+        ),
+        (
+            "## Background: a shared setup",
+            "## Background: A Shared Setup",
+            "## Background: A shared setup",
+            "## Background: A SHARED SETUP",
+        ),
+        (
+            "## Rule: money is never lost",
+            "## Rule: Money Is Never Lost",
+            "## Rule: Money is never lost",
+            "## Rule: MONEY IS NEVER LOST",
+        ),
+        (
+            "### Scenario: add two numbers",
+            "### Scenario: Add Two Numbers",
+            "### Scenario: Add two numbers",
+            "### Scenario: ADD TWO NUMBERS",
+        ),
+        (
+            "### Scenario Outline: add two numbers",
+            "### Scenario Outline: Add Two Numbers",
+            "### Scenario Outline: Add two numbers",
+            "### Scenario Outline: ADD TWO NUMBERS",
+        ),
+        (
+            "#### Examples: happy path",
+            "#### Examples: Happy Path",
+            "#### Examples: Happy path",
+            "#### Examples: HAPPY PATH",
+        ),
+    ];
+
+    /// The heading MD063 leaves behind under `flavor`, rewritten or not.
+    fn recased(style: HeadingCapStyle, heading: &str, flavor: crate::config::MarkdownFlavor) -> String {
+        let rule = create_rule_with_style(style);
+        let content = format!("{heading}\n");
+        let ctx = LintContext::new(&content, flavor, None);
+        let warnings = rule.check(&ctx).unwrap();
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(
+            warnings.is_empty(),
+            fixed == content,
+            "a warning and a rewrite must agree for {content:?} under {flavor:?}"
+        );
+        fixed.trim_end().to_string()
+    }
+
+    #[test]
+    fn test_mdg_keeps_the_keyword_of_every_structure() {
+        // A keyword only names a structure when spelled exactly, so a recased one
+        // silently turns the structure into prose.
+        for (heading, ..) in GHERKIN_STRUCTURES {
+            let keyword = &heading[..=heading.find(':').unwrap()];
+            for style in STYLES {
+                let fixed = recased(style, heading, crate::config::MarkdownFlavor::MDG);
+                assert!(
+                    fixed.starts_with(keyword),
+                    "{style:?} lost the keyword of {heading:?}: {fixed}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_mdg_recases_only_the_name_of_a_structure() {
+        for (heading, title, sentence, caps) in GHERKIN_STRUCTURES {
+            let mdg = crate::config::MarkdownFlavor::MDG;
+            assert_eq!(recased(HeadingCapStyle::TitleCase, heading, mdg), title);
+            assert_eq!(recased(HeadingCapStyle::SentenceCase, heading, mdg), sentence);
+            assert_eq!(recased(HeadingCapStyle::AllCaps, heading, mdg), caps);
+        }
+    }
+
+    #[test]
+    fn test_standard_flavor_recases_a_keyword_like_any_other_word() {
+        // The exemption belongs to the flavor, not to the rule.
+        let standard = crate::config::MarkdownFlavor::Standard;
+        assert_eq!(
+            recased(HeadingCapStyle::TitleCase, "# Feature: the system under test", standard),
+            "# Feature: the System Under Test"
+        );
+        assert_eq!(
+            recased(
+                HeadingCapStyle::SentenceCase,
+                "### Scenario Outline: add two numbers",
+                standard
+            ),
+            "### Scenario outline: add two numbers"
+        );
+        assert_eq!(
+            recased(HeadingCapStyle::AllCaps, "# Feature: the system under test", standard),
+            "# FEATURE: THE SYSTEM UNDER TEST"
+        );
+    }
+
+    #[test]
+    fn test_mdg_leaves_a_heading_without_a_colon_to_the_normal_rule() {
+        for heading in ["## notes about the system", "## Notes", "# THE SYSTEM"] {
+            for style in STYLES {
+                assert_eq!(
+                    recased(style, heading, crate::config::MarkdownFlavor::MDG),
+                    recased(style, heading, crate::config::MarkdownFlavor::Standard),
+                    "{style:?} treated {heading:?} as a Gherkin structure"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_mdg_splits_at_the_first_colon_only() {
+        // A later colon belongs to the name, which is prose this rule still owns.
+        let mdg = crate::config::MarkdownFlavor::MDG;
+        let heading = "## Scenario: ratio: two to one";
+        assert_eq!(
+            recased(HeadingCapStyle::TitleCase, heading, mdg),
+            "## Scenario: Ratio: Two to One"
+        );
+        assert_eq!(
+            recased(HeadingCapStyle::SentenceCase, heading, mdg),
+            "## Scenario: Ratio: two to one"
+        );
+        assert_eq!(
+            recased(HeadingCapStyle::AllCaps, heading, mdg),
+            "## Scenario: RATIO: TWO TO ONE"
+        );
+    }
+
+    #[test]
+    fn test_mdg_leaves_a_colon_behind_a_backtick_to_the_normal_rule() {
+        // Dialect keywords are plain words, so such a colon is inside a code span rather
+        // than after a keyword. Splitting there would hide the span from the segment
+        // parser and recase what a reader sees as code.
+        for heading in [
+            "# See `x: y` Notes",
+            "# `a: b`",
+            "# `code` Feature: a name",
+            "# `x: y` Feature: a name",
+        ] {
+            for style in STYLES {
+                assert_eq!(
+                    recased(style, heading, crate::config::MarkdownFlavor::MDG),
+                    recased(style, heading, crate::config::MarkdownFlavor::Standard),
+                    "{style:?} split {heading:?} at a colon inside a code span"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_mdg_splits_at_a_keyword_colon_that_precedes_a_code_span() {
+        // The backtick is in the name, so the keyword colon still governs.
+        let mdg = crate::config::MarkdownFlavor::MDG;
+        let heading = "# Scenario: use `a: b` here";
+        assert_eq!(
+            recased(HeadingCapStyle::TitleCase, heading, mdg),
+            "# Scenario: Use `a: b` Here"
+        );
+        assert_eq!(
+            recased(HeadingCapStyle::SentenceCase, heading, mdg),
+            "# Scenario: Use `a: b` here"
+        );
+        assert_eq!(
+            recased(HeadingCapStyle::AllCaps, heading, mdg),
+            "# Scenario: USE `a: b` HERE"
+        );
+    }
+
+    #[test]
+    fn test_mdg_splits_at_a_keyword_colon_before_an_unbalanced_backtick() {
+        // An unclosed backtick opens no code span for either flavor, so the tail stays
+        // prose and only the keyword is held back.
+        let mdg = crate::config::MarkdownFlavor::MDG;
+        let heading = "# Scenario: a ` b";
+        assert_eq!(recased(HeadingCapStyle::TitleCase, heading, mdg), "# Scenario: A ` B");
+        assert_eq!(
+            recased(HeadingCapStyle::SentenceCase, heading, mdg),
+            "# Scenario: A ` b"
+        );
+        assert_eq!(recased(HeadingCapStyle::AllCaps, heading, mdg), "# Scenario: A ` B");
+    }
+
+    #[test]
+    fn test_mdg_keeps_a_keyword_with_nothing_left_to_recase() {
+        for style in STYLES {
+            assert_eq!(
+                recased(style, "# Feature:", crate::config::MarkdownFlavor::MDG),
+                "# Feature:"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mdg_keeps_a_custom_id_after_the_name() {
+        assert_eq!(
+            recased(
+                HeadingCapStyle::TitleCase,
+                "# Feature: the system {#overview}",
+                crate::config::MarkdownFlavor::MDG
+            ),
+            "# Feature: The System {#overview}"
+        );
+    }
+
+    #[test]
+    fn test_mdg_fix_is_idempotent() {
+        for (heading, ..) in GHERKIN_STRUCTURES {
+            for style in STYLES {
+                let rule = create_rule_with_style(style);
+                let content = format!("{heading}\n");
+                let ctx = LintContext::new(&content, crate::config::MarkdownFlavor::MDG, None);
+                let once = rule.fix(&ctx).unwrap();
+                let ctx = LintContext::new(&once, crate::config::MarkdownFlavor::MDG, None);
+                assert_eq!(
+                    rule.fix(&ctx).unwrap(),
+                    once,
+                    "fix is not idempotent for {heading:?} ({style:?})"
+                );
+            }
+        }
     }
 }

--- a/src/utils/mdg.rs
+++ b/src/utils/mdg.rs
@@ -1,0 +1,155 @@
+//! Line-level tokens the Markdown with Gherkin flavor inherits from Gherkin.
+//!
+//! Gherkin is line-oriented: its parser classifies each line on its own, by a
+//! leading marker and nothing else. MDG embeds three of those shapes in
+//! Markdown, where each one collides with a Markdown construct that would
+//! otherwise rewrite or delete it:
+//!
+//! - a Data Table or Examples row, matched as `/^\s\s\s?\s?\s?\|/`, whose
+//!   indentation overlaps the 4-column indented-code threshold;
+//! - a tag line, spelled in MDG as backtick-wrapped `@tags` so Gherkin's bare
+//!   `@tag` survives as Markdown, which binds to the structure on the very next
+//!   line;
+//! - a structure heading, `Keyword: name`, whose keyword is a dialect term that
+//!   names a structure only when spelled exactly.
+//!
+//! Each rule decides for itself what to do about a token; this module only says
+//! what Gherkin sees.
+
+/// The narrowest indentation Gherkin accepts for a Data Table or Examples
+/// table, and therefore the canonical width such a table is normalized to.
+pub const MIN_TABLE_INDENT: usize = 2;
+
+/// The widest indentation Gherkin still reads as such a table.
+pub const MAX_TABLE_INDENT: usize = 5;
+
+/// Whether `line` is a row of a Gherkin Data Table or Examples table.
+///
+/// Gherkin matches such a row as 2-5 whitespace characters followed by a pipe,
+/// so a tab counts like a space. Anything else in that position, a blockquote
+/// marker or a list marker included, stays ordinary Markdown.
+pub fn is_table_row(line: &str) -> bool {
+    let indent = line.bytes().take_while(|&byte| byte == b' ' || byte == b'\t').count();
+    (MIN_TABLE_INDENT..=MAX_TABLE_INDENT).contains(&indent) && line.as_bytes().get(indent) == Some(&b'|')
+}
+
+/// Whether a line consists solely of backtick-wrapped Gherkin tags.
+pub fn is_tag_line(line: &str) -> bool {
+    let mut rest = line.trim();
+    let mut found_tag = false;
+
+    while let Some(after_open) = rest.strip_prefix('`') {
+        let Some(close) = after_open.find('`') else {
+            return false;
+        };
+        let tag = &after_open[..close];
+        if !tag.starts_with('@') || tag.len() == 1 || tag.chars().any(char::is_whitespace) {
+            return false;
+        }
+        found_tag = true;
+        rest = after_open[close + 1..].trim_start();
+    }
+
+    found_tag && rest.is_empty()
+}
+
+/// Split a structure heading into its keyword, colon included, and the name
+/// that follows, or `None` when the text names no structure.
+///
+/// The colon alone marks the structure: keywords are localized, so no list of
+/// them can name them all. A backtick before the colon does disqualify it
+/// though: dialect keywords are one or two plain words, so such a colon is
+/// inside a code span rather than behind a keyword.
+pub fn keyword_split(text: &str) -> Option<(&str, &str)> {
+    let colon = text.find(':')?;
+    (!text[..colon].contains('`')).then(|| text.split_at(colon + 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_row_accepts_gherkins_whole_indent_range() {
+        for indent in ["  ", "   ", "    ", "     ", "\t\t", " \t", "\t   \t"] {
+            assert!(
+                is_table_row(&format!("{indent}| a | b |")),
+                "{indent:?} indents a table"
+            );
+        }
+    }
+
+    #[test]
+    fn table_row_rejects_an_indent_outside_the_range() {
+        for indent in ["", " ", "      ", "\t\t\t\t\t\t"] {
+            assert!(
+                !is_table_row(&format!("{indent}| a | b |")),
+                "{indent:?} is outside Gherkin's range"
+            );
+        }
+    }
+
+    #[test]
+    fn table_row_needs_a_pipe_behind_its_indent() {
+        for line in ["  > | a | b |", "  - | a | b |", "  text | a |", "   ", "  "] {
+            assert!(!is_table_row(line), "{line:?} is not a table row");
+        }
+    }
+
+    #[test]
+    fn tag_line_holds_one_or_more_wrapped_tags_and_nothing_else() {
+        for line in ["`@browser`", "`@checkout` `@smoke`", "  `@a`\t`@b`  ", "`@a``@b`"] {
+            assert!(is_tag_line(line), "{line:?} is a tag line");
+        }
+    }
+
+    #[test]
+    fn tag_line_rejects_anything_beside_the_tags() {
+        // MDG has no `#` comment syntax, so a trailing comment is just prose.
+        for line in [
+            "",
+            "   ",
+            "plain prose",
+            "`@browser` and prose",
+            "`@browser` #a comment",
+            "@browser",
+            "`browser`",
+            "`@`",
+            "`@a b`",
+            "`@a",
+            "prose `@a`",
+        ] {
+            assert!(!is_tag_line(line), "{line:?} is not a tag line");
+        }
+    }
+
+    #[test]
+    fn keyword_split_keeps_the_colon_with_the_keyword() {
+        assert_eq!(keyword_split("Feature: Checkout"), Some(("Feature:", " Checkout")));
+        assert_eq!(keyword_split("Scenario:name"), Some(("Scenario:", "name")));
+        assert_eq!(keyword_split("Examples:"), Some(("Examples:", "")));
+    }
+
+    #[test]
+    fn keyword_split_takes_the_first_colon() {
+        // A later colon belongs to the name, which stays prose.
+        assert_eq!(keyword_split("Scenario: a: b"), Some(("Scenario:", " a: b")));
+    }
+
+    #[test]
+    fn keyword_split_declines_a_colon_behind_a_backtick() {
+        assert_eq!(keyword_split("A `b: c` d"), None);
+        assert_eq!(keyword_split("`a: b"), None);
+    }
+
+    #[test]
+    fn keyword_split_declines_text_without_a_colon() {
+        assert_eq!(keyword_split("Notes"), None);
+        assert_eq!(keyword_split(""), None);
+    }
+
+    #[test]
+    fn keyword_split_takes_a_keyword_colon_that_precedes_a_backtick() {
+        assert_eq!(keyword_split("Scenario: a `b` c"), Some(("Scenario:", " a `b` c")));
+    }
+}

--- a/src/utils/mdg.rs
+++ b/src/utils/mdg.rs
@@ -1,9 +1,9 @@
 //! Line-level tokens the Markdown with Gherkin flavor inherits from Gherkin.
 //!
-//! Gherkin is line-oriented: its parser classifies each line on its own, by a
-//! leading marker and nothing else. MDG embeds three of those shapes in
-//! Markdown, where each one collides with a Markdown construct that would
-//! otherwise rewrite or delete it:
+//! Gherkin is line-oriented: its parser classifies Markdown content one line at
+//! a time. MDG embeds three of its recognized shapes in Markdown, where each
+//! one collides with a Markdown construct that would otherwise rewrite or
+//! delete it:
 //!
 //! - a Data Table or Examples row, matched as `/^\s\s\s?\s?\s?\|/`, whose
 //!   indentation overlaps the 4-column indented-code threshold;
@@ -15,6 +15,13 @@
 //!
 //! Each rule decides for itself what to do about a token; this module only says
 //! what Gherkin sees.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// The JavaScript reference matcher scans globally rather than requiring the
+/// whole line to consist of tags.
+static TAG_TOKEN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`(@[^`]+)`").unwrap());
 
 /// The narrowest indentation Gherkin accepts for a Data Table or Examples
 /// table, and therefore the canonical width such a table is normalized to.
@@ -33,24 +40,13 @@ pub fn is_table_row(line: &str) -> bool {
     (MIN_TABLE_INDENT..=MAX_TABLE_INDENT).contains(&indent) && line.as_bytes().get(indent) == Some(&b'|')
 }
 
-/// Whether a line consists solely of backtick-wrapped Gherkin tags.
+/// Whether Gherkin finds at least one backtick-wrapped tag on a line.
+///
+/// This deliberately mirrors the reference `/`(@[^`]+)`/g` scan: surrounding
+/// prose and trailing comments do not disqualify a tag, and the tag body may
+/// contain whitespace or `#` as long as it reaches a closing backtick.
 pub fn is_tag_line(line: &str) -> bool {
-    let mut rest = line.trim();
-    let mut found_tag = false;
-
-    while let Some(after_open) = rest.strip_prefix('`') {
-        let Some(close) = after_open.find('`') else {
-            return false;
-        };
-        let tag = &after_open[..close];
-        if !tag.starts_with('@') || tag.len() == 1 || tag.chars().any(char::is_whitespace) {
-            return false;
-        }
-        found_tag = true;
-        rest = after_open[close + 1..].trim_start();
-    }
-
-    found_tag && rest.is_empty()
+    TAG_TOKEN.is_match(line)
 }
 
 /// Split a structure heading into its keyword, colon included, and the name
@@ -97,28 +93,24 @@ mod tests {
     }
 
     #[test]
-    fn tag_line_holds_one_or_more_wrapped_tags_and_nothing_else() {
-        for line in ["`@browser`", "`@checkout` `@smoke`", "  `@a`\t`@b`  ", "`@a``@b`"] {
+    fn tag_line_matches_gherkin_reference_scan() {
+        for line in [
+            "`@browser`",
+            "`@checkout` `@smoke`",
+            "  `@a`\t`@b`  ",
+            "`@a``@b`",
+            "`@comment_tag1` #a comment",
+            "prose `@a` after",
+            "`@a b`",
+            "`@comment_tag#2` #a comment",
+        ] {
             assert!(is_tag_line(line), "{line:?} is a tag line");
         }
     }
 
     #[test]
-    fn tag_line_rejects_anything_beside_the_tags() {
-        // MDG has no `#` comment syntax, so a trailing comment is just prose.
-        for line in [
-            "",
-            "   ",
-            "plain prose",
-            "`@browser` and prose",
-            "`@browser` #a comment",
-            "@browser",
-            "`browser`",
-            "`@`",
-            "`@a b`",
-            "`@a",
-            "prose `@a`",
-        ] {
+    fn tag_line_requires_at_least_one_complete_wrapped_tag() {
+        for line in ["", "   ", "plain prose", "@browser", "`browser`", "`@`", "`@a"] {
             assert!(!is_tag_line(line), "{line:?} is not a tag line");
         }
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,6 +14,7 @@ pub mod html_block;
 pub mod jinja_utils;
 pub mod kramdown_utils;
 pub mod line_ending;
+pub mod mdg;
 pub mod mkdocs_admonitions;
 pub mod mkdocs_attr_list;
 pub mod mkdocs_common;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -193,7 +193,7 @@ pub struct LinterConfig {
     /// Line length limit (default: 80)
     pub line_length: Option<u64>,
 
-    /// Markdown flavor: "standard", "mkdocs", "mdx", "pandoc", "quarto", "obsidian", "kramdown", "azure_devops", "myst", or "hugo"
+    /// Markdown flavor: "standard", "mkdocs", "mdx", "pandoc", "quarto", "obsidian", "kramdown", "azure_devops", "myst", "hugo", or "mdg"
     pub flavor: Option<String>,
 
     /// Rules allowed to apply fixes (if specified, only these rules are fixed)
@@ -1097,6 +1097,14 @@ mod tests {
             .markdown_flavor(),
             MarkdownFlavor::Standard
         );
+        assert_eq!(
+            LinterConfig {
+                flavor: Some("markdown_with_gherkin".to_string()),
+                ..Default::default()
+            }
+            .markdown_flavor(),
+            MarkdownFlavor::MDG
+        );
     }
 
     /// This test ensures all MarkdownFlavor variants are handled in WASM.
@@ -1116,6 +1124,7 @@ mod tests {
             MarkdownFlavor::AzureDevOps,
             MarkdownFlavor::MyST,
             MarkdownFlavor::Hugo,
+            MarkdownFlavor::MDG,
         ];
 
         for flavor in flavors {
@@ -1131,6 +1140,7 @@ mod tests {
                 MarkdownFlavor::AzureDevOps => "azure_devops",
                 MarkdownFlavor::MyST => "myst",
                 MarkdownFlavor::Hugo => "hugo",
+                MarkdownFlavor::MDG => "mdg",
             };
 
             let config = LinterConfig {

--- a/tests/cli/cli_flavor_test.rs
+++ b/tests/cli/cli_flavor_test.rs
@@ -92,14 +92,19 @@ fn test_flavor_help_lists_mdg() {
         stdout.contains("markdown_with_gherkin"),
         "Help should list the markdown_with_gherkin alias. stdout: {stdout}"
     );
+    let normalized = stdout.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        normalized.contains("myst (also accepts mystmd), or mdg (also accepts markdown_with_gherkin)"),
+        "Help should use one final conjunction in the flavor list. stdout: {stdout}"
+    );
 }
 
 #[test]
 fn test_feature_md_auto_detection_applies_mdg_rules() {
     let temp_dir = tempdir().unwrap();
     let feature_path = temp_dir.path().join("checkout.feature.md");
-    // A tilde fence is never a Doc String, so MDG converts it to backticks and
-    // MD040 labels it — neither change disturbs the Gherkin structure.
+    // A tilde fence is never a Doc String, so MD048 converts it to backticks.
+    // MD040 reports the missing media type but does not invent one under MDG.
     let content = "# Feature: Checkout\n\n## Scenario: Payload\n\n* Given a message\n\n  ~~~\n  hello\n  ~~~\n";
     fs::write(&feature_path, content).unwrap();
 
@@ -118,9 +123,93 @@ fn test_feature_md_auto_detection_applies_mdg_rules() {
     assert!(success, "Formatting should succeed. stderr: {stderr}, stdout: {stdout}");
     assert_eq!(
         fs::read_to_string(feature_path).unwrap(),
-        "# Feature: Checkout\n\n## Scenario: Payload\n\n* Given a message\n\n  ```text\n  hello\n  ```\n",
-        "auto-detected MDG formatting must steer fences to labelled backticks"
+        "# Feature: Checkout\n\n## Scenario: Payload\n\n* Given a message\n\n  ```\n  hello\n  ```\n",
+        "auto-detected MDG formatting must steer fences to backticks without inventing a media type"
     );
+}
+
+#[test]
+fn test_mdg_md003_explicit_style_override_warns() {
+    let temp_dir = tempdir().unwrap();
+    fs::write(temp_dir.path().join(".rumdl.toml"), "[MD003]\nstyle = \"setext\"\n").unwrap();
+    fs::write(
+        temp_dir.path().join("headings.feature.md"),
+        "Feature: Checkout\n=================\n",
+    )
+    .unwrap();
+
+    let (_success, _stdout, stderr) = run_rumdl(
+        temp_dir.path(),
+        &["check", "--no-cache", "--enable", "MD003", "headings.feature.md"],
+    );
+
+    assert!(stderr.contains("[config warning]"), "stderr: {stderr}");
+    assert!(stderr.contains("MD003:"), "stderr: {stderr}");
+    assert!(stderr.contains("requires style=\"atx\""), "stderr: {stderr}");
+}
+
+#[test]
+fn test_mdg_md026_override_warns_before_rule_skip_once_across_config_groups() {
+    let temp_dir = tempdir().unwrap();
+    fs::write(
+        temp_dir.path().join(".rumdl.toml"),
+        "[MD026]\npunctuation = \".,;:!\"\n",
+    )
+    .unwrap();
+    fs::write(temp_dir.path().join("root.feature.md"), "#### Examples:\n").unwrap();
+
+    let nested = temp_dir.path().join("nested");
+    fs::create_dir(&nested).unwrap();
+    fs::write(nested.join(".rumdl.toml"), "[MD026]\npunctuation = \".,;:!\"\n").unwrap();
+    fs::write(nested.join("nested.feature.md"), "#### Examples:\n").unwrap();
+
+    let (success, stdout, stderr) = run_rumdl(temp_dir.path(), &["check", "--no-cache", "--enable", "MD026", "."]);
+
+    assert!(
+        success,
+        "No effective punctuation should be reported. stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(stderr.contains("[config warning]"), "stderr: {stderr}");
+    assert!(stderr.contains("MD026:"), "stderr: {stderr}");
+    assert!(stderr.contains("punctuation=\".,;:!\""), "stderr: {stderr}");
+    assert_eq!(
+        stderr.matches("MD026:").count(),
+        1,
+        "the process-wide override notice must not repeat for nested config groups. stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_mdg_md034_reports_email_and_xmpp_without_link_prefilter_match() {
+    let temp_dir = tempdir().unwrap();
+    fs::write(
+        temp_dir.path().join("contacts.feature.md"),
+        "# Feature: Contact\n\n* Given I email user@example.com\n* And I message xmpp:user@example.org\n",
+    )
+    .unwrap();
+
+    let (success, stdout, stderr) = run_rumdl(
+        temp_dir.path(),
+        &[
+            "check",
+            "--no-cache",
+            "--no-config",
+            "--flavor",
+            "mdg",
+            "--enable",
+            "MD034",
+            "contacts.feature.md",
+        ],
+    );
+
+    assert!(
+        !success,
+        "MD034 findings should fail check. stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(stdout.contains("MD034"), "stdout: {stdout}");
+    assert!(stdout.contains("user@example.com"), "stdout: {stdout}");
+    assert!(stdout.contains("xmpp:user@example.org"), "stdout: {stdout}");
+    assert!(stdout.contains("Gherkin placeholder syntax"), "stdout: {stdout}");
 }
 
 #[test]

--- a/tests/cli/cli_flavor_test.rs
+++ b/tests/cli/cli_flavor_test.rs
@@ -95,6 +95,35 @@ fn test_flavor_help_lists_mdg() {
 }
 
 #[test]
+fn test_feature_md_auto_detection_applies_mdg_rules() {
+    let temp_dir = tempdir().unwrap();
+    let feature_path = temp_dir.path().join("checkout.feature.md");
+    // A tilde fence is never a Doc String, so MDG converts it to backticks and
+    // MD040 labels it — neither change disturbs the Gherkin structure.
+    let content = "# Feature: Checkout\n\n## Scenario: Payload\n\n* Given a message\n\n  ~~~\n  hello\n  ~~~\n";
+    fs::write(&feature_path, content).unwrap();
+
+    let (success, stdout, stderr) = run_rumdl(
+        temp_dir.path(),
+        &[
+            "fmt",
+            "--no-cache",
+            "--no-config",
+            "--enable",
+            "MD040,MD048",
+            "checkout.feature.md",
+        ],
+    );
+
+    assert!(success, "Formatting should succeed. stderr: {stderr}, stdout: {stdout}");
+    assert_eq!(
+        fs::read_to_string(feature_path).unwrap(),
+        "# Feature: Checkout\n\n## Scenario: Payload\n\n* Given a message\n\n  ```text\n  hello\n  ```\n",
+        "auto-detected MDG formatting must steer fences to labelled backticks"
+    );
+}
+
+#[test]
 fn test_flavor_cli_invalid_value() {
     let temp_dir = tempdir().unwrap();
     let md_path = temp_dir.path().join("test.md");

--- a/tests/cli/cli_flavor_test.rs
+++ b/tests/cli/cli_flavor_test.rs
@@ -69,6 +69,8 @@ fn test_flavor_cli_all_variants() {
         "azure_devops",
         "azure",
         "ado",
+        "mdg",
+        "markdown_with_gherkin",
     ] {
         let (success, stdout, stderr) = run_rumdl(temp_dir.path(), &["check", "--flavor", flavor, "test.md"]);
         assert!(
@@ -76,6 +78,20 @@ fn test_flavor_cli_all_variants() {
             "Command should succeed for flavor '{flavor}'. stderr: {stderr}, stdout: {stdout}"
         );
     }
+}
+
+#[test]
+fn test_flavor_help_lists_mdg() {
+    let (success, stdout, stderr) = run_rumdl(std::path::Path::new("."), &["check", "--help"]);
+    assert!(success, "Help should succeed. stderr: {stderr}");
+    assert!(
+        stdout.contains("mdg"),
+        "Help should list the MDG flavor. stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("markdown_with_gherkin"),
+        "Help should list the markdown_with_gherkin alias. stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/tests/formats/mdg_integration_test.rs
+++ b/tests/formats/mdg_integration_test.rs
@@ -1,0 +1,149 @@
+//! Flavor-level behavior for Markdown with Gherkin (`.feature.md`).
+//!
+//! MDG only exempts linting that would stop a document from parsing as Gherkin.
+//! Everything else is steered toward the single form Gherkin accepts, so these
+//! tests pin both directions: the corrections that must happen and the ones
+//! that must be withheld.
+
+use rumdl_lib::config::MarkdownFlavor;
+use rumdl_lib::lint_context::LintContext;
+use rumdl_lib::rule::Rule;
+use rumdl_lib::rules::heading_utils::HeadingStyle;
+use rumdl_lib::rules::{
+    CodeBlockStyle, CodeFenceStyle, MD003HeadingStyle, MD046CodeBlockStyle, MD048CodeFenceStyle, MD060TableFormat,
+};
+
+fn examples_table(indent: usize) -> String {
+    let spaces = " ".repeat(indent);
+    format!(
+        "# Feature: Eating\n\n#### Examples:\n\n{spaces}| start | eat | left |\n{spaces}|---|---|---|\n{spaces}| 12 | 5 | 7 |\n"
+    )
+}
+
+fn data_table(indent: usize) -> String {
+    let spaces = " ".repeat(indent);
+    format!(
+        "# Feature: Eating\n\n## Scenario: Eat\n\n* Given these items\n{spaces}| start | eat | left |\n{spaces}|---|---|---|\n{spaces}| 12 | 5 | 7 |\n"
+    )
+}
+
+/// Two spaces is always a valid Gherkin table indent, so 3-5 are corrected to it
+/// rather than preserved.
+#[test]
+fn md060_normalizes_mdg_table_indentation_to_two_spaces() {
+    let rule = MD060TableFormat::new(true, "aligned".to_string());
+    let expected = "# Feature: Eating\n\n#### Examples:\n\n  | start | eat | left |\n  | ----- | --- | ---- |\n  | 12    | 5   | 7    |\n";
+
+    for indent in [2, 3, 4, 5] {
+        let input = examples_table(indent);
+        let ctx = LintContext::new(&input, MarkdownFlavor::MDG, None);
+
+        assert!(
+            !rule.check(&ctx).unwrap().is_empty(),
+            "the unaligned {indent}-space MDG table should be reported"
+        );
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(fixed, expected, "MD060 must normalize a {indent}-space indent to 2");
+
+        let fixed_ctx = LintContext::new(&fixed, MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+        assert_eq!(rule.fix(&fixed_ctx).unwrap(), fixed, "MD060 fix must be idempotent");
+    }
+}
+
+#[test]
+fn md060_normalizes_data_table_indent_under_step() {
+    let rule = MD060TableFormat::new(true, "aligned".to_string());
+    let expected = "# Feature: Eating\n\n## Scenario: Eat\n\n* Given these items\n  | start | eat | left |\n  | ----- | --- | ---- |\n  | 12    | 5   | 7    |\n";
+
+    for indent in [2, 3, 4, 5] {
+        let input = data_table(indent);
+        let ctx = LintContext::new(&input, MarkdownFlavor::MDG, None);
+
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(fixed, expected, "MD060 must normalize Data Table indent {indent} to 2");
+
+        let fixed_ctx = LintContext::new(&fixed, MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+    }
+}
+
+#[test]
+fn md060_mdg_behavior_is_flavor_isolated() {
+    let rule = MD060TableFormat::new(true, "aligned".to_string());
+    let input = examples_table(4);
+
+    let mdg_fixed = rule.fix(&LintContext::new(&input, MarkdownFlavor::MDG, None)).unwrap();
+    assert!(mdg_fixed.lines().any(|line| line.starts_with("  | start")));
+
+    let standard_fixed = rule
+        .fix(&LintContext::new(&input, MarkdownFlavor::Standard, None))
+        .unwrap();
+    assert!(standard_fixed.lines().any(|line| line.starts_with("| start")));
+    assert!(!standard_fixed.lines().any(|line| line.starts_with("  | start")));
+}
+
+/// MDG parses `#{1,6} ` headings only, so every heading is steered to plain ATX
+/// regardless of the configured style.
+#[test]
+fn md003_converges_on_plain_atx_under_mdg() {
+    let input = "Feature: Checkout\n=================\n\n## Scenario: Purchase ##\n\nNotes\n-----\n";
+    let expected = "# Feature: Checkout\n\n## Scenario: Purchase\n\n## Notes\n";
+
+    for style in [
+        HeadingStyle::Consistent,
+        HeadingStyle::Atx,
+        HeadingStyle::AtxClosed,
+        HeadingStyle::Setext1,
+    ] {
+        let rule = MD003HeadingStyle::new(style);
+        let ctx = LintContext::new(input, MarkdownFlavor::MDG, None);
+
+        let fixed = rule.fix(&ctx).unwrap();
+        assert_eq!(fixed, expected, "MDG must converge on plain ATX for {style:?}");
+
+        let fixed_ctx = LintContext::new(&fixed, MarkdownFlavor::MDG, None);
+        assert!(rule.check(&fixed_ctx).unwrap().is_empty());
+    }
+}
+
+/// Only a backtick fence can be a Doc String, so MDG converges on backtick
+/// fences and never rewrites one into a tilde fence or an indented block.
+#[test]
+fn md046_and_md048_converge_on_backtick_fences_under_mdg() {
+    let input = "# Feature: Payloads\n\n## Scenario: Mixed\n\n* Given a payload\n\n~~~text\nfrom a tilde fence\n~~~\n\nPlain sample:\n\n    from an indented block\n";
+
+    let fixed = MD046CodeBlockStyle::new(CodeBlockStyle::Consistent)
+        .fix(&LintContext::new(input, MarkdownFlavor::MDG, None))
+        .unwrap();
+    let fixed = MD048CodeFenceStyle::new(CodeFenceStyle::Consistent)
+        .fix(&LintContext::new(&fixed, MarkdownFlavor::MDG, None))
+        .unwrap();
+
+    assert!(!fixed.contains("~~~"), "no tilde fence may survive: {fixed:?}");
+    assert!(
+        fixed.contains("from an indented block") && fixed.contains("```"),
+        "the indented block must be fenced: {fixed:?}"
+    );
+
+    // Withheld directions: an explicit indented or tilde style would delete Doc
+    // Strings, so neither is applied.
+    let backticks =
+        "# Feature: Payloads\n\n## Scenario: Doc String\n\n* Given a payload\n\n  ```json\n  {\"ok\": true}\n  ```\n";
+    for (name, fixed) in [
+        (
+            "MD046 indented",
+            MD046CodeBlockStyle::new(CodeBlockStyle::Indented)
+                .fix(&LintContext::new(backticks, MarkdownFlavor::MDG, None))
+                .unwrap(),
+        ),
+        (
+            "MD048 tilde",
+            MD048CodeFenceStyle::new(CodeFenceStyle::Tilde)
+                .fix(&LintContext::new(backticks, MarkdownFlavor::MDG, None))
+                .unwrap(),
+        ),
+    ] {
+        assert_eq!(fixed, backticks, "{name} must be withheld under MDG");
+    }
+}

--- a/tests/formats/mdg_integration_test.rs
+++ b/tests/formats/mdg_integration_test.rs
@@ -95,6 +95,9 @@ fn md003_converges_on_plain_atx_under_mdg() {
         HeadingStyle::Atx,
         HeadingStyle::AtxClosed,
         HeadingStyle::Setext1,
+        HeadingStyle::Setext2,
+        HeadingStyle::SetextWithAtx,
+        HeadingStyle::SetextWithAtxClosed,
     ] {
         let rule = MD003HeadingStyle::new(style);
         let ctx = LintContext::new(input, MarkdownFlavor::MDG, None);

--- a/tests/formats/mod.rs
+++ b/tests/formats/mod.rs
@@ -12,3 +12,5 @@ mod mkdocs_extensions_test;
 mod myst_integration_test;
 mod quarto_comprehensive_test;
 mod sentence_per_line_test;
+
+mod mdg_integration_test;


### PR DESCRIPTION
## Description

Adds first-class support for [Markdown with Gherkin](https://github.com/cucumber/gherkin/blob/main/MARKDOWN_WITH_GHERKIN.md) as the `mdg` flavor (alias `markdown_with_gherkin`). Files ending in `.feature.md` are auto-detected, while ordinary Markdown behavior remains unchanged. The flavor protects Gherkin-sensitive syntax during linting and formatting but does not validate Gherkin.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated
- [x] All tests passing (`make test-dev`)
- [x] Manual testing performed

<details>
<summary>Manual testing details</summary>

Validated 16 representative `.feature.md` files with `@cucumber/gherkin` v42 by comparing compiled pickles before and after `rumdl fmt --flavor mdg`, normalizing only generated IDs and source locations.

- MDG preserved every pickle set, produced idempotent output, and passed `fmt --check`; malformed input remained rejected.
- Verified suffix auto-detection, explicit flavor aliases and overrides, and `[per-file-flavor]` mappings.
- Verified report-only behavior for MD013, MD034, and MD040, and one warning per process for incompatible MD003, MD026, MD046, MD048, and MD055 overrides.
- Reproduced the documented limitations, control cases, and intentionally unchanged rule behavior.
- Standard flavor changed 11 pickle sets on the same corpus; MDG changed none.

Testing used an external scratch workspace; no fixtures or generated artifacts were added.

</details>

## Checklist

- [x] Code follows project style (`make fmt` and `make lint`)
- [x] Conventional commit messages used
- [x] Documentation updated (if needed)
- [x] No unrelated changes included