### PR TITLE
fix(config): suggestion panics on multibyte characters

### DIFF
--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -546,9 +546,9 @@ fn levenshtein_distance(s1: &str, s2: &str) -> usize {
     let mut prev_row: Vec<usize> = (0..=len2).collect();
     let mut curr_row = vec![0; len2 + 1];
 
-    for i in 1..=len1 {
+    for i in 1..=s1_chars.len() {
         curr_row[0] = i;
-        for j in 1..=len2 {
+        for j in 1..=s2_chars.len() {
             let cost = usize::from(s1_chars[i - 1] != s2_chars[j - 1]);
             curr_row[j] = (prev_row[j] + 1)          // deletion
                 .min(curr_row[j - 1] + 1)            // insertion
@@ -637,6 +637,11 @@ mod suggestion_tests {
     #[test]
     fn a_key_beyond_the_edit_budget_is_no_suggestion() {
         assert_eq!(suggest_similar_key("MD999", &keys(&["line-length"])), None);
+    }
+
+    #[test]
+    fn multibyte_character_no_panic() {
+        assert_eq!(suggest_similar_key("—", &keys(&["MD049", "MD009"])), None);
     }
 }
 


### PR DESCRIPTION
This fixes that the config's similar key suggestion mechanism doesn't
panic when a string contains a multibyte character, such as an em-dash
or an emoji.

The bug was caused by reusing the byte length for the Levenshtein
distance calculation instead of using the length of the character
vectors.

Fun fact: I didn't even notice this with an AI-generated em-dash, I just
typed it myself in a `rumdl-disable-next-line` comment to get rid of the
`Unknown rule` warning to document why I disabled the rule.
