### PR TITLE
docs(MD004): remove the non-existent after-marker option

### DIFF
--- a/docs/md004.md
+++ b/docs/md004.md
@@ -73,7 +73,6 @@ Ensures all unordered lists use the same marker (* or + or -) throughout your do
 ```toml
 [MD004]
 style = "consistent"  # Options: "consistent", "asterisk", "plus", "dash", "sublist"
-after-marker = 1      # Number of spaces after marker (default: 1)
 ```
 
 ### Style options


### PR DESCRIPTION
## Description

`docs/md004.md` documents an `after-marker` option that no rule accepts. This PR deletes that single line, leaving `style` as MD004's only documented option — which is what `MD004Config` actually declares.

### The mismatch

Docs side — `docs/md004.md:73-77` on `main` (394473d):

```toml
[MD004]
style = "consistent"  # Options: "consistent", "asterisk", "plus", "dash", "sublist"
after-marker = 1      # Number of spaces after marker (default: 1)
```

Code side — `src/rules/md004_unordered_list_style/md004_config.rs` has exactly one field:

```rust
pub(super) struct MD004Config {
    /// The style for unordered list markers
    #[serde(default)]
    pub style: UnorderedListStyle,
}
```

MD004 declares no `config_aliases` and no `polymorphic_config_keys`, so `impl_rule_config_sections!(MD004Config)` (`src/rules/md004_unordered_list_style.rs:288`) leaves `registry.config_keys_for("MD004")` yielding only `style`/`severity`/`enabled`, and `src/config/validation.rs:324` emits the unknown-option warning.

rumdl's own schema agrees, and shows where the described behaviour actually lives:

```console
$ rumdl config --defaults --output json   # MD004 and MD030 sections
{
  "MD004": { "style": "consistent" },
  "MD030": {
    "ol-align-column": 0, "ol-multi": 1, "ol-single": 1,
    "ul-multi": 1, "ul-single": 1
  }
}
```

Spaces after list markers are MD030's concern, so `after-marker` belongs to no rule at all. Repo-wide it occurs exactly once:

```console
$ grep -rn "after-marker" . --exclude-dir=.git
./docs/md004.md:76:after-marker = 1      # Number of spaces after marker (default: 1)
```

(`docs/md004.md` already links MD030 under "Related rules", so no new cross-reference is needed.)

### Why it is worth fixing

A user who copies the documented block verbatim is warned on every run — and gets a **non-zero exit** under `--deny-config-warnings` (`src/commands/check.rs:242`), so it breaks CI rather than just adding noise:

```console
$ cat .rumdl.toml
[MD004]
style = "consistent"
after-marker = 1

$ rumdl check .
[config warning] Unknown option for rule MD004: after-marker
Success: No issues found in 1 file (58ms)
exit=0

$ rumdl check --deny-config-warnings .
[config warning] Unknown option for rule MD004: after-marker
Success: No issues found in 1 file (2ms)
exit=2
```

With the line removed, a user following the docs writes only `style`, and both invocations are clean:

```console
$ rumdl check --deny-config-warnings .
Success: No issues found in 1 file (49ms)
exit=0
```

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [ ] Tests added/updated — not applicable, see the note below
- [x] All tests passing
- [x] Manual testing performed

`cargo-nextest` was not available in my environment, so I ran the equivalents through `cargo test` with filters:

```console
$ cargo test --test lib test_all_config_fields_are_documented
test config::config_documentation_completeness::test_all_config_fields_are_documented ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5884 filtered out

$ cargo test --test lib config::
test result: ok. 398 passed; 0 failed; 0 ignored; 0 measured; 5487 filtered out; finished in 13.29s

$ python scripts/test_check_rule_docs.py
Ran 18 tests in 0.183s
OK

$ python scripts/check-rule-docs.py
Rule docs in sync: 84 rules (31 beyond markdownlint, max MD091).

$ ./target/debug/rumdl check --no-exclude docs/md004.md
Success: No issues found in 1 file (154ms)
```

On tests: `tests/config/config_documentation_completeness.rs` only asserts config field → docs (it flags *undocumented* fields), never docs → config, which is how this stale line survived. `style` remains documented, so that test is unaffected either way.

## Checklist

- [x] Code follows project style (`rumdl check` is clean on the edited file; docs-only change, no Rust touched)
- [x] Conventional commit messages used — `docs(MD004): …`, uppercase scope per `scripts/check-commit-scope.sh`
- [x] Documentation updated (this *is* the documentation change)

No `CHANGELOG.md` edit: per CONTRIBUTING this is a routine change whose commit subject becomes the entry at release time.

### Limitation

I did not add a docs → config guard test. A general one would first have to account for config aliases and polymorphic keys, and CONTRIBUTING asks that PRs stay focused — so this is a pure one-line deletion. Happy to follow up with such a test separately if you would find it useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
