### PR TITLE
fix(MD051): delete the emoji marker pass from the GitHub anchor style

### DIFF
--- a/src/utils/anchor_styles/github.rs
+++ b/src/utils/anchor_styles/github.rs
@@ -13,7 +13,7 @@
 //! 6. Multi-character pattern replacement (-->, <->, ==>, ->)
 //! 7. Special symbol replacement (& → --, © → --)
 //! 8. Character processing (preserve letters, digits, underscores, hyphens)
-//! 9. Space → single hyphen, emojis → single hyphen
+//! 9. Space → single hyphen; emojis and other symbols are deleted, keeping the spaces around them
 //! 10. No leading/trailing trimming (unlike kramdown)
 //!
 //! Security measures implemented:
@@ -23,7 +23,6 @@
 //! - Zero-width character stripping
 //! - Control character filtering
 //! - ReDoS-resistant regex patterns with complexity limits
-//! - Comprehensive emoji detection including country flags and keycaps
 
 use regex::Regex;
 use std::sync::LazyLock;
@@ -78,7 +77,6 @@ static HTML_COMMENT_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<!-
 /// - Zero-width character removal
 /// - Control character filtering
 /// - ReDoS-resistant regex patterns
-/// - Comprehensive emoji detection
 ///
 /// # Examples
 /// ```
@@ -121,23 +119,13 @@ fn heading_to_fragment_internal(heading: &str) -> String {
     // NFC normalization ensures canonical representation
     let normalized: String = heading.nfc().collect();
 
-    // Step 3: Handle emoji sequences BEFORE sanitizing ZWJ
-    // This preserves multi-component emojis and keycaps
-    // Quick optimization: skip if clearly no emojis (common case)
-    let emoji_processed = if normalized.chars().any(|c| {
-        let code = c as u32;
-        // Quick check for common emoji ranges
-        (0x1F300..=0x1F9FF).contains(&code) || // Most emojis
-        (0x2600..=0x26FF).contains(&code) ||   // Misc symbols
-        (0x1F1E6..=0x1F1FF).contains(&code) // Regional indicators
-    }) {
-        process_emoji_sequences(&normalized)
-    } else {
-        normalized
-    };
+    // An emoji is deleted by the character pass below like any other symbol,
+    // and the spaces around it stay, which is what GitHub does: its filter
+    // keeps `[\p{Word}\- ]` and drops everything else before turning spaces
+    // into hyphens.
 
     // Security Step 4: Filter dangerous Unicode characters
-    let sanitized = sanitize_unicode(&emoji_processed);
+    let sanitized = sanitize_unicode(&normalized);
 
     // Step 5: Convert to lowercase
     let mut text = sanitized.to_lowercase();
@@ -229,9 +217,6 @@ fn heading_to_fragment_internal(heading: &str) -> String {
     // First remove em-dashes and en-dashes entirely
     text = text.replace(['–', '—'], "");
 
-    // Step 8: Emojis were already replaced with hyphens in process_emoji_sequences
-    // No further processing needed for emoji markers
-
     // Step 9: Special symbol replacements
     // Handle ampersand based on position and surrounding spaces
     // GitHub's behavior:
@@ -272,13 +257,9 @@ fn heading_to_fragment_internal(heading: &str) -> String {
         if c.is_ascii_alphabetic() || c.is_ascii_digit() || c == '_' || c == '-' {
             // Preserve letters, numbers, underscores, and hyphens
             result.push(c);
-        } else if c == '§' {
-            // Preserve our marker character
-            result.push(c);
         } else if code == 0x20E3 {
             // Preserve combining keycap for keycap sequences
             // Note: FE0F should only be preserved as part of a keycap, not standalone
-            // The keycap preservation is handled in process_emoji_sequences
             result.push(c);
         } else if code == 0xFE0F {
             // Only preserve variation selector if it's preceded by a keycap base
@@ -308,231 +289,6 @@ fn heading_to_fragment_internal(heading: &str) -> String {
     // "© 2024" → "-2024"
     // "trailing---" → "trailing---"
 
-    // Step 11: Replace emoji markers with the correct number of hyphens
-    // Note: markers are lowercase after the lowercasing step above
-    // GitHub's behavior:
-    // - Single emoji at start: "-"
-    // - Single emoji at end: "-"
-    // - Single emoji between words: "--"
-    // - Multiple emojis with spaces: n+1 hyphens
-
-    // Quick check: if no emoji markers, skip processing entirely
-    if !result.contains("§emoji§") {
-        return result;
-    }
-
-    // Simple two-step approach for better performance
-    let mut final_result = result;
-
-    // First, handle multiple consecutive markers (n markers → n+1 hyphens)
-    // Process from longest to shortest to avoid partial replacements
-    for count in (2..=10).rev() {
-        if final_result.contains("§emoji§") {
-            let marker_seq = "§emoji§".repeat(count);
-            if final_result.contains(&marker_seq) {
-                let replacement = "-".repeat(count + 1);
-                final_result = final_result.replace(&marker_seq, &replacement);
-            }
-        }
-    }
-
-    // Then handle single markers based on position
-    if final_result.contains("§emoji§") {
-        let bytes = final_result.as_bytes();
-        let marker = "§emoji§".as_bytes();
-        let mut result_bytes = Vec::with_capacity(bytes.len());
-        let mut i = 0;
-
-        while i < bytes.len() {
-            if i + marker.len() <= bytes.len() && &bytes[i..i + marker.len()] == marker {
-                // Found a marker - check position
-                let at_start = i == 0;
-                let at_end = i + marker.len() >= bytes.len();
-
-                if at_start || at_end {
-                    result_bytes.push(b'-');
-                } else {
-                    result_bytes.extend_from_slice(b"--");
-                }
-                i += marker.len();
-            } else {
-                result_bytes.push(bytes[i]);
-                i += 1;
-            }
-        }
-
-        final_result = String::from_utf8(result_bytes).unwrap_or(final_result);
-    }
-
-    final_result
-}
-
-/// Process emoji sequences before sanitization
-/// Handles multi-component emojis, keycaps, and flags as units
-/// GitHub's behavior: consecutive symbols with spaces between them become n+1 hyphens
-fn process_emoji_sequences(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        // Check if this starts a symbol/emoji sequence
-        if is_emoji_or_symbol(c) || is_regional_indicator(c) {
-            // Remove preceding space if any
-            if result.ends_with(' ') {
-                result.pop();
-            }
-
-            // Count symbols in this sequence (separated by single spaces)
-            let mut symbol_count = 1;
-
-            // Handle the current symbol
-            // If it's a regional indicator pair (flag)
-            if is_regional_indicator(c) {
-                if let Some(&next) = chars.peek()
-                    && is_regional_indicator(next)
-                {
-                    chars.next(); // Consume second part of flag
-                }
-            }
-            // If it's an emoji with ZWJ sequences
-            else if is_emoji_or_symbol(c) {
-                // Consume the entire emoji sequence including ZWJs
-                while let Some(&next) = chars.peek() {
-                    if next as u32 == 0x200D {
-                        // ZWJ
-                        chars.next();
-                        // After ZWJ, expect another emoji component
-                        if let Some(&emoji) = chars.peek() {
-                            if is_emoji_or_symbol(emoji) || is_regional_indicator(emoji) {
-                                chars.next();
-                            } else {
-                                break;
-                            }
-                        }
-                    } else if next as u32 == 0xFE0F {
-                        // Variation selector
-                        chars.next();
-                    } else if is_emoji_or_symbol(next) || is_regional_indicator(next) {
-                        // Adjacent symbols without spaces are treated as a single unit
-                        // Don't increment symbol_count, just consume them
-                        chars.next();
-                        // Handle multi-part adjacent symbols
-                        if is_regional_indicator(next)
-                            && let Some(&next2) = chars.peek()
-                            && is_regional_indicator(next2)
-                        {
-                            chars.next();
-                        }
-                    } else {
-                        break;
-                    }
-                }
-            }
-
-            // Look for more symbols separated by single spaces
-            while let Some(&next) = chars.peek() {
-                if next == ' ' {
-                    // Peek ahead to see if there's a symbol after the space
-                    let mut temp_chars = chars.clone();
-                    temp_chars.next(); // Skip the space
-                    if let Some(&after_space) = temp_chars.peek() {
-                        if is_emoji_or_symbol(after_space) || is_regional_indicator(after_space) {
-                            // Consume the space and the symbol
-                            chars.next(); // Space
-                            let symbol = chars.next().unwrap(); // Symbol
-                            symbol_count += 1;
-
-                            // Handle multi-part symbols
-                            if is_regional_indicator(symbol) {
-                                if let Some(&next) = chars.peek()
-                                    && is_regional_indicator(next)
-                                {
-                                    chars.next();
-                                }
-                            } else if is_emoji_or_symbol(symbol) {
-                                // Handle ZWJ sequences
-                                while let Some(&next) = chars.peek() {
-                                    if next as u32 == 0x200D {
-                                        // ZWJ
-                                        chars.next();
-                                        if let Some(&emoji) = chars.peek() {
-                                            if is_emoji_or_symbol(emoji) || is_regional_indicator(emoji) {
-                                                chars.next();
-                                            } else {
-                                                break;
-                                            }
-                                        }
-                                    } else if next as u32 == 0xFE0F {
-                                        chars.next();
-                                    } else {
-                                        break;
-                                    }
-                                }
-                            }
-                        } else {
-                            break; // Not a symbol after space
-                        }
-                    } else {
-                        break; // Nothing after space
-                    }
-                } else {
-                    break; // Not a space
-                }
-            }
-
-            // Skip trailing space if any
-            if let Some(&next) = chars.peek()
-                && next == ' '
-            {
-                chars.next();
-            }
-
-            // Generate markers based on symbol count
-            // GitHub's pattern: n symbols with spaces = n+1 hyphens
-            // We use markers that will be replaced with the correct number of hyphens
-            result.push_str("§EMOJI§");
-            // Add extra markers for each additional symbol that was separated by spaces
-            for _ in 1..symbol_count {
-                result.push_str("§EMOJI§");
-            }
-        }
-        // Check for keycap sequences - these should be PRESERVED
-        else if is_keycap_base(c) {
-            let mut keycap_seq = String::new();
-            keycap_seq.push(c);
-
-            // Check for variation selector and/or combining keycap
-            let mut has_keycap = false;
-            while let Some(&next) = chars.peek() {
-                if next as u32 == 0xFE0F || next as u32 == 0x20E3 {
-                    keycap_seq.push(next);
-                    chars.next();
-                    if next as u32 == 0x20E3 {
-                        has_keycap = true;
-                        break;
-                    }
-                } else {
-                    break;
-                }
-            }
-
-            if has_keycap {
-                // Preserve the entire keycap sequence
-                result.push_str(&keycap_seq);
-            } else {
-                // Not a keycap, just push the original character
-                result.push(c);
-                // Push back any variation selectors we consumed
-                for ch in keycap_seq.chars().skip(1) {
-                    result.push(ch);
-                }
-            }
-        } else {
-            // Regular character
-            result.push(c);
-        }
-    }
-
     result
 }
 
@@ -555,64 +311,6 @@ fn sanitize_unicode(input: &str) -> String {
     }
 
     sanitized
-}
-
-/// Comprehensive emoji and symbol detection
-/// Covers all major emoji ranges including newer additions and symbols
-fn is_emoji_or_symbol(c: char) -> bool {
-    let code = c as u32;
-
-    // Exclude dangerous unicode characters that should be filtered, not replaced
-    // These include bidirectional overrides, zero-width chars, etc.
-    if (0x202A..=0x202E).contains(&code) ||  // Bidirectional formatting
-       (0x2066..=0x2069).contains(&code) ||  // Isolate formatting
-       (0x200B..=0x200D).contains(&code) ||  // Zero-width chars
-       (0x200E..=0x200F).contains(&code) ||  // LTR/RTL marks
-       code == 0x061C ||                     // Arabic Letter Mark
-       code == 0x2060 ||                     // Word Joiner
-       code == 0xFEFF
-    {
-        // Zero Width No-Break Space
-        return false;
-    }
-
-    // Core emoji ranges
-    (0x1F600..=0x1F64F).contains(&code) ||  // Emoticons
-    (0x1F300..=0x1F5FF).contains(&code) ||  // Miscellaneous Symbols and Pictographs
-    (0x1F680..=0x1F6FF).contains(&code) ||  // Transport and Map Symbols
-    (0x1F700..=0x1F77F).contains(&code) ||  // Alchemical Symbols
-    (0x1F780..=0x1F7FF).contains(&code) ||  // Geometric Shapes Extended
-    (0x1F800..=0x1F8FF).contains(&code) ||  // Supplemental Arrows-C
-    (0x1F900..=0x1F9FF).contains(&code) ||  // Supplemental Symbols and Pictographs
-    (0x1FA00..=0x1FA6F).contains(&code) ||  // Chess Symbols
-    (0x1FA70..=0x1FAFF).contains(&code) ||  // Symbols and Pictographs Extended-A
-    (0x1FB00..=0x1FBFF).contains(&code) ||  // Symbols for Legacy Computing
-
-    // Symbol ranges that should be removed
-    (0x2600..=0x26FF).contains(&code) ||    // Miscellaneous Symbols
-    (0x2700..=0x27BF).contains(&code) ||    // Dingbats
-    (0x2B00..=0x2BFF).contains(&code) ||    // Miscellaneous Symbols and Arrows
-    (0x1F000..=0x1F02F).contains(&code) ||  // Mahjong Tiles
-    (0x1F030..=0x1F09F).contains(&code) ||  // Domino Tiles
-    (0x1F0A0..=0x1F0FF).contains(&code) ||  // Playing Cards
-
-    // Additional symbol ranges
-    (0x2190..=0x21FF).contains(&code) ||    // Arrows
-    (0x2200..=0x22FF).contains(&code) ||    // Mathematical Operators
-    (0x2300..=0x23FF).contains(&code) ||    // Miscellaneous Technical
-    (0x2400..=0x243F).contains(&code) ||    // Control Pictures
-    (0x2440..=0x245F).contains(&code) ||    // Optical Character Recognition
-    (0x25A0..=0x25FF).contains(&code) ||    // Geometric Shapes
-    (0x2000..=0x206F).contains(&code) ||    // General Punctuation (includes dangerous chars)
-
-    // Combining marks used in emoji (but not variation selectors - those are handled separately)
-    (0x20D0..=0x20FF).contains(&code) // Combining Diacritical Marks for Symbols
-}
-
-/// Check if character is a regional indicator (used for country flags)
-fn is_regional_indicator(c: char) -> bool {
-    let code = c as u32;
-    (0x1F1E6..=0x1F1FF).contains(&code) // Regional Indicator Symbol letters A-Z
 }
 
 /// Check if character can be the base of a keycap sequence
@@ -1052,6 +750,48 @@ mod tests {
 
         assert!(duration.as_millis() < 100);
         assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn test_github_section_sign_is_stripped() {
+        // `§` was the delimiter of the emoji marker pass, and the character
+        // pass preserved it so a marker survived; a section sign written in
+        // the heading survived with it. Expected values from github-slugger.
+        assert_eq!(heading_to_fragment("A §1 B"), "a-1-b");
+        assert_eq!(
+            heading_to_fragment("9. Worked Examples — the ridl §13 Contracts"),
+            "9-worked-examples--the-ridl-13-contracts"
+        );
+        assert_eq!(heading_to_fragment("§ 1"), "-1");
+        assert_eq!(heading_to_fragment("A §"), "a-");
+        assert_eq!(heading_to_fragment("A§B"), "ab");
+        assert_eq!(heading_to_fragment("A § B"), "a--b");
+        assert_eq!(heading_to_fragment("See §§ 3–4"), "see--34");
+        assert_eq!(heading_to_fragment("A §1 B 🚀"), "a-1-b-");
+        assert_eq!(heading_to_fragment("A §🚀 B"), "a--b");
+        assert_eq!(heading_to_fragment("A 🚀§ B"), "a--b");
+    }
+
+    #[test]
+    fn test_github_emoji_keeps_the_spaces_around_it() {
+        // GitHub deletes the emoji and keeps the spaces, so the hyphen count
+        // is the space count. The marker pass re-added one or two hyphens by
+        // position instead, which was one too many whenever the emoji was
+        // not surrounded by spaces, and it treated general punctuation as a
+        // symbol too, but only in a heading that also held an emoji.
+        // Expected values from github-slugger.
+        assert_eq!(heading_to_fragment("A🚀 B"), "a-b");
+        assert_eq!(heading_to_fragment("A 🚀B"), "a-b");
+        assert_eq!(heading_to_fragment("A🚀B"), "ab");
+        assert_eq!(heading_to_fragment("A °🚀 B"), "a--b");
+        assert_eq!(heading_to_fragment("Notes… 🚀 done"), "notes--done");
+        assert_eq!(heading_to_fragment("Notes… done"), "notes-done");
+        // Unchanged: the cases the marker pass reproduced
+        assert_eq!(heading_to_fragment("A 🚀 B"), "a--b");
+        assert_eq!(heading_to_fragment("A 🚀 🎉 B"), "a---b");
+        assert_eq!(heading_to_fragment("A 🚀🎉 B"), "a--b");
+        assert_eq!(heading_to_fragment("🚀 Title"), "-title");
+        assert_eq!(heading_to_fragment("Title 🚀"), "title-");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #854.

GitHub's anchor filter keeps `[\p{Word}\- ]`, drops every other character and turns each space into a hyphen, so an emoji is deleted and the spaces around it stay. The character pass in `heading_to_fragment_internal` already does exactly that. The emoji marker pass in front of it (`process_emoji_sequences`) replaced each emoji with a `§EMOJI§` marker, popped the spaces around it, and re-added one or two hyphens by position at the end — a reconstruction that is exact only when the emoji is surrounded by spaces, and whose delimiter was in band, so a section sign written in the heading survived the slug.

This PR deletes the pass, the step-11 marker rewrite, the `§` branch of the character pass, and the two helpers only the pass used (`is_emoji_or_symbol` and `is_regional_indicator` in this file; `is_keycap_base` stays, the character pass uses it; `common::is_emoji_or_symbol` is untouched). An emoji now falls through the character pass like any other symbol. Nothing `§`-specific is left in the file.

### What changes for a user

All toward GitHub's output, verified against github-slugger 2.0.0:

| Heading | before | after |
| --- | --- | --- |
| `A §1 B` | `a-§1-b` | `a-1-b` |
| `A🚀 B`, `A 🚀B` | `a--b` | `a-b` |
| `A🚀B` | `a--b` | `ab` |
| `A °🚀 B` | `a---b` | `a--b` |
| `Notes… 🚀 done` | `notes---done` | `notes--done` |
| `Top 3☀️ days` | `top-3--days` | `top-3️-days` (as `⭐️` already behaved) |

Consequences downstream of the slug: MD051 stops reporting correct links to a `§` heading and starts reporting a link that was written to the old slug (`#a--b` for `## A🚀 B`), which GitHub never resolved; MD073's auto-fix regenerates a marker-based TOC with the corrected anchors, so a TOC rumdl wrote for such a heading changes on the next `--fix`; MD080 and the LSP rename compute the same slug and move with it.

### What does not change — tested

ZWJ family sequences (the pass ran before `sanitize_unicode` strips U+200D; each component is deleted and no space sits between them), flags, keycaps, skin-tone modifiers, text-style emoji with VS16, symbols outside the pass's quick-check ranges (`→`, `∑`, `⭐`), and every security filter. The other anchor styles are not touched.

### The smaller alternative, and why I did not take it

Keeping the pass and dropping the heading's own `§` before it runs is a one-line fix for the section sign, and I have it ready on a branch. It does not touch the hyphen count, since that comes from the pass itself, so the emoji rows above stay as they are. If you would rather land the one-liner first and consider the deletion separately, say so and I will swap the branch.

The one thing I cannot measure: the module says its cases were verified against GitHub Gists, and a verified emoji case that never became a test would be invisible to me. All 33 existing tests in the module pass without the pass, and GitHub's published filter has no emoji special case at all.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Tests added/updated — `test_github_section_sign_is_stripped` (ten headings) and `test_github_emoji_keeps_the_spaces_around_it` (eleven), expected values from github-slugger 2.0.0. The first fails on `main` with `"a-§1-b"` vs `"a-1-b"`, the second with `"a--b"` vs `"a-b"`.
- [x] All tests passing (`make test-dev`) — 13,140 run, 13,140 passed; `cargo test --doc` 21 passed.
- [x] Manual testing performed — `rumdl check` on the reproductions in #854: the `§` and emoji files report nothing, the mirror `[l](#a-§1-b)` is reported.

## Checklist

- [x] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used (they generate the changelog)
- [x] Documentation updated (the module doc no longer describes the pass)
