### PR TITLE
fix(md057): handle balanced parentheses in relative link paths

### DIFF
--- a/src/rules/md057_existing_relative_links.rs
+++ b/src/rules/md057_existing_relative_links.rs
@@ -87,8 +87,10 @@ static URL_EXTRACT_ANGLE_BRACKET_REGEX: LazyLock<Regex> =
 
 /// Regex to extract the URL from a normal markdown link (without angle brackets)
 /// Format: `](URL)` or `](URL "title")`
-static URL_EXTRACT_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new("\\]\\(\\s*([^>\\)\\s#]+)(#[^)\\s]*)?\\s*(?:\"[^\"]*\")?\\s*\\)").unwrap());
+/// Supports one level of nested parentheses so `](file(inner).md)` works.
+static URL_EXTRACT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new("\\]\\(\\s*((?:[^()>\\s#]|\\([^()]*\\))+)(#[^)\\s]*)?\\s*(?:\"[^\"]*\")?\\s*\\)").unwrap()
+});
 
 /// Regex to detect URLs with explicit schemes (should not be checked as relative links)
 /// Matches: scheme:// or scheme: (per RFC 3986)
@@ -2435,6 +2437,57 @@ This is a [real missing link](missing.md) that should be flagged.
         assert!(
             result[0].message.contains("app/(missing)/file.md"),
             "Warning should mention app/(missing)/file.md"
+        );
+    }
+
+    #[test]
+    fn test_balanced_parentheses_in_link_paths() {
+        // Reproduces https://github.com/rvben/rumdl/issues/830:
+        // links whose file path contains balanced parentheses used to be
+        // truncated at the first ')' and reported as missing even when the
+        // target exists on disk.
+        let temp_dir = tempdir().unwrap();
+        let base_path = temp_dir.path();
+
+        // Existing file with parens in its name
+        let paren_file = base_path.join("file(inner).md");
+        File::create(&paren_file)
+            .unwrap()
+            .write_all(b"# file(inner).md\n")
+            .unwrap();
+
+        // Existing file inside a folder with parens in its name
+        let folder = base_path.join("folder(inner)");
+        std::fs::create_dir(&folder).unwrap();
+        File::create(folder.join("file.md"))
+            .unwrap()
+            .write_all(b"# folder(inner)/file.md\n")
+            .unwrap();
+
+        let content = r#"
+# Test cases
+
+[File with parenthesis exists](file(inner).md)
+[Folder with parenthesis exists](folder(inner)/file.md)
+[Missing with parenthesis](missing(inner).md)
+"#;
+
+        let rule = MD057ExistingRelativeLinks::new().with_path(base_path);
+
+        let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+        let result = rule.check(&ctx).unwrap();
+
+        // The two existing targets must not warn, and the missing one must be
+        // reported with its full, untruncated path.
+        assert_eq!(
+            result.len(),
+            1,
+            "Expected exactly one warning (the missing file). Got: {result:?}"
+        );
+        assert!(
+            result[0].message.contains("missing(inner).md"),
+            "Warning should name the full path `missing(inner).md`, got: {}",
+            result[0].message
         );
     }
 


### PR DESCRIPTION
Closes #830.

## Problem

When a markdown link's destination contains balanced parentheses, for example
`[File](file(inner).md)`, MD057 extracts only the text up to the first closing
paren and reports the link as missing:

> Relative link 'file(inner' does not exist

The issue is in `URL_EXTRACT_REGEX`: the URL capture group
`[^>\)\s#]+` explicitly excludes `)` and stops at the first one.

## Fix

Changed the URL capture group to allow one level of nested parentheses:

```diff
-([^>\)\s#]+)
+((?:[^()>\s#]|\([^()]*\))+)
```

This mirrors what MD063's `LINK_REGEX` already does for the same reason
(see src/rules/md063_heading_capitalization.rs:31-32).

The fix applies to all three consumers of this regex:
1. MD057's `check()` pass (line ~1407)
2. MD057's `contribute_dependency_targets()` (line ~423)
3. `workspace_index::extract_cross_file_links()` (line ~206)

## Testing

Added `test_balanced_parentheses_in_link_paths` which creates a temp dir
with `file(inner).md` and `folder(inner)/file.md` on disk, then verifies
that links to both existing targets pass without warning, while a genuinely
missing target `missing(inner).md` is still reported with its full path
(not truncated).