### PR TITLE
feat(cli): add --no-code-block-tools and --only-code-block-tools flags

### DIFF
--- a/src/cli_types.rs
+++ b/src/cli_types.rs
@@ -115,6 +115,25 @@ pub struct SharedCliArgs {
     /// default.
     #[arg(long, help = "Treat configuration warnings as errors (exit code 2)")]
     pub deny_config_warnings: bool,
+
+    /// Disable code-block-tools for this invocation while preserving the
+    /// configured Markdown rules and other loaded settings.
+    #[arg(
+        long,
+        conflicts_with = "only_code_block_tools",
+        help = "Disable code-block-tools for this invocation (Markdown rules still run)"
+    )]
+    pub no_code_block_tools: bool,
+
+    /// Run only code-block-tools: enable them for this invocation, preserve
+    /// their configured languages and tools, and disable all regular Markdown
+    /// rules.
+    #[arg(
+        long,
+        conflicts_with = "no_code_block_tools",
+        help = "Run only code-block-tools (disables all regular Markdown rules)"
+    )]
+    pub only_code_block_tools: bool,
 }
 
 #[derive(Args, Debug)]

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -45,6 +45,15 @@ pub fn apply_cli_overrides(sourced: &mut rumdl_config::SourcedConfig, args: &Che
             .collect();
         sourced.global.unfixable = rumdl_config::SourcedValue::new(rules, rumdl_config::ConfigSource::Cli);
     }
+
+    // Apply --no-code-block-tools / --only-code-block-tools override.
+    // Either explicit CLI flag wins over configuration files and any
+    // environment variable that can affect the same behavior.
+    if args.no_code_block_tools || args.only_code_block_tools {
+        let mut cbt = sourced.code_block_tools.value.clone();
+        cbt.enabled = args.only_code_block_tools;
+        sourced.code_block_tools = rumdl_config::SourcedValue::new(cbt, rumdl_config::ConfigSource::Cli);
+    }
 }
 
 /// Resolve the lint output format with the standard precedence:

--- a/src/file_processor/discovery.rs
+++ b/src/file_processor/discovery.rs
@@ -83,6 +83,11 @@ pub fn rule_selection(
 }
 
 pub fn get_enabled_rules_from_checkargs(args: &crate::CheckArgs, config: &rumdl_config::Config) -> Vec<Box<dyn Rule>> {
+    // --only-code-block-tools disables all regular Markdown rules.
+    if args.only_code_block_tools {
+        return Vec::new();
+    }
+
     let selection = rule_selection(&RuleSelectionFlags::from(&args.shared), &config.global);
     let all_rules = rumdl_lib::rules::all_rules(config);
     let final_rules = rumdl_lib::rules::filter_rules(&all_rules, &selection);

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -476,6 +476,12 @@ fn apply_cli_config_overrides(config: &mut rumdl_config::Config, args: &crate::C
     if let Some(respect_gitignore) = args.respect_gitignore {
         config.global.respect_gitignore = respect_gitignore;
     }
+
+    // Apply --no-code-block-tools / --only-code-block-tools override
+    // to subdirectory configs, mirroring apply_cli_overrides for the root config.
+    if args.no_code_block_tools || args.only_code_block_tools {
+        config.code_block_tools.enabled = args.only_code_block_tools;
+    }
 }
 
 #[cfg(test)]

--- a/tests/cli/cli_cbt_flags_test.rs
+++ b/tests/cli/cli_cbt_flags_test.rs
@@ -1,0 +1,124 @@
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+/// Write a config that enables code-block-tools with the built-in rumdl tool
+/// for embedded markdown blocks (no external binary needed), and a markdown
+/// file whose outer content is short but whose embedded markdown block has a
+/// line that exceeds MD013's 80-char limit.
+///
+/// This gives:
+/// - default: 2 issues (MD013 from regular check + from embedded check via CBT)
+/// - --no-code-block-tools: 1 issue (only MD013 from regular check; CBT off)
+/// - --only-code-block-tools: 0 issues (rules disabled; CBT runs but no rules)
+fn setup(tmp: &tempfile::TempDir) {
+    let base = tmp.path();
+    fs::write(
+        base.join(".rumdl.toml"),
+        "[code-block-tools]\nenabled = true\n\n[code-block-tools.languages.markdown]\nlint = [\"rumdl\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        base.join("test.md"),
+        "# Title\n\nShort outer paragraph.\n\n```markdown\nSome very long embedded markdown line that definitely exceeds eighty characters by a lot for sure yes\n```\n",
+    )
+    .unwrap();
+}
+
+fn rumdl() -> &'static str {
+    env!("CARGO_BIN_EXE_rumdl")
+}
+
+/// Without any flag, both the regular Markdown check and the embedded
+/// code-block-tools (rumdl builtin) run → 2 issues.
+#[test]
+fn test_cbt_flags_default_runs_both() {
+    let tmp = tempdir().unwrap();
+    setup(&tmp);
+    let out = Command::new(rumdl())
+        .current_dir(tmp.path())
+        .args(["check", "test.md"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Issues: Found 2"),
+        "expected 2 issues (regular + embedded), got: {stdout}"
+    );
+}
+
+/// --no-code-block-tools keeps Markdown rules but silences the embedded
+/// code-block-tools check → 1 issue (regular only).
+#[test]
+fn test_no_code_block_tools_flag() {
+    let tmp = tempdir().unwrap();
+    setup(&tmp);
+    let out = Command::new(rumdl())
+        .current_dir(tmp.path())
+        .args(["check", "--no-code-block-tools", "test.md"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("MD013"),
+        "expected MD013 from regular check, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Issues: Found 1"),
+        "expected 1 issue (regular only), got: {stdout}"
+    );
+}
+
+/// --only-code-block-tools keeps code-block-tools but disables all regular
+/// Markdown rules → 0 issues (no rules to run).
+#[test]
+fn test_only_code_block_tools_flag() {
+    let tmp = tempdir().unwrap();
+    setup(&tmp);
+    let out = Command::new(rumdl())
+        .current_dir(tmp.path())
+        .args(["check", "--only-code-block-tools", "test.md"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Success: No issues found"),
+        "expected 0 issues, got: {stdout}"
+    );
+}
+
+/// --only-code-block-tools also works with `fmt` (via the same CheckArgs
+/// conversion) → no Markdown formatting output.
+#[test]
+fn test_only_code_block_tools_with_fmt() {
+    let tmp = tempdir().unwrap();
+    setup(&tmp);
+    let out = Command::new(rumdl())
+        .current_dir(tmp.path())
+        .args(["fmt", "--only-code-block-tools", "test.md"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("MD013"),
+        "Markdown rules should be disabled under fmt, got: {stdout}"
+    );
+}
+
+/// The two flags are mutually exclusive: clap rejects them together.
+#[test]
+fn test_cbt_flags_are_mutually_exclusive() {
+    let tmp = tempdir().unwrap();
+    setup(&tmp);
+    let out = Command::new(rumdl())
+        .current_dir(tmp.path())
+        .args(["check", "--no-code-block-tools", "--only-code-block-tools", "test.md"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "expected clap to reject the combination");
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected mutual-exclusion error, got: {stderr}"
+    );
+}

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -1,6 +1,7 @@
 mod check_runner_tests;
 mod cli_alias_test;
 mod cli_cache_cross_file_test;
+mod cli_cbt_flags_test;
 mod cli_config_override_test;
 mod cli_config_test;
 mod cli_disable_all_test;


### PR DESCRIPTION
## Summary

Adds two complementary CLI flags that control code-block-tools for a single invocation **without discarding unrelated rumdl configuration**:

- `--no-code-block-tools` — disables code-block-tools for this run while Markdown rules and all other settings stay active
- `--only-code-block-tools` — enables code-block-tools (preserving its configured languages/tools) and disables all regular Markdown rules

Both flags are mutually exclusive (clap `conflicts_with`) and take final precedence over config files and environment variables. They are available on `rumdl check`, `check --fix`, and `rumdl fmt` (added to `SharedCliArgs`, so every command that flattens it gets them, including watch mode and stdin paths).

## Why

Closes #829. Users on shared machines or CI want to toggle the (potentially slow/external) code-block-tools per invocation without editing `.rumdl.toml`:

```bash
# CI: only run the fast Markdown rules
rumdl check --no-code-block-tools .

# Focused run: only the code-block tools
rumdl check --only-code-block-tools .
```

## Implementation

- `src/cli_types.rs` — both flags on `SharedCliArgs`, mutually exclusive
- `src/cli_utils.rs` — `apply_cli_overrides` sets `code_block_tools.enabled` at `ConfigSource::Cli` precedence
- `src/resolution.rs` — `apply_cli_config_overrides` mirrors the override onto subdirectory configs so the flag wins everywhere
- `src/file_processor/discovery.rs` — `--only-code-block-tools` short-circuits `get_enabled_rules_from_checkargs` to no rules
- `tests/cli/cli_cbt_flags_test.rs` — 5 integration tests using the built-in `rumdl` tool for embedded markdown blocks (no external binary needed in CI)

## Test plan

- `cargo test --test lib -- cli_cbt_flags_test` — 5/5 pass
- `cargo test --lib` — 7184 pass, 2 pre-existing perf-test failures (`text_reflow`, unrelated)
- `make fmt-check`, `cargo clippy --lib` — clean