### PR TITLE
docs(rules): Move other rules to related tables

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -220,7 +220,6 @@ Severity affects:
 | Rule ID           | Rule Name               | Description                                        |
 | ----------------- | ----------------------- | -------------------------------------------------- |
 | [MD026](md026.md) | No trailing punctuation | Trailing punctuation in heading                    |
-| [MD033](md033.md) | No inline HTML          | Inline HTML                                        |
 | [MD035](md035.md) | HR style                | Horizontal rule style                              |
 | [MD037](md037.md) | Spaces around emphasis  | Spaces inside emphasis markers                     |
 | [MD038](md038.md) | No space in code        | Spaces inside code span elements                   |
@@ -229,6 +228,16 @@ Severity affects:
 | [MD049](md049.md) | Emphasis style          | Emphasis style should be consistent                |
 | [MD050](md050.md) | Strong style            | Strong style should be consistent                  |
 | [MD081](md081.md) | No excessive emphasis   | Excessive bold/italic emphasis in prose            |
+| [MD088](md088.md) | Quotes and dashes       | Normalize Quotes and Dashes                        |
+
+## HTML Rules
+
+| Rule ID           | Rule Name              | Description                                |
+| ----------------- | ---------------------- | ------------------------------------------ |
+| [MD033](md033.md) | No inline HTML         | Inline HTML                                |
+| [MD086](md086.md) | No unclosed comments   | Comment openers should have a closer       |
+| [MD087](md087.md) | Unused disable comment | Disable comments should suppress something |
+| [MD091](md091.md) | No markdown in HTML    | Markdown in an HTML block renders as text  |
 
 ## Code Block Rules
 
@@ -254,16 +263,19 @@ Severity affects:
 | [MD052](md052.md) | Reference links images | References should be defined                          |
 | [MD053](md053.md) | Link image definitions | Link and image reference definitions should be needed |
 | [MD054](md054.md) | Link image style       | Link and image style                                  |
+| [MD057](md057.md) | Relative links         | Relative links should exist                           |
 | [MD059](md059.md) | Link text              | Link text should be descriptive                       |
+| [MD062](md062.md) | Link destination space | No whitespace in link destinations                    |
 
 ## Table Rules
 
-| Rule ID           | Rule Name           | Description                                        |
-| ----------------- | ------------------- | -------------------------------------------------- |
-| [MD055](md055.md) | Table pipe style    | Table pipe style should be consistent              |
-| [MD056](md056.md) | Table column count  | Table column count should be consistent            |
-| [MD058](md058.md) | Table spacing       | Tables should be surrounded by blank lines         |
-| [MD075](md075.md) | Orphaned table rows | Orphaned table rows or headerless pipe content     |
+| Rule ID           | Rule Name           | Description                                    |
+| ----------------- | ------------------- | ---------------------------------------------- |
+| [MD055](md055.md) | Table pipe style    | Table pipe style should be consistent          |
+| [MD056](md056.md) | Table column count  | Table column count should be consistent        |
+| [MD058](md058.md) | Table spacing       | Tables should be surrounded by blank lines     |
+| [MD060](md060.md) | Table format        | Table formatting should be consistent          |
+| [MD075](md075.md) | Orphaned table rows | Orphaned table rows or headerless pipe content |
 
 ## Footnote Rules
 
@@ -284,17 +296,10 @@ Severity affects:
 
 | Rule ID           | Rule Name              | Description                                |
 | ----------------- | ---------------------- | ------------------------------------------ |
-| [MD057](md057.md) | Relative links         | Relative links should exist                |
-| [MD060](md060.md) | Table format           | Table formatting should be consistent      |
 | [MD061](md061.md) | Forbidden terms        | Certain terms should not be used           |
-| [MD062](md062.md) | Link destination space | No whitespace in link destinations         |
 | [MD073](md073.md) | TOC validation         | Table of Contents should match headings    |
 | [MD074](md074.md) | MkDocs nav validation  | Nav entries should point to existing files |
 | [MD083](md083.md) | Mojibake               | Detect mojibake due to encoding issues     |
-| [MD086](md086.md) | No unclosed comments   | Comment openers should have a closer       |
-| [MD087](md087.md) | Unused disable comment | Disable comments should suppress something |
-| [MD088](md088.md) | Quotes and dashes      | Normalize Quotes and Dashes                |
-| [MD091](md091.md) | No markdown in HTML    | Markdown in an HTML block renders as text  |
 
 ## Using Rules
 


### PR DESCRIPTION
## Description

While reading through the rules list at https://rumdl.dev/rules/, it seemed like several rules in the `## Other rules` section could be moved into specific sections.

Additionally, it seems like there are enough HTML-related rules for a `## HTML Rules`, so why not move those 4 rules into a new section too?

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [ ] Tests added/updated
- [ ] All tests passing (`make test-dev`)
- [ ] Manual testing performed

## Checklist

- [ ] Code follows project style (`make fmt` && `make lint`)
- [x] Conventional commit messages used (they generate the changelog)
- [x] Documentation updated (if needed)