### PR TITLE
feat(md034): add a config option to turn off auto fixes

### DIFF
--- a/benches/fix_performance.rs
+++ b/benches/fix_performance.rs
@@ -311,7 +311,7 @@ fn bench_fix_performance(c: &mut Criterion) {
 
     // MD034 - Bare URLs
     c.bench_function("MD034 fix", |b| {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         b.iter(|| rule.fix(black_box(&ctx)))
     });
 

--- a/docs/md034.md
+++ b/docs/md034.md
@@ -52,13 +52,21 @@ Chat with me at <xmpp:user@example.com>
 
 ## Configuration
 
-This rule has no configuration options.
+The `fix` option controls whether automatic fixes are emitted. It defaults to `true`.
+This can be useful when working with Markdown files that are embedded in MDX, since automatic fixes
+may break MDX compilation.
+
+```toml
+[MD034]
+fix = false
+```
 
 ## Automatic fixes
 
-Outside the `mdg` flavor, this rule automatically wraps plain URLs, email
-addresses, and XMPP URIs in angle brackets (`<` and `>`). Under `mdg`, it
-reports without fixing; see below.
+When `fix` is enabled (default), outside the `mdg` flavor this rule automatically wraps
+plain URLs, email addresses, and XMPP URIs in angle brackets (`<` and `>`).
+When `fix` is disabled, the rule still reports violations but emits no fixes.
+Under `mdg`, it reports without fixing regardless of this option; see below.
 
 ## GFM extended autolinks
 

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -1479,7 +1479,7 @@ mod tests {
     fn test_converted_email_link_round_trips_through_md034() {
         // The action's output must not itself be a bare URL MD034 reports again.
         use crate::rule::Rule;
-        let rule = crate::rules::MD034NoBareUrls;
+        let rule = crate::rules::MD034NoBareUrls::default();
         let ctx = crate::lint_context::LintContext::new(
             "Mail [user@example.com](mailto:user@example.com) now\n",
             crate::config::MarkdownFlavor::Standard,

--- a/src/rules/md034_no_bare_urls.rs
+++ b/src/rules/md034_no_bare_urls.rs
@@ -4,8 +4,10 @@
 use std::sync::LazyLock;
 
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 use crate::rule::{Fix, LintError, LintResult, LintWarning, Rule, RuleCategory, Severity};
+use crate::rule_config_serde::{RuleConfig, load_rule_config};
 use crate::utils::range_utils::calculate_url_range;
 use crate::utils::regex_cache::{
     EMAIL_PATTERN, URL_IPV6_REGEX, URL_QUICK_CHECK_REGEX, URL_STANDARD_REGEX, URL_WWW_REGEX, XMPP_URI_REGEX,
@@ -201,8 +203,33 @@ struct LineCheckBuffers {
     urls_found: Vec<(usize, usize, String)>,
 }
 
+/// Configuration for MD034 (No bare URLs).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct MD034Config {
+    /// Emit automatic fixes for bare URLs and email addresses.
+    #[serde(default = "default_fix")]
+    pub fix: bool,
+}
+
+const fn default_fix() -> bool {
+    true
+}
+
+impl Default for MD034Config {
+    fn default() -> Self {
+        Self { fix: default_fix() }
+    }
+}
+
+impl RuleConfig for MD034Config {
+    const RULE_NAME: &'static str = "MD034";
+}
+
 #[derive(Default, Clone)]
-pub struct MD034NoBareUrls;
+pub struct MD034NoBareUrls {
+    config: MD034Config,
+}
 
 impl MD034NoBareUrls {
     #[inline]
@@ -497,15 +524,22 @@ impl MD034NoBareUrls {
                 };
                 let line_start_byte = ctx.line_start_byte(line_number).unwrap_or(0);
                 let span_end = line_start_byte + start + trimmed_len;
-                let fix = if ctx.flavor.supports_jsx() {
-                    jsx_fix(line, start, trimmed_url, &destination)
-                        .map(|(fix_start, replacement)| Fix::new((line_start_byte + fix_start)..span_end, replacement))
-                } else {
-                    Some(Fix::new(
-                        (line_start_byte + start)..span_end,
-                        format!("<{destination}>"),
-                    ))
-                };
+                let fix = self
+                    .config
+                    .fix
+                    .then(|| {
+                        if ctx.flavor.supports_jsx() {
+                            jsx_fix(line, start, trimmed_url, &destination).map(|(fix_start, replacement)| {
+                                Fix::new((line_start_byte + fix_start)..span_end, replacement)
+                            })
+                        } else {
+                            Some(Fix::new(
+                                (line_start_byte + start)..span_end,
+                                format!("<{destination}>"),
+                            ))
+                        }
+                    })
+                    .flatten();
 
                 warnings.push(LintWarning {
                     rule_name: Some("MD034".to_string()),
@@ -581,16 +615,27 @@ impl MD034NoBareUrls {
                         let (start_line, start_col, end_line, end_col) =
                             calculate_url_range(line_number, line, start, email_len);
 
-                        let fix = if ctx.flavor.supports_jsx() {
-                            jsx_fix(line, start, email, &format!("mailto:{email}")).map(|(fix_start, replacement)| {
-                                Fix::new((line_start_byte + fix_start)..(line_start_byte + end), replacement)
+                        let fix = self
+                            .config
+                            .fix
+                            .then(|| {
+                                if ctx.flavor.supports_jsx() {
+                                    jsx_fix(line, start, email, &format!("mailto:{email}")).map(
+                                        |(fix_start, replacement)| {
+                                            Fix::new(
+                                                (line_start_byte + fix_start)..(line_start_byte + end),
+                                                replacement,
+                                            )
+                                        },
+                                    )
+                                } else {
+                                    Some(Fix::new(
+                                        (line_start_byte + start)..(line_start_byte + end),
+                                        format!("<{email}>"),
+                                    ))
+                                }
                             })
-                        } else {
-                            Some(Fix::new(
-                                (line_start_byte + start)..(line_start_byte + end),
-                                format!("<{email}>"),
-                            ))
-                        };
+                            .flatten();
 
                         warnings.push(LintWarning {
                             rule_name: Some("MD034".to_string()),
@@ -627,11 +672,13 @@ impl Rule for MD034NoBareUrls {
         self
     }
 
-    fn from_config(_config: &crate::config::Config) -> Box<dyn Rule>
+    fn from_config(config: &crate::config::Config) -> Box<dyn Rule>
     where
         Self: Sized,
     {
-        Box::new(MD034NoBareUrls)
+        Box::new(MD034NoBareUrls {
+            config: load_rule_config(config),
+        })
     }
 
     #[inline]
@@ -760,6 +807,9 @@ impl Rule for MD034NoBareUrls {
     }
 
     fn fix(&self, ctx: &LintContext) -> Result<String, LintError> {
+        if !self.config.fix {
+            return Ok(ctx.content.to_string());
+        }
         let mut content = ctx.content.to_string();
         let warnings = self.check(ctx)?;
         let mut warnings =
@@ -786,8 +836,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_fix_can_be_disabled_without_suppressing_warnings() {
+        let rule = MD034NoBareUrls {
+            config: MD034Config { fix: false },
+        };
+        let content = "Visit https://example.com and email user@example.com.";
+        let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
+
+        let warnings = rule.check(&ctx).unwrap();
+        assert_eq!(warnings.len(), 2);
+        assert!(warnings.iter().all(|warning| warning.fix.is_none()));
+        assert_eq!(rule.fix(&ctx).unwrap(), content);
+    }
+
+    #[test]
     fn test_shortcut_ref_at_end_of_line_no_trailing_chars() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "See [https://example.com]";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
@@ -799,7 +863,7 @@ mod tests {
 
     #[test]
     fn test_shortcut_ref_multiple_spaces_before_paren() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "[text]  (https://example.com)";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
@@ -811,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_shortcut_ref_tab_before_bracket() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "[https://example.com]\t[other]";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
@@ -827,7 +891,7 @@ mod tests {
 
     #[test]
     fn test_shortcut_ref_followed_by_punctuation() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "[https://example.com], see also other things.";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
@@ -842,7 +906,7 @@ mod tests {
         // Exact reproduction from issue #572: URL inside inline code within an MDX
         // component body must not be flagged. The same URL in backticks outside the
         // component is already handled correctly and serves as a control.
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "# Test\n\nControl: `https://rumdl.example.com/` is fine here.\n\n<ParamField path=\"--stuff\">\n  This URL `https://rumdl.example.com/` must not be flagged.\n</ParamField>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -856,7 +920,7 @@ mod tests {
     fn test_bare_url_inside_mdx_component_still_flagged() {
         // A bare URL (not in backticks) inside an MDX component body must still be flagged.
         // This ensures the fix for issue #572 only suppresses properly code-spanned URLs.
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content =
             "# Test\n\n<ParamField path=\"--stuff\">\n  Visit https://rumdl.example.com/ for details.\n</ParamField>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
@@ -871,7 +935,7 @@ mod tests {
     #[test]
     fn test_url_in_backticks_inside_nested_mdx_component_not_flagged() {
         // Nested MDX components must also respect code spans.
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "<Outer>\n  <Inner>\n    Check `https://example.com/` here.\n  </Inner>\n</Outer>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -886,7 +950,7 @@ mod tests {
     /// flagged, and `fix` must not rewrite it (which would corrupt the command).
     #[test]
     fn test_url_in_fenced_code_block_inside_jsx_not_flagged() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "# Title\n\n<Steps>\n  <Step title=\"Send a request\">\n```bash\ncurl https://example.com/api\n```\n  </Step>\n</Steps>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -900,7 +964,7 @@ mod tests {
     /// `<https://...>` rewrite that breaks a copy-pasteable command).
     #[test]
     fn test_fix_does_not_rewrite_url_in_fenced_code_block_inside_jsx() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "# Title\n\n<Steps>\n  <Step title=\"Send a request\">\n```bash\ncurl https://example.com/api\n```\n  </Step>\n</Steps>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let fixed = rule.fix(&ctx).unwrap();
@@ -914,7 +978,7 @@ mod tests {
     /// and must still be flagged, so the fence exemption is not over-broad.
     #[test]
     fn test_bare_url_in_jsx_body_outside_fence_still_flagged() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "# Title\n\n<Steps>\n  <Step title=\"Send a request\">\n  Visit https://example.com/api now.\n  </Step>\n</Steps>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -930,7 +994,7 @@ mod tests {
     /// bare URL between them (the code-block counterpart to the code-span fix).
     #[test]
     fn test_bare_url_not_masked_by_comment_delimiter_in_code_block() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content =
             "# T\n\n```text\n<!-- literal opener, not a comment\n```\n\nhttps://example.com should be flagged\n\n-->\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
@@ -948,7 +1012,7 @@ mod tests {
     /// comment, so its bare URL stays skipped.
     #[test]
     fn test_bare_url_in_indented_comment_in_admonition_still_skipped() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "# T\n\n!!! note\n    Some text.\n\n    <!--\n    https://example.com\n    -->\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MkDocs, None);
         let result = rule.check(&ctx).unwrap();
@@ -963,7 +1027,7 @@ mod tests {
     /// invalid JSX, so MD034 must not flag it under the MDX flavor.
     #[test]
     fn test_url_in_jsx_component_attribute_not_flagged() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "<Card title=\"Docs\" href=\"https://example.com/docs\" />\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -976,7 +1040,7 @@ mod tests {
     /// The same exemption must apply when the JSX opening tag spans multiple lines.
     #[test]
     fn test_url_in_multiline_jsx_component_attribute_not_flagged() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "<Card\n  title=\"Docs\"\n  href=\"https://example.com/docs\"\n/>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -990,7 +1054,7 @@ mod tests {
     /// but a bare URL in the component's *body* is genuine prose and still flagged.
     #[test]
     fn test_jsx_attribute_url_skipped_but_body_url_flagged() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "<Card href=\"https://attr.example.com\">\n  Visit https://body.example.com now.\n</Card>\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -1009,7 +1073,7 @@ mod tests {
     /// JSX component attribute value must not be flagged either.
     #[test]
     fn test_email_in_jsx_component_attribute_not_flagged() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "<Contact email=\"hello@example.com\" />\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
         let result = rule.check(&ctx).unwrap();
@@ -1024,7 +1088,7 @@ mod tests {
     /// This locks in that the two flavors agree.
     #[test]
     fn test_jsx_attribute_url_not_flagged_in_standard_flavor() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "<Card href=\"https://example.com/docs\" />\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
@@ -1039,7 +1103,7 @@ mod tests {
     fn test_pandoc_skips_urls_in_line_blocks() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "| See https://example.com\n| For details\n";
         let ctx = LintContext::new(content, MarkdownFlavor::Pandoc, None);
         let result = rule.check(&ctx).unwrap();
@@ -1054,7 +1118,7 @@ mod tests {
     fn test_pandoc_skips_urls_in_metadata() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "---\nhomepage: https://example.com\n---\n\nBody.\n";
         let ctx = LintContext::new(content, MarkdownFlavor::Pandoc, None);
         let result = rule.check(&ctx).unwrap();
@@ -1070,7 +1134,7 @@ mod tests {
     fn test_standard_still_flags_urls_in_pipe_prefixed_lines() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "| See https://example.com\n";
         let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
@@ -1085,7 +1149,7 @@ mod tests {
         // A fenced code block inside a JSX component must not misalign the code-span
         // offset map. The URL in backticks that appears *after* the code block must
         // still be recognised as being inside a code span.
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 <Component>
 Some intro text.
@@ -1112,7 +1176,7 @@ Check `https://example.com/` here.
     fn test_myst_colon_directive_argument_url_not_flagged() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 :::{anywidget} https://cdn.jsdelivr.net/npm/repo-review-webapp@1.1.3/dist/repo-review-anywidget.mjs
 {
@@ -1133,7 +1197,7 @@ Check `https://example.com/` here.
     fn test_myst_nested_colon_directive_argument_url_not_flagged() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 ::::{grid}
 :::{card} https://example.com/card-target
@@ -1155,7 +1219,7 @@ Some caption.
     fn test_myst_directive_body_url_still_flagged() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 :::{note}
 See https://example.com/docs for more details.
@@ -1176,7 +1240,7 @@ See https://example.com/docs for more details.
     fn test_myst_unclosed_colon_directive_argument_url_not_flagged() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 :::{anywidget} https://example.com/widget.mjs
 Some trailing content with no closing fence.
@@ -1195,7 +1259,7 @@ Some trailing content with no closing fence.
     fn test_colon_directive_url_flagged_in_standard_flavor() {
         use crate::config::MarkdownFlavor;
         use crate::lint_context::LintContext;
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = ":::{anywidget} https://example.com/widget.mjs\n";
         let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
         let result = rule.check(&ctx).unwrap();
@@ -1208,7 +1272,7 @@ Some trailing content with no closing fence.
 
     #[test]
     fn test_md034_complex_link() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
 
         // Case 1: Balanced brackets in code span.
         // We should flag the bare URL at the end, but NOT the one inside the link.
@@ -1235,7 +1299,7 @@ Some trailing content with no closing fence.
     /// still reports bare URLs under MDG, but withholds that unsafe automatic fix.
     #[test]
     fn test_mdg_reports_bare_urls_without_fixing_them() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 # Feature: Visit https://feature.example.com
 
@@ -1286,7 +1350,7 @@ Prose about https://prose.example.com for background.
 
     #[test]
     fn test_mdg_reports_bare_email_without_fixing_it() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "# Feature: Contact\n\n* Given I email user@example.com\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDG, None);
 
@@ -1302,7 +1366,7 @@ Prose about https://prose.example.com for background.
     /// document, at every position.
     #[test]
     fn test_mdg_exemption_does_not_affect_other_flavors() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 # Feature: Visit https://feature.example.com
 
@@ -1369,7 +1433,7 @@ Prose about <https://prose.example.com> for background.
     /// angle-bracket form everywhere would pass a one-sided test.
     #[test]
     fn test_mdx_fixes_bare_urls_to_links_instead_of_autolinks() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let cases = [
             (
                 "Bare link: http://localhost/\n",
@@ -1417,7 +1481,7 @@ Prose about <https://prose.example.com> for background.
     /// the same construct and were reported, which would have split the URI at the colon.
     #[test]
     fn test_an_address_behind_a_uri_scheme_is_not_a_bare_email() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         for content in [
             "Mail mailto:user@example.com now\n",
             "Chat xmpp:foo@bar.baz please\n",
@@ -1448,7 +1512,7 @@ Prose about <https://prose.example.com> for background.
     /// colon somewhere before it, which is ordinary prose and a real finding.
     #[test]
     fn test_a_colon_before_an_address_is_still_a_bare_email() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         for content in [
             "Contact: user@example.com\n",
             "Note (see 3:1): user@example.com\n",
@@ -1493,7 +1557,7 @@ Prose about <https://prose.example.com> for background.
     /// valid Markdown that MD034 does not report again.
     #[test]
     fn test_mdx_escapes_an_active_bang_before_the_link() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let cases = [
             (
                 "Download now!https://example.com/f today\n",
@@ -1531,7 +1595,7 @@ Prose about <https://prose.example.com> for background.
     /// an escape they never needed: `!<url>` is not image syntax.
     #[test]
     fn test_a_preceding_bang_is_untouched_outside_jsx_flavors() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let ctx = crate::lint_context::LintContext::new(
             "Download now!https://example.com/f today\n",
             crate::config::MarkdownFlavor::Standard,
@@ -1546,7 +1610,7 @@ Prose about <https://prose.example.com> for background.
     /// finding is reported with no fix rather than with a corrupting one.
     #[test]
     fn test_mdx_reports_but_does_not_fix_a_url_after_an_active_close_bracket() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content =
             "[See more]https://example.com/x here\n\n[https://example.com/x]: https://elsewhere.example.com/\n";
         let ctx = crate::lint_context::LintContext::new(content, crate::config::MarkdownFlavor::MDX, None);
@@ -1560,7 +1624,7 @@ Prose about <https://prose.example.com> for background.
     /// An escaped `]` closes no span, so the link is safe and keeps its fix.
     #[test]
     fn test_mdx_fixes_after_an_escaped_close_bracket() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let ctx = crate::lint_context::LintContext::new(
             "Text \\]https://example.com/x here\n",
             crate::config::MarkdownFlavor::MDX,
@@ -1601,7 +1665,7 @@ Prose about <https://prose.example.com> for background.
     /// in MDX projects, so they are escaped rather than left to the plugin set.
     #[test]
     fn test_mdx_link_text_escapes_characters_that_would_not_render_literally() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let cases = [
             ("https://ex.com/a*b*c", "https://ex.com/a\\*b\\*c"),
             ("https://ex.com/a&amp;b", "https://ex.com/a\\&amp;b"),
@@ -1635,7 +1699,7 @@ Prose about <https://prose.example.com> for background.
     /// would make the fix produce a document that no longer builds.
     #[test]
     fn test_mdx_braces_are_skipped_when_paired_and_escaped_when_not() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
 
         let paired = "See https://ex.com/a{b}c here\n";
         let paired_ctx = crate::lint_context::LintContext::new(paired, crate::config::MarkdownFlavor::MDX, None);
@@ -1671,7 +1735,7 @@ Prose about <https://prose.example.com> for background.
     /// angle-bracket destination is what covers the remaining case.
     #[test]
     fn test_mdx_unbalanced_open_paren_uses_an_angle_bracket_destination() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
 
         let unbalanced = "Go to https://ex.com/a(b now\n";
         let ctx = crate::lint_context::LintContext::new(unbalanced, crate::config::MarkdownFlavor::MDX, None);
@@ -1693,7 +1757,7 @@ Prose about <https://prose.example.com> for background.
     /// including the shapes whose escaping or angle brackets are unusual.
     #[test]
     fn test_mdx_fix_is_idempotent_and_stops_reporting() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "\
 Plain http://localhost/ and www.example.com.
 
@@ -1718,7 +1782,7 @@ Parens https://ex.com/a(b and https://en.wikipedia.org/wiki/Foo_(bar).
     /// its own fix-stripping branch unchanged.
     #[test]
     fn test_link_form_is_confined_to_jsx_flavors() {
-        let rule = MD034NoBareUrls;
+        let rule = MD034NoBareUrls::default();
         let content = "Visit https://example.com today\n";
 
         for flavor in [

--- a/src/rules/md034_no_bare_urls.rs
+++ b/src/rules/md034_no_bare_urls.rs
@@ -206,7 +206,7 @@ struct LineCheckBuffers {
 /// Configuration for MD034 (No bare URLs).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-pub struct MD034Config {
+struct MD034Config {
     /// Emit automatic fixes for bare URLs and email addresses.
     #[serde(default = "default_fix")]
     pub fix: bool,

--- a/tests/character_ranges/mod.rs
+++ b/tests/character_ranges/mod.rs
@@ -216,7 +216,7 @@ pub fn create_rule_by_name(rule_name: &str) -> Option<Box<dyn Rule>> {
         "MD031" => Some(Box::new(MD031BlanksAroundFences::default())),
         "MD032" => Some(Box::new(MD032BlanksAroundLists::default())),
         "MD033" => Some(Box::new(MD033NoInlineHtml::new())),
-        "MD034" => Some(Box::new(MD034NoBareUrls)),
+        "MD034" => Some(Box::new(MD034NoBareUrls::default())),
         "MD035" => Some(Box::new(MD035HRStyle::new("consistent".to_string()))),
         "MD036" => Some(Box::new(MD036NoEmphasisAsHeading::new(".,;:!?".to_string()))),
         "MD037" => Some(Box::new(MD037NoSpaceInEmphasis)),

--- a/tests/config/inline_config_test.rs
+++ b/tests/config/inline_config_test.rs
@@ -758,7 +758,7 @@ fn test_fix_md009_strict_respects_disable_line() {
 fn test_fix_md034_respects_disable_enable() {
     use rumdl_lib::rules::MD034NoBareUrls;
 
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "# Test\n\n<!-- rumdl-disable MD034 -->\nVisit http://example.com for info\n<!-- rumdl-enable MD034 -->\n\nVisit http://other.com for info\n";
 
@@ -842,7 +842,7 @@ fn test_fix_global_disable_preserves_all_content() {
 
     let rules_to_test: Vec<Box<dyn Rule>> = vec![
         Box::new(rumdl_lib::rules::MD009TrailingSpaces::new(2, false)),
-        Box::new(rumdl_lib::rules::MD034NoBareUrls),
+        Box::new(rumdl_lib::rules::MD034NoBareUrls::default()),
     ];
 
     for rule in &rules_to_test {

--- a/tests/formats/azure_devops_test.rs
+++ b/tests/formats/azure_devops_test.rs
@@ -179,7 +179,7 @@ fn test_link_parser_does_not_flag_content_inside_colon_fence() {
 
     let content = "::: mermaid\nA --> https://example.com/very/long/path\n:::\n";
     let ctx = azure_ctx(content);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let warnings = rule.check(&ctx).unwrap();
     assert!(
         warnings.is_empty(),

--- a/tests/formats/gh_aw_integration_test.rs
+++ b/tests/formats/gh_aw_integration_test.rs
@@ -22,7 +22,7 @@ fn gh_aw_ctx(content: &str) -> LintContext<'_> {
 
 #[test]
 fn representative_workflow_preserves_directives_and_finds_the_first_heading() {
-    let md034 = MD034NoBareUrls;
+    let md034 = MD034NoBareUrls::default();
     let md041 = MD041FirstLineHeading::default();
     let ctx = gh_aw_ctx(REPRESENTATIVE_WORKFLOW);
 
@@ -34,7 +34,7 @@ fn representative_workflow_preserves_directives_and_finds_the_first_heading() {
 
 #[test]
 fn representative_valid_corpus_is_clean_and_fix_stable() {
-    let md034 = MD034NoBareUrls;
+    let md034 = MD034NoBareUrls::default();
     let md041 = MD041FirstLineHeading::with_pattern(1, true, None, true);
 
     for (name, content) in [
@@ -62,7 +62,7 @@ fn directive_exemptions_are_exact_and_flavor_scoped() {
         "# Workflow\n\n",
         "Body URL https://example.com must still be linted.\n",
     );
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&gh_aw_ctx(content)).unwrap();
     assert_eq!(warnings.len(), 1);
@@ -97,7 +97,7 @@ fn current_conditional_branch_forms_are_structural() {
     );
     let ctx = gh_aw_ctx(content);
 
-    assert!(MD034NoBareUrls.check(&ctx).unwrap().is_empty());
+    assert!(MD034NoBareUrls::default().check(&ctx).unwrap().is_empty());
     assert!(MD041FirstLineHeading::default().check(&ctx).unwrap().is_empty());
 }
 
@@ -115,7 +115,7 @@ fn directive_lookalikes_remain_markdown() {
         "{{#runtime-import https://example.com/extra-close.md}}}\n",
         "{{#runtime-import https://example.com/two-extra-closes.md}}}}\n",
     );
-    let warnings = MD034NoBareUrls.check(&gh_aw_ctx(content)).unwrap();
+    let warnings = MD034NoBareUrls::default().check(&gh_aw_ctx(content)).unwrap();
 
     assert_eq!(
         warnings.len(),

--- a/tests/formats/mkdocs_extensions_test.rs
+++ b/tests/formats/mkdocs_extensions_test.rs
@@ -4799,7 +4799,7 @@ mod admonition_content_broader_rules {
         // should NOT be flagged by MD034
         let content = "# Test\n\n=== \"Tab\"\n\n    1.  Visit `https://example.com` to get started.\n\n        - Set **URL** to `https://example.com/api`\n";
         let ctx = LintContext::new(content, MarkdownFlavor::MkDocs, None);
-        let rule = rumdl_lib::MD034NoBareUrls;
+        let rule = rumdl_lib::MD034NoBareUrls::default();
         let warnings = rule.check(&ctx).unwrap();
         let md034: Vec<_> = warnings
             .iter()
@@ -4816,7 +4816,7 @@ mod admonition_content_broader_rules {
         // Issue #487: fix mode should not modify URLs inside code spans
         let content = "# Test\n\n=== \"Tab\"\n\n    1.  Visit `https://example.com` to get started.\n\n        - Set **URL** to `https://example.com/api`\n";
         let ctx = LintContext::new(content, MarkdownFlavor::MkDocs, None);
-        let rule = rumdl_lib::MD034NoBareUrls;
+        let rule = rumdl_lib::MD034NoBareUrls::default();
         let fixed = rule.fix(&ctx).unwrap();
         assert_eq!(fixed, content, "Fix should not modify URLs in code spans");
     }
@@ -4826,7 +4826,7 @@ mod admonition_content_broader_rules {
         // Bare URLs (not in code spans) inside content tabs should still be flagged
         let content = "# Test\n\n=== \"Tab 1\"\n\n    Visit https://example.com for details.\n";
         let ctx = LintContext::new(content, MarkdownFlavor::MkDocs, None);
-        let rule = rumdl_lib::MD034NoBareUrls;
+        let rule = rumdl_lib::MD034NoBareUrls::default();
         let warnings = rule.check(&ctx).unwrap();
         let md034: Vec<_> = warnings
             .iter()
@@ -4842,7 +4842,7 @@ mod admonition_content_broader_rules {
     fn test_md034_no_warning_for_url_in_code_span_in_admonition() {
         let content = "# Test\n\n!!! note\n\n    Visit `https://example.com` for details.\n";
         let ctx = LintContext::new(content, MarkdownFlavor::MkDocs, None);
-        let rule = rumdl_lib::MD034NoBareUrls;
+        let rule = rumdl_lib::MD034NoBareUrls::default();
         let warnings = rule.check(&ctx).unwrap();
         let md034: Vec<_> = warnings
             .iter()
@@ -5091,7 +5091,7 @@ mod admonition_content_broader_rules {
         );
 
         // MD034 should NOT flag this URL since it's inside a code span
-        let rule = rumdl_lib::MD034NoBareUrls;
+        let rule = rumdl_lib::MD034NoBareUrls::default();
         let warnings = rule.check(&ctx).unwrap();
         let md034: Vec<_> = warnings
             .iter()
@@ -5140,7 +5140,7 @@ mod admonition_content_broader_rules {
             "Should detect multi-line code span containing email fragment"
         );
 
-        let rule = rumdl_lib::MD034NoBareUrls;
+        let rule = rumdl_lib::MD034NoBareUrls::default();
         let warnings = rule.check(&ctx).unwrap();
         let md034: Vec<_> = warnings
             .iter()
@@ -5167,7 +5167,7 @@ mod admonition_content_broader_rules {
         assert_eq!(code_spans[0].content, "https://example.com");
 
         // MD034 should not flag the URL
-        let rule = rumdl_lib::MD034NoBareUrls;
+        let rule = rumdl_lib::MD034NoBareUrls::default();
         let warnings = rule.check(&ctx).unwrap();
         let md034: Vec<_> = warnings
             .iter()

--- a/tests/integration/gfm_comprehensive_test.rs
+++ b/tests/integration/gfm_comprehensive_test.rs
@@ -14,7 +14,7 @@ use rumdl_lib::rules::MD034NoBareUrls;
 #[test]
 fn test_gfm_autolink_https() {
     let content = "Visit https://example.com for more info.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -24,7 +24,7 @@ fn test_gfm_autolink_https() {
 #[test]
 fn test_gfm_autolink_http() {
     let content = "Visit http://example.com for more info.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -34,7 +34,7 @@ fn test_gfm_autolink_http() {
 #[test]
 fn test_gfm_autolink_www_prefix() {
     let content = "Check www.example.com for details.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -45,7 +45,7 @@ fn test_gfm_autolink_www_prefix() {
 #[test]
 fn test_gfm_autolink_ftp() {
     let content = "Download from ftp://files.example.com/file.zip here.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -55,7 +55,7 @@ fn test_gfm_autolink_ftp() {
 #[test]
 fn test_gfm_autolink_in_proper_link_no_warning() {
     let content = "Visit [example](https://example.com) for more info.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -65,7 +65,7 @@ fn test_gfm_autolink_in_proper_link_no_warning() {
 #[test]
 fn test_gfm_autolink_in_angle_brackets_no_warning() {
     let content = "Visit <https://example.com> for more info.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -75,7 +75,7 @@ fn test_gfm_autolink_in_angle_brackets_no_warning() {
 #[test]
 fn test_gfm_autolink_in_code_span_no_warning() {
     let content = "Use `https://example.com` in your config.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -88,7 +88,7 @@ fn test_gfm_autolink_in_code_block_no_warning() {
 https://example.com
 ```
 "#;
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -98,7 +98,7 @@ https://example.com
 #[test]
 fn test_gfm_autolink_multiple_on_same_line() {
     let content = "Visit https://example.com and https://other.com today.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -108,7 +108,7 @@ fn test_gfm_autolink_multiple_on_same_line() {
 #[test]
 fn test_gfm_autolink_with_path() {
     let content = "See https://example.com/docs/guide/intro.html for details.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -118,7 +118,7 @@ fn test_gfm_autolink_with_path() {
 #[test]
 fn test_gfm_autolink_with_query_params() {
     let content = "Visit https://example.com/search?q=test&page=1 for results.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -128,7 +128,7 @@ fn test_gfm_autolink_with_query_params() {
 #[test]
 fn test_gfm_autolink_with_fragment() {
     let content = "See https://example.com/page#section for the section.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -138,7 +138,7 @@ fn test_gfm_autolink_with_fragment() {
 #[test]
 fn test_gfm_autolink_with_port() {
     let content = "Server at https://localhost:8080/api for testing.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -148,7 +148,7 @@ fn test_gfm_autolink_with_port() {
 #[test]
 fn test_gfm_autolink_ip_address() {
     let content = "Connect to http://192.168.1.1/admin for settings.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -158,7 +158,7 @@ fn test_gfm_autolink_ip_address() {
 #[test]
 fn test_gfm_autolink_localhost() {
     let content = "Development at http://localhost/dev for testing.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -168,7 +168,7 @@ fn test_gfm_autolink_localhost() {
 #[test]
 fn test_gfm_autolink_in_parentheses() {
     let content = "More info (see https://example.com) available.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -178,7 +178,7 @@ fn test_gfm_autolink_in_parentheses() {
 #[test]
 fn test_gfm_autolink_at_line_start() {
     let content = "https://example.com is the site.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -188,7 +188,7 @@ fn test_gfm_autolink_at_line_start() {
 #[test]
 fn test_gfm_autolink_at_line_end() {
     let content = "Visit https://example.com\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -198,7 +198,7 @@ fn test_gfm_autolink_at_line_end() {
 #[test]
 fn test_gfm_email_autolink() {
     let content = "Contact user@example.com for help.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -210,7 +210,7 @@ fn test_gfm_email_autolink() {
 #[test]
 fn test_gfm_autolink_with_encoded_chars() {
     let content = "See https://example.com/path%20with%20spaces for info.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -220,7 +220,7 @@ fn test_gfm_autolink_with_encoded_chars() {
 #[test]
 fn test_gfm_autolink_with_unicode_domain() {
     let content = "Visit https://例え.jp for Japanese content.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -496,7 +496,7 @@ See documentation[^1] for details.
     assert!(ctx.lines.len() >= 15);
 
     // Check for bare URLs in table and footnote
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let warnings = rule.check(&ctx).unwrap();
 
     // Should detect bare URLs in table and footnote
@@ -518,7 +518,7 @@ fn test_gfm_all_features_in_one_line() {
 #[test]
 fn test_gfm_url_followed_by_punctuation() {
     let content = "Visit https://example.com.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -530,7 +530,7 @@ fn test_gfm_url_in_list() {
     let content = r#"- First item https://example.com
 - Second item
 "#;
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -540,7 +540,7 @@ fn test_gfm_url_in_list() {
 #[test]
 fn test_gfm_url_in_blockquote() {
     let content = "> Check https://example.com for info.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -551,7 +551,7 @@ fn test_gfm_url_in_blockquote() {
 fn test_gfm_not_a_url_looks_like_one() {
     // These should NOT trigger warnings
     let content = "The ratio is 1:1 and time is 10:30.\n";
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 
@@ -600,7 +600,7 @@ fn test_gfm_many_urls() {
         content.push_str(&format!("Visit https://example{i}.com here.\n"));
     }
 
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let ctx = LintContext::new(&content, MarkdownFlavor::Standard, None);
     let warnings = rule.check(&ctx).unwrap();
 

--- a/tests/integration/rules_mod_test.rs
+++ b/tests/integration/rules_mod_test.rs
@@ -396,8 +396,8 @@ fn test_all_configurable_rules_expose_config_schema() {
     // Update this number when adding new configurable rules.
     assert_eq!(
         rules_with_config.len(),
-        56,
-        "Expected 56 rules with config sections. If you added config to a rule, \
+        57,
+        "Expected 57 rules with config sections. If you added config to a rule, \
          implement default_config_section(). Rules with config: {rules_with_config:?}"
     );
 }

--- a/tests/perf/malformed_markdown_stress_tests.rs
+++ b/tests/perf/malformed_markdown_stress_tests.rs
@@ -319,7 +319,7 @@ fn test_pathological_regex_patterns() {
     ];
 
     let rules: Vec<Box<dyn Rule>> = vec![
-        Box::new(MD034NoBareUrls),
+        Box::new(MD034NoBareUrls::default()),
         Box::new(MD039NoSpaceInLinks),
         Box::new(MD038NoSpaceInCode::default()),
         Box::new(MD040FencedCodeLanguage::default()),

--- a/tests/perf/real_world_performance.rs
+++ b/tests/perf/real_world_performance.rs
@@ -39,7 +39,7 @@ fn test_real_world_performance() {
 
         test_rule(&ctx, "MD033", || rumdl_lib::MD033NoInlineHtml::default().check(&ctx));
 
-        test_rule(&ctx, "MD034", || rumdl_lib::MD034NoBareUrls.check(&ctx));
+        test_rule(&ctx, "MD034", || rumdl_lib::MD034NoBareUrls::default().check(&ctx));
 
         test_rule(&ctx, "MD053", || {
             rumdl_lib::MD053LinkImageReferenceDefinitions::default().check(&ctx)

--- a/tests/perf/rule_complexity_regression_test.rs
+++ b/tests/perf/rule_complexity_regression_test.rs
@@ -697,7 +697,7 @@ fn test_md050_linear_complexity() {
 fn test_md034_linear_complexity() {
     let sizes = [500, 1000, 2000];
     let iterations = 5;
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let durations: Vec<_> = sizes
         .iter()

--- a/tests/regressions/md034_parentheses_url_test.rs
+++ b/tests/regressions/md034_parentheses_url_test.rs
@@ -15,7 +15,7 @@ use rumdl_lib::rules::MD034NoBareUrls;
 fn test_wikipedia_url_with_parentheses_detected() {
     let content = "https://en.wikipedia.org/wiki/Rust_(programming_language)\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
 
@@ -35,7 +35,7 @@ fn test_wikipedia_url_with_parentheses_detected() {
 fn test_wikipedia_url_with_parentheses_fixed() {
     let content = "https://en.wikipedia.org/wiki/Rust_(programming_language)\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let fixed = rule.fix(&ctx).unwrap();
 
@@ -51,7 +51,7 @@ fn test_wikipedia_url_with_parentheses_fixed() {
 fn test_balanced_parentheses_in_url_path() {
     let content = "https://example.com/path_(foo)_(bar)\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
     assert_eq!(warnings.len(), 1);
@@ -73,7 +73,7 @@ fn test_balanced_parentheses_in_url_path() {
 fn test_sentence_parentheses_after_url_excluded() {
     let content = "Check https://example.com (it's great)\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
     assert_eq!(warnings.len(), 1);
@@ -101,7 +101,7 @@ fn test_sentence_parentheses_after_url_excluded() {
 fn test_url_inside_parentheses() {
     let content = "See (https://example.com) for more\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
     assert_eq!(warnings.len(), 1);
@@ -119,7 +119,7 @@ fn test_url_inside_parentheses() {
 fn test_unbalanced_trailing_paren_excluded() {
     let content = "https://example.com)\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
     assert_eq!(warnings.len(), 1);
@@ -145,7 +145,7 @@ fn test_multibyte_url_with_unbalanced_paren() {
     // Chinese Wikipedia URL with closing paren - this used to panic
     let content = "https://zh.wikipedia.org/wiki/百分号编码)\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Should not panic and should detect the URL correctly
     let warnings = rule.check(&ctx).unwrap();
@@ -171,7 +171,7 @@ fn test_multibyte_url_with_balanced_parens() {
     // URL with Chinese characters AND balanced parentheses in path
     let content = "https://example.com/路径_(测试)\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
     assert_eq!(warnings.len(), 1);
@@ -202,7 +202,7 @@ This URL should be ignored: https://hidden.example.com
 This URL should be flagged: https://visible.example.com
 "#;
     let ctx = LintContext::new(content, MarkdownFlavor::Obsidian, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
 
@@ -220,7 +220,7 @@ This URL should be flagged: https://visible.example.com
 fn test_url_inside_obsidian_inline_comment_ignored() {
     let content = "Check this: %%https://hidden.example.com%% and https://visible.example.com\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Obsidian, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
 
@@ -238,7 +238,7 @@ fn test_url_inside_obsidian_inline_comment_ignored() {
 fn test_url_inside_obsidian_inline_comment_with_unicode_ignored() {
     let content = "✅ Check this: %%https://hidden.example.com%% and https://visible.example.com\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Obsidian, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
 
@@ -263,7 +263,7 @@ http://d.com
 http://visible.com
 "#;
     let ctx = LintContext::new(content, MarkdownFlavor::Obsidian, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
 
@@ -281,7 +281,7 @@ http://visible.com
 fn test_obsidian_comment_syntax_not_special_in_standard_flavor() {
     let content = "Check: %%http://example.com%% end\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
 
@@ -295,7 +295,7 @@ fn test_obsidian_comment_syntax_not_special_in_standard_flavor() {
 fn test_url_after_obsidian_comment_flagged() {
     let content = "%%comment%% http://visible.example.com\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Obsidian, None);
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let warnings = rule.check(&ctx).unwrap();
 

--- a/tests/rules/formatter_idempotency_test.rs
+++ b/tests/rules/formatter_idempotency_test.rs
@@ -343,7 +343,7 @@ fn test_md032_edge_case_code_fence_after_ordered_non1() {
 
 #[test]
 fn test_md034_fix_idempotent() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Visit https://example.com for more info.\n";
     assert_fix_idempotent(&rule, content, "MD034");
 }

--- a/tests/rules/formatter_proptest.rs
+++ b/tests/rules/formatter_proptest.rs
@@ -162,7 +162,7 @@ proptest! {
             Box::new(MD031BlanksAroundFences::default()),
             Box::new(MD032BlanksAroundLists::default()),
             Box::new(MD033NoInlineHtml::default()),
-            Box::new(MD034NoBareUrls),
+            Box::new(MD034NoBareUrls::default()),
             Box::new(MD035HRStyle::default()),
             Box::new(MD036NoEmphasisAsHeading::default()),
             Box::new(MD037NoSpaceInEmphasis),
@@ -431,7 +431,7 @@ idempotent_rule!(
 );
 idempotent_rule!(
     md034,
-    MD034NoBareUrls,
+    MD034NoBareUrls::default(),
     markdown_content_strategy(),
     Standard => test_md034_idempotent_standard,
     MkDocs => test_md034_idempotent_mkdocs,

--- a/tests/rules/link_edge_cases_test.rs
+++ b/tests/rules/link_edge_cases_test.rs
@@ -8,7 +8,7 @@ use rumdl_lib::rules::{MD034NoBareUrls, MD039NoSpaceInLinks, MD042NoEmptyLinks};
 
 #[test]
 fn test_md034_ipv6_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 1: IPv6 URLs should be detected as bare URLs
     let content = "\
@@ -29,7 +29,7 @@ Connect to http://[fe80::1%eth0]:3000 for link-local";
 
 #[test]
 fn test_md034_urls_with_punctuation() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 2: URLs with trailing punctuation
     let content = "\
@@ -56,7 +56,7 @@ Go to https://example.com; it's great
 
 #[test]
 fn test_md034_urls_in_special_contexts() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 3: URLs that should be ignored in special contexts
     let content = "\
@@ -84,7 +84,7 @@ https://example.com in code block
 
 #[test]
 fn test_md034_email_addresses() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 4: Email address detection
     let content = "\
@@ -107,7 +107,7 @@ Complex: firstname.lastname+tag@really.long.domain.example.org";
 
 #[test]
 fn test_md034_various_url_schemes() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 5: Different URL schemes
     let content = "\
@@ -123,7 +123,7 @@ FTPS: ftps://secure.example.com";
 
 #[test]
 fn test_md034_complex_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 6: URLs with complex query strings and fragments
     let content = "\
@@ -139,7 +139,7 @@ Special chars: https://example.com/path?data=%7B%22test%22%3A%20true%7D";
 
 #[test]
 fn test_md034_multiple_urls_per_line() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 7: Multiple URLs on the same line
     let content = "\
@@ -160,7 +160,7 @@ Both email@example.com and https://example.com are available";
 
 #[test]
 fn test_md034_unicode_domains() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test 8: Unicode/IDN domains
     let content = "\
@@ -577,7 +577,7 @@ fn test_md042_nested_links() {
 #[test]
 fn test_link_rules_interaction() {
     // Test all three rules together
-    let md034 = MD034NoBareUrls;
+    let md034 = MD034NoBareUrls::default();
     let md039 = MD039NoSpaceInLinks;
     let md042 = MD042NoEmptyLinks::new();
 
@@ -626,7 +626,7 @@ Another [ spaced link ](  )";
 #[test]
 fn test_link_rules_code_block_handling() {
     // Test that all link rules ignore code blocks
-    let md034 = MD034NoBareUrls;
+    let md034 = MD034NoBareUrls::default();
     let md039 = MD039NoSpaceInLinks;
     let md042 = MD042NoEmptyLinks::new();
 
@@ -651,7 +651,7 @@ contact@example.com
 #[test]
 fn test_link_rules_html_handling() {
     // Test HTML context handling
-    let md034 = MD034NoBareUrls;
+    let md034 = MD034NoBareUrls::default();
     let md039 = MD039NoSpaceInLinks;
     let md042 = MD042NoEmptyLinks::new();
 

--- a/tests/rules/md034_comprehensive_test.rs
+++ b/tests/rules/md034_comprehensive_test.rs
@@ -16,7 +16,7 @@ use rumdl_lib::rules::MD034NoBareUrls;
 /// Test URL-encoded characters in paths
 #[test]
 fn test_url_encoded_characters() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let test_cases = [
         (
             "https://example.com/path%20with%20spaces",
@@ -49,7 +49,7 @@ fn test_url_encoded_characters() {
 /// Test URLs with special query parameters
 #[test]
 fn test_urls_with_complex_query_strings() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let test_cases = [
         // Multiple query parameters
         ("https://example.com?a=1&b=2&c=3", 1),
@@ -71,7 +71,7 @@ fn test_urls_with_complex_query_strings() {
 /// Test URLs with fragments containing special characters
 #[test]
 fn test_urls_with_special_fragments() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let test_cases = [
         ("https://example.com#section-1", 1),
         ("https://example.com#L123-L456", 1), // GitHub line range
@@ -93,7 +93,7 @@ fn test_urls_with_special_fragments() {
 /// Test URLs in nested blockquotes
 #[test]
 fn test_urls_in_nested_blockquotes() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Single level blockquote
     let content1 = "> Visit https://example.com for info";
@@ -117,7 +117,7 @@ fn test_urls_in_nested_blockquotes() {
 /// Test URLs in various list contexts
 #[test]
 fn test_urls_in_list_items() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         // Unordered list with different markers
@@ -144,7 +144,7 @@ fn test_urls_in_list_items() {
 /// Test URLs in bold/italic contexts
 #[test]
 fn test_urls_with_emphasis() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         // URL after bold text
@@ -167,7 +167,7 @@ fn test_urls_with_emphasis() {
 /// Test URLs adjacent to closing emphasis markers - should not be flagged as bare URLs
 #[test]
 fn test_urls_inside_emphasis_in_links() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // URL inside bold link text - should not be flagged
     let content = "[**https://example.com**](https://example.com)";
@@ -186,7 +186,7 @@ fn test_urls_inside_emphasis_in_links() {
 /// Test URLs followed by various punctuation
 #[test]
 fn test_urls_with_trailing_punctuation() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         // Common sentence-ending punctuation
@@ -221,7 +221,7 @@ fn test_urls_with_trailing_punctuation() {
 /// Test URLs at document boundaries
 #[test]
 fn test_urls_at_document_boundaries() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // URL at very start of document
     let content1 = "https://example.com is the link";
@@ -250,7 +250,7 @@ fn test_urls_at_document_boundaries() {
 /// Test URLs with unusual but valid TLDs
 #[test]
 fn test_urls_with_unusual_tlds() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         ("https://example.museum", 1),
@@ -272,7 +272,7 @@ fn test_urls_with_unusual_tlds() {
 /// Test internationalized domain names (IDN)
 #[test]
 fn test_internationalized_domain_names() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         // Punycode domains
@@ -297,7 +297,7 @@ fn test_internationalized_domain_names() {
 /// Test URLs in inline HTML comments
 #[test]
 fn test_urls_in_inline_html_comments() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // URL in HTML comment - should not be flagged
     let content = "Text <!-- https://example.com --> more text";
@@ -312,7 +312,7 @@ fn test_urls_in_inline_html_comments() {
 /// Test URLs in multiline HTML comments
 #[test]
 fn test_urls_in_multiline_html_comments() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Text\n<!--\nhttps://example.com\nhttps://another.com\n-->\nMore text";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -326,7 +326,7 @@ fn test_urls_in_multiline_html_comments() {
 /// Test that URL after HTML comment IS flagged
 #[test]
 fn test_url_after_html_comment_is_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "<!-- comment --> https://example.com";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -341,7 +341,7 @@ fn test_url_after_html_comment_is_flagged() {
 /// Test that shortcut reference links are not flagged
 #[test]
 fn test_shortcut_reference_links_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // [URL] pattern - user intent is to use reference link
     let content = "[https://example.com]";
@@ -356,7 +356,7 @@ fn test_shortcut_reference_links_not_flagged() {
 /// Test that collapsed reference links are not flagged
 #[test]
 fn test_collapsed_reference_links_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // [URL][] pattern - collapsed reference link
     let content = "[https://example.com][]";
@@ -375,7 +375,7 @@ fn test_collapsed_reference_links_not_flagged() {
 /// Test URLs in table cells
 #[test]
 fn test_urls_in_table_cells() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // URL in table cell
     let content = "| Column 1 | Column 2 |\n|----------|----------|\n| https://example.com | text |";
@@ -393,7 +393,7 @@ fn test_urls_in_table_cells() {
 /// Test URLs in table headers
 #[test]
 fn test_urls_in_table_headers() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "| https://example.com | Header 2 |\n|---------------------|----------|\n| data | data |";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -408,7 +408,7 @@ fn test_urls_in_table_headers() {
 /// Test empty content handling
 #[test]
 fn test_empty_content() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -419,7 +419,7 @@ fn test_empty_content() {
 /// Test whitespace-only content
 #[test]
 fn test_whitespace_only_content() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "   \n\n   \t\t\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -430,7 +430,7 @@ fn test_whitespace_only_content() {
 /// Test content without any URL-like patterns
 #[test]
 fn test_content_without_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "# Heading\n\nThis is a paragraph without any URLs.\n\n- List item\n- Another item";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -445,7 +445,7 @@ fn test_content_without_urls() {
 /// Test very long URLs
 #[test]
 fn test_very_long_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // URL with many path segments
     let long_path = (0..20).map(|i| format!("segment{i}")).collect::<Vec<_>>().join("/");
@@ -474,7 +474,7 @@ fn test_very_long_urls() {
 /// This is expected behavior since both patterns appear in the content
 #[test]
 fn test_urls_with_credentials() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // URL with username (deprecated but valid)
     // Both the full URL AND the email-like part are detected
@@ -493,7 +493,7 @@ fn test_urls_with_credentials() {
 /// Test protocol-relative URLs (//example.com)
 #[test]
 fn test_protocol_relative_urls_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Protocol-relative URLs are not http/https/ftp URLs
     // They should not be flagged by MD034
@@ -515,7 +515,7 @@ fn test_protocol_relative_urls_not_flagged() {
 /// which will be detected separately. This test excludes those cases.
 #[test]
 fn test_custom_protocols_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Custom protocols without email-like patterns
     let test_cases = [
@@ -546,7 +546,7 @@ fn test_custom_protocols_not_flagged() {
 /// The email pattern (e.g., git@github.com) is detected separately from the protocol
 #[test]
 fn test_custom_protocols_with_email_patterns() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // ssh:// URLs often contain user@host patterns
     let content = "ssh://git@github.com/repo.git";
@@ -569,7 +569,7 @@ fn test_custom_protocols_with_email_patterns() {
 /// Test that fix produces valid markdown
 #[test]
 fn test_fix_produces_valid_markdown() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Visit https://example.com for more info.";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -586,7 +586,7 @@ fn test_fix_produces_valid_markdown() {
 /// Test fix with multiple URLs on same line
 #[test]
 fn test_fix_multiple_urls_same_line() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Visit https://one.com and https://two.com today";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);
@@ -603,7 +603,7 @@ fn test_fix_multiple_urls_same_line() {
 /// Test fix preserves surrounding markdown structure
 #[test]
 fn test_fix_preserves_markdown_structure() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "# Heading\n\n> Blockquote with https://example.com\n\n- List item https://test.com\n";
     let ctx = LintContext::new(content, MarkdownFlavor::Standard, None);

--- a/tests/rules/md034_ipv6_test.rs
+++ b/tests/rules/md034_ipv6_test.rs
@@ -4,7 +4,7 @@ use rumdl_lib::rules::MD034NoBareUrls;
 
 #[test]
 fn test_ipv6_url_basic() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Visit https://[::1]:8080 for local testing";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -17,7 +17,7 @@ fn test_ipv6_url_basic() {
 
 #[test]
 fn test_ipv6_url_full_address() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Server at http://[2001:db8::8a2e:370:7334]/path";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -29,7 +29,7 @@ fn test_ipv6_url_full_address() {
 
 #[test]
 fn test_ipv6_localhost_variations() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let test_cases = vec![
         ("http://[::1]", "<http://[::1]>"),
         ("https://[::1]", "<https://[::1]>"),
@@ -50,7 +50,7 @@ fn test_ipv6_localhost_variations() {
 
 #[test]
 fn test_ipv6_with_zone_id() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Connect to https://[fe80::1%eth0]:8080";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -62,7 +62,7 @@ fn test_ipv6_with_zone_id() {
 
 #[test]
 fn test_ipv6_mixed_with_ipv4() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Try http://127.0.0.1 or https://[::1]:8080 or http://localhost";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -77,7 +77,7 @@ fn test_ipv6_mixed_with_ipv4() {
 
 #[test]
 fn test_ipv6_in_markdown_link() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "[IPv6 Server](https://[2001:db8::1]:8080) is already linked";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -86,7 +86,7 @@ fn test_ipv6_in_markdown_link() {
 
 #[test]
 fn test_ipv6_in_angle_brackets() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Already wrapped: <https://[::1]:8080>";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -98,7 +98,7 @@ fn test_ipv6_in_angle_brackets() {
 
 #[test]
 fn test_ipv6_edge_cases() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Test compressed zeros
     let content = "Visit http://[2001:db8:0:0:0:0:0:1] or http://[2001:db8::1]";
@@ -112,7 +112,7 @@ fn test_ipv6_edge_cases() {
 
 #[test]
 fn test_ipv6_with_path_query_fragment() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "API at https://[2001:db8::1]:8080/api/v1?param=value#section";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -124,7 +124,7 @@ fn test_ipv6_with_path_query_fragment() {
 
 #[test]
 fn test_ipv6_trailing_punctuation() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Visit https://[::1]:8080.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -136,7 +136,7 @@ fn test_ipv6_trailing_punctuation() {
 
 #[test]
 fn test_ipv6_ftp_protocol() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "FTP server at ftp://[2001:db8::ftp]:21";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -148,7 +148,7 @@ fn test_ipv6_ftp_protocol() {
 
 #[test]
 fn test_ipv6_multiple_on_line() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Primary: https://[2001:db8::1] Secondary: https://[2001:db8::2]";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -163,7 +163,7 @@ fn test_ipv6_multiple_on_line() {
 
 #[test]
 fn test_ipv6_in_reference_definition() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "[ref]: https://[::1]:8080";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -175,7 +175,7 @@ fn test_ipv6_in_reference_definition() {
 
 #[test]
 fn test_ipv6_invalid_formats_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     // These are not valid URLs and should not be flagged
     let test_cases = vec![
         "Just brackets [::1] without protocol",

--- a/tests/rules/md034_test.rs
+++ b/tests/rules/md034_test.rs
@@ -4,7 +4,7 @@ use rumdl_lib::rules::MD034NoBareUrls;
 
 #[test]
 fn test_valid_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "[Link](https://example.com)\n<https://example.com>";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -13,7 +13,7 @@ fn test_valid_urls() {
 
 #[test]
 fn test_bare_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "This is a bare URL: https://example.com/foobar";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -26,7 +26,7 @@ fn test_bare_urls() {
 
 #[test]
 fn test_multiple_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Visit https://example.com and http://another.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -37,7 +37,7 @@ fn test_multiple_urls() {
 
 #[test]
 fn test_urls_in_code_block() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "```
 https://example.com
 ```
@@ -52,7 +52,7 @@ https://outside.com";
 
 #[test]
 fn test_urls_in_inline_code() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "`https://example.com`\nhttps://outside.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -64,7 +64,7 @@ fn test_urls_in_inline_code() {
 
 #[test]
 fn test_urls_in_markdown_links() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "[Example](https://example.com)\nhttps://bare.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -76,7 +76,7 @@ fn test_urls_in_markdown_links() {
 
 #[test]
 fn test_ftp_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Download from ftp://example.com/file";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -87,7 +87,7 @@ fn test_ftp_urls() {
 
 #[test]
 fn test_complex_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Visit https://example.com/path?param=value#fragment";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -98,7 +98,7 @@ fn test_complex_urls() {
 
 #[test]
 fn test_multiple_protocols() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "http://example.com\nhttps://secure.com\nftp://files.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -109,7 +109,7 @@ fn test_multiple_protocols() {
 
 #[test]
 fn test_mixed_content() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "# Heading\nVisit https://example.com\n> Quote with https://another.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -123,7 +123,7 @@ fn test_mixed_content() {
 
 #[test]
 fn test_not_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Text with example.com and just://something";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -132,7 +132,7 @@ fn test_not_urls() {
 
 #[test]
 fn test_badge_links_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content =
         "[![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react)";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -142,7 +142,7 @@ fn test_badge_links_not_flagged() {
 
 #[test]
 fn test_multiple_badges_and_links_on_one_line() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "# [React](https://react.dev/) \
 &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/react/blob/main/LICENSE) \
 [![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react) \
@@ -159,7 +159,7 @@ fn test_multiple_badges_and_links_on_one_line() {
 
 #[test]
 fn test_md034_edge_cases() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let cases = [
         // URL inside inline code - should not be flagged
         ("`https://example.com`", 0),
@@ -229,7 +229,7 @@ fn test_md034_edge_cases() {
 // #[test]
 // fn test_performance_md034() {
 //     use std::time::Instant;
-//     let rule = MD034NoBareUrls;
+//     let rule = MD034NoBareUrls::default();
 
 //     // Generate a large document with a mix of bare URLs, proper links, and code blocks
 //     let mut content = String::with_capacity(500_000);
@@ -346,7 +346,7 @@ fn test_md034_edge_cases() {
 
 #[test]
 fn test_bare_email_addresses() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Contact us at support@example.com or admin@test.org";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -371,7 +371,7 @@ fn test_bare_email_addresses() {
 
 #[test]
 fn test_email_addresses_various_formats() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let test_cases = [
         ("Email: user@domain.com", 1, "Email: <user@domain.com>"),
         (
@@ -414,7 +414,7 @@ fn test_email_addresses_various_formats() {
 
 #[test]
 fn test_email_exclusions() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let test_cases = [
         // Emails in markdown links should not be flagged
         ("[Contact](mailto:user@example.com)", 0),
@@ -441,7 +441,7 @@ fn test_email_exclusions() {
 
 #[test]
 fn test_localhost_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Visit http://localhost:3000 and https://localhost:8080/api";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -459,7 +459,7 @@ fn test_localhost_urls() {
 
 #[test]
 fn test_localhost_variations() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let test_cases = [
         ("http://localhost", 1, "<http://localhost>"),
         ("https://localhost", 1, "<https://localhost>"),
@@ -491,7 +491,7 @@ fn test_localhost_variations() {
 
 #[test]
 fn test_ip_address_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Connect to http://127.0.0.1:8080 or https://192.168.1.100";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -502,7 +502,7 @@ fn test_ip_address_urls() {
 
 #[test]
 fn test_combined_emails_and_localhost() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Contact admin@localhost.com or visit http://localhost:9090\nAlso try user@example.org and https://192.168.1.1:3000";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -517,7 +517,7 @@ fn test_combined_emails_and_localhost() {
 
 #[test]
 fn test_multiline_markdown_links_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     // This is the exact pattern that was causing false positives before the fix
     let content = "Details about each issue type and the issue lifecycle are discussed in the [MLflow Issue\nPolicy](https://github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md).\n\nAfter you have agreed upon an implementation strategy for your feature\nor patch with an MLflow committer, the next step is to introduce your\nchanges (see [developing\nchanges](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.md#developing-and-testing-mlflow))\nas a pull request against the MLflow Repository.";
 
@@ -543,7 +543,7 @@ fn test_multiline_markdown_links_not_flagged() {
 #[test]
 fn test_issue_48_url_in_link_text() {
     // Issue #48: URL within link text should not be flagged as a bare URL
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Also don't forget that the next time you need to figure out which `datetime` format you need, **[use the strptime tool at https://pym.dev/strptime](https://www.pythonmorsels.com/strptime/)**!";
 
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -561,7 +561,7 @@ fn test_issue_48_url_in_link_text() {
 #[test]
 fn test_issue_47_urls_emails_in_html_attributes() {
     // Issue #47: Email addresses and URLs in HTML attributes should not be flagged
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = r#"# Example
 
 This is **some text**.
@@ -583,7 +583,7 @@ This is **some text**.
 
 #[test]
 fn test_mixed_multiline_links_and_bare_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     // Test content with both multi-line markdown links (should not be flagged) and bare URLs (should be flagged)
     let content = "This has a [multi-line\nlink](https://github.com/example/repo) which should not be flagged.\n\nBut this bare URL should be flagged: https://bare-url.com\n\nAnd this [another multi-line\nlink with long URL](https://github.com/very/long/repository/path/that/spans/multiple/lines) should also not be flagged.";
 
@@ -628,7 +628,7 @@ fn test_issue_104_url_in_empty_link() {
     // Issue #104: URL in link text with empty URL part [url]()
     // This is the pattern from issue #104: [https://github.com/pfeif/hx-complete-generator]()
     // The URL is in the link text with empty URL part
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "check it out in its new repository at [https://github.com/pfeif/hx-complete-generator]().";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -647,7 +647,7 @@ fn test_issue_104_url_in_empty_link() {
 #[test]
 fn test_issue_104_url_in_empty_bracket_link() {
     // Issue #104: Similar pattern with [url][]
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "Visit [https://www.google.com][] for more info.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -666,7 +666,7 @@ fn test_issue_104_url_in_empty_bracket_link() {
 fn test_issue_104_full_paragraph_not_corrupted() {
     // Issue #104: Full regression test with the actual paragraph from the bug report
     // This tests that after MD042 fixes the empty link, MD034 doesn't corrupt the text
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // This is what the content looks like AFTER MD042 has fixed the empty link
     // MD042 now intelligently uses the URL from the text as the destination
@@ -695,7 +695,7 @@ fn test_issue_104_full_paragraph_not_corrupted() {
 // Issue #116: URLs in front matter should not be flagged
 #[test]
 fn test_urls_in_yaml_front_matter() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "---\nurl: http://example.com\ntitle: Test\n---\n\n# Content";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -704,7 +704,7 @@ fn test_urls_in_yaml_front_matter() {
 
 #[test]
 fn test_urls_in_toml_front_matter() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "+++\nurl = \"http://example.com\"\ntitle = \"Test\"\n+++\n\n# Content";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -713,7 +713,7 @@ fn test_urls_in_toml_front_matter() {
 
 #[test]
 fn test_urls_in_json_front_matter() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "{\n\"url\": \"http://example.com\",\n\"title\": \"Test\"\n}\n\n# Content";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -722,7 +722,7 @@ fn test_urls_in_json_front_matter() {
 
 #[test]
 fn test_bare_url_after_front_matter() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "---\nurl: http://example.com\n---\n\nVisit http://bare-url.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -742,7 +742,7 @@ fn test_bare_url_after_front_matter() {
 
 #[test]
 fn test_email_in_front_matter() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "---\nauthor_email: user@example.com\ncontact: admin@test.org\n---\n\n# Content";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -751,7 +751,7 @@ fn test_email_in_front_matter() {
 
 #[test]
 fn test_multiple_urls_in_front_matter() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "---\nurl: http://example.com\nrepository: https://github.com/user/repo\nwebsite: ftp://files.example.org\n---\n\n# Content";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -761,7 +761,7 @@ fn test_multiple_urls_in_front_matter() {
 #[test]
 fn test_issue_116_exact_reproduction() {
     // This is the exact test case from issue #116
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = "---\nurl: http://example.com\n---\n\n# Repro";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -775,7 +775,7 @@ fn test_issue_116_exact_reproduction() {
 fn test_issue_151_urls_in_html_block_attributes() {
     // This is the exact test case from issue #151
     // URLs in HTML tag attributes should not be flagged
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = r#"<figure>
   <img
     src="https://example.com/test.html"
@@ -791,7 +791,7 @@ fn test_issue_151_urls_in_html_block_attributes() {
 
 #[test]
 fn test_issue_151_single_line_html_tag_with_url() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = r#"<img src="https://example.com/image.png" alt="test" />"#;
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
     let result = rule.check(&ctx).unwrap();
@@ -803,7 +803,7 @@ fn test_issue_151_single_line_html_tag_with_url() {
 
 #[test]
 fn test_issue_151_multiple_urls_in_html_block() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = r#"<div>
   <img src="https://example.com/image1.png" />
   <img src="https://example.com/image2.png" />
@@ -819,7 +819,7 @@ fn test_issue_151_multiple_urls_in_html_block() {
 
 #[test]
 fn test_issue_151_various_html_tag_types() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = r#"<section>
   <div data-url="https://example.com/api">
     <iframe src="https://example.com/embed.html"></iframe>
@@ -835,7 +835,7 @@ fn test_issue_151_various_html_tag_types() {
 
 #[test]
 fn test_issue_151_nested_html_blocks_with_urls() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = r#"<article>
   <header>
     <img src="https://example.com/logo.png" />
@@ -854,7 +854,7 @@ fn test_issue_151_nested_html_blocks_with_urls() {
 
 #[test]
 fn test_issue_151_html_block_with_mixed_content() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
     let content = r#"<div>
   Some text content
   <img src="https://example.com/image.png" />
@@ -872,7 +872,7 @@ Outside HTML: https://example.com/should-flag.html"#;
 /// caused byte-vs-character position mismatch, leading to false positives
 #[test]
 fn test_issue_178_unicode_before_inline_code_url() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Curly apostrophe (U+2019) is 3 bytes in UTF-8, causing byte offset mismatch
     let content = "- Some code\u{2019}s example `https://example.com` containing a URL";
@@ -896,7 +896,7 @@ fn test_issue_178_unicode_before_inline_code_url() {
 /// Test various multi-byte Unicode characters before inline code with URLs
 #[test]
 fn test_unicode_multibyte_chars_before_inline_code_url() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Various multi-byte characters
     let test_cases = [
@@ -920,7 +920,7 @@ fn test_unicode_multibyte_chars_before_inline_code_url() {
 
 #[test]
 fn test_reference_definitions_with_titles_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Reference definitions should NOT be flagged - they are valid markdown link syntax
     let test_cases = [
@@ -959,7 +959,7 @@ fn test_ref_like_paragraph_with_trailing_prose_still_flags_urls() {
     // A line that only *starts* like a reference definition but has trailing prose
     // is paragraph text in CommonMark, not a definition, so rumdl's parser does not
     // treat it as one and its bare URLs are flagged - inside and outside a blockquote.
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     for content in [
         "[x]: https://a.example.com and https://b.example.com",
@@ -979,7 +979,7 @@ fn test_ref_like_paragraph_with_trailing_prose_still_flags_urls() {
 fn test_reference_definitions_in_blockquotes_not_flagged() {
     // Issue #674: a link reference definition inside a blockquote is valid
     // CommonMark and must not be flagged as a bare URL.
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         "> [example]: https://example.com",
@@ -1006,7 +1006,7 @@ fn test_reference_definitions_in_blockquotes_not_flagged() {
 fn test_reference_definition_with_escaped_title_delimiter_not_flagged() {
     // A reference-definition title may contain an escaped delimiter; such a line
     // is still a valid definition and must not be flagged.
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         r#"[x]: https://example.com "a \" quote""#,
@@ -1029,7 +1029,7 @@ fn test_reference_definition_with_escaped_bracket_label_not_flagged() {
     // Issue #814: a link label ends at the first `]` that is not
     // backslash-escaped, so each of these is a valid definition whose
     // destination must not be reported as a bare URL.
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "# Reference Example\n\n\
         * [this is a link to example.com][ref1\\[\\]]\n\
@@ -1052,7 +1052,7 @@ fn test_unterminated_label_is_not_a_reference_definition() {
     // never closes and the line is a paragraph, not a definition. pulldown-cmark
     // agrees (it resolves no reference here), so the destination is a genuine
     // bare URL and MD034 must still report it.
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "[a\\]: https://example.com/trailing\n";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1068,7 +1068,7 @@ fn test_unterminated_label_is_not_a_reference_definition() {
 fn test_bare_url_in_blockquote_still_flagged() {
     // The blockquote ref-def exemption must not suppress a genuine bare URL
     // that merely sits inside a blockquote.
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "> See https://bare.example.com for details";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1082,7 +1082,7 @@ fn test_bare_url_in_blockquote_still_flagged() {
 
 #[test]
 fn test_bare_urls_still_flagged_with_reference_definitions() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Mix of reference definitions (ok) and bare URLs (should be flagged)
     let content = r#"# Test Document
@@ -1113,7 +1113,7 @@ Another bare URL: https://another.bare.url
 
 #[test]
 fn test_www_urls_without_protocol() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // www URLs should be detected as bare URLs (matching markdownlint behavior)
     let content = "# Test\n\nVisit www.example.com for info.";
@@ -1139,7 +1139,7 @@ fn test_www_urls_without_protocol() {
 /// Test that URLs inside markdown links are not flagged (basic case)
 #[test]
 fn test_url_inside_markdown_link_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "[Link text](https://example.com)";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1154,7 +1154,7 @@ fn test_url_inside_markdown_link_not_flagged() {
 /// Test URL inside markdown link followed by text
 #[test]
 fn test_url_inside_markdown_link_with_trailing_text() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "See [here](https://example.com) for details.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1169,7 +1169,7 @@ fn test_url_inside_markdown_link_with_trailing_text() {
 /// Test multiple markdown links on the same line
 #[test]
 fn test_multiple_markdown_links_same_line() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "[Link1](https://example.com) and [Link2](https://test.com) are both valid.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1184,7 +1184,7 @@ fn test_multiple_markdown_links_same_line() {
 /// Test URL inside image syntax
 #[test]
 fn test_url_inside_image_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "![Alt text](https://example.com/image.png)";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1199,7 +1199,7 @@ fn test_url_inside_image_not_flagged() {
 /// Test URL inside nested parentheses (complex boundary)
 #[test]
 fn test_url_with_nested_parentheses_in_link() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Wikipedia-style URL inside a markdown link
     let content = "[Rust](https://en.wikipedia.org/wiki/Rust_(programming_language))";
@@ -1215,7 +1215,7 @@ fn test_url_with_nested_parentheses_in_link() {
 /// Test that bare URLs outside links ARE still flagged
 #[test]
 fn test_bare_url_outside_link_still_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Visit https://example.com for more info.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1228,7 +1228,7 @@ fn test_bare_url_outside_link_still_flagged() {
 /// Test mixed: markdown link and bare URL on same line
 #[test]
 fn test_markdown_link_and_bare_url_same_line() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "[Good link](https://example.com) but also https://bare.url here";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1245,7 +1245,7 @@ fn test_markdown_link_and_bare_url_same_line() {
 /// Test URL starting inside link construct (boundary edge case)
 #[test]
 fn test_url_starting_inside_link_boundary() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // URL detection might find a URL that extends beyond the link boundary
     // if the link has complex structure. The fix ensures we check if the URL
@@ -1263,7 +1263,7 @@ fn test_url_starting_inside_link_boundary() {
 /// Test URL in angle brackets (autolink) not flagged
 #[test]
 fn test_url_in_angle_brackets_not_flagged() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Contact us at <https://example.com>";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1278,7 +1278,7 @@ fn test_url_in_angle_brackets_not_flagged() {
 /// Test URL in reference definition not flagged
 #[test]
 fn test_url_in_reference_definition_boundary() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "[ref]: https://example.com\n\nSee [ref] for details.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1297,7 +1297,7 @@ fn test_url_in_reference_definition_boundary() {
 /// Test bare XMPP URIs are flagged
 #[test]
 fn test_bare_xmpp_uri() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Contact me at xmpp:user@example.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1316,7 +1316,7 @@ fn test_bare_xmpp_uri() {
 /// Test XMPP URI with resource path
 #[test]
 fn test_xmpp_uri_with_resource() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "My chat address: xmpp:foo@bar.baz/txt";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1335,7 +1335,7 @@ fn test_xmpp_uri_with_resource() {
 /// Test XMPP URI in angle brackets (properly formatted) is not flagged
 #[test]
 fn test_xmpp_uri_in_angle_brackets() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Contact me at <xmpp:user@example.com>";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1350,7 +1350,7 @@ fn test_xmpp_uri_in_angle_brackets() {
 /// Test XMPP URI in markdown link is not flagged
 #[test]
 fn test_xmpp_uri_in_markdown_link() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "[Chat with me](xmpp:user@example.com)";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1365,7 +1365,7 @@ fn test_xmpp_uri_in_markdown_link() {
 /// Test multiple XMPP URIs
 #[test]
 fn test_multiple_xmpp_uris() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Contact xmpp:alice@example.com or xmpp:bob@example.org/work";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1380,7 +1380,7 @@ fn test_multiple_xmpp_uris() {
 /// Test XMPP URI mixed with regular URLs and emails
 #[test]
 fn test_xmpp_uri_mixed_with_urls_and_emails() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Website: https://example.com\nEmail: user@example.com\nXMPP: xmpp:chat@example.com";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1398,7 +1398,7 @@ fn test_xmpp_uri_mixed_with_urls_and_emails() {
 /// Test XMPP URI in code block is not flagged
 #[test]
 fn test_xmpp_uri_in_code_block() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "```\nxmpp:user@example.com\n```";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1413,7 +1413,7 @@ fn test_xmpp_uri_in_code_block() {
 /// Test XMPP URI in inline code is not flagged
 #[test]
 fn test_xmpp_uri_in_inline_code() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Use `xmpp:user@example.com` for chat.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1428,7 +1428,7 @@ fn test_xmpp_uri_in_inline_code() {
 /// Test XMPP URI variations per GFM spec
 #[test]
 fn test_xmpp_uri_variations() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         // Basic XMPP URI
@@ -1464,7 +1464,7 @@ fn test_xmpp_uri_variations() {
 /// Test www URLs with query strings (GFM autolink extension)
 #[test]
 fn test_www_urls_with_query_string() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         (
@@ -1495,7 +1495,7 @@ fn test_www_urls_with_query_string() {
 /// Test www URLs with fragment identifiers
 #[test]
 fn test_www_urls_with_fragment() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         ("www.example.com#section", 1, "<https://www.example.com#section>"),
@@ -1522,7 +1522,7 @@ fn test_www_urls_with_fragment() {
 /// Test www URLs with port numbers
 #[test]
 fn test_www_urls_with_port() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         ("www.example.com:8080", 1, "<https://www.example.com:8080>"),
@@ -1545,7 +1545,7 @@ fn test_www_urls_with_port() {
 /// Test www URLs in context (embedded in sentences)
 #[test]
 fn test_www_urls_in_context() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         ("Visit www.example.com for more info.", 1),
@@ -1563,7 +1563,7 @@ fn test_www_urls_in_context() {
 /// Test www URLs properly formatted (should NOT be flagged)
 #[test]
 fn test_www_urls_not_flagged_when_formatted() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         "<https://www.example.com>",
@@ -1582,7 +1582,7 @@ fn test_www_urls_not_flagged_when_formatted() {
 /// Test mixed www and protocol URLs
 #[test]
 fn test_www_and_protocol_urls_mixed() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let content = "Visit www.example.com and https://other.com for info.";
     let ctx = LintContext::new(content, rumdl_lib::config::MarkdownFlavor::Standard, None);
@@ -1600,7 +1600,7 @@ fn test_www_and_protocol_urls_mixed() {
 /// Regression test for kubernetes/website Bengali text issue
 #[test]
 fn test_email_detection_with_multibyte_utf8() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Bengali text followed by email - the email address starts at a byte offset
     // that could land inside a multi-byte character if we subtract 5 naively
@@ -1620,7 +1620,7 @@ fn test_email_detection_with_multibyte_utf8() {
 /// Test various multi-byte UTF-8 edge cases with emails
 #[test]
 fn test_email_detection_various_scripts() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     let test_cases = [
         // Japanese

--- a/tests/unicode/unicode_edge_case_tests.rs
+++ b/tests/unicode/unicode_edge_case_tests.rs
@@ -17,7 +17,7 @@ Here is some `中文代码` in inline code
         Box::new(MD009TrailingSpaces::default()),
         Box::new(MD011NoReversedLinks),
         Box::new(MD022BlanksAroundHeadings::new()),
-        Box::new(MD034NoBareUrls),
+        Box::new(MD034NoBareUrls::default()),
         Box::new(MD047SingleTrailingNewline),
     ];
 

--- a/tests/unicode/utf8_comprehensive_stress_test.rs
+++ b/tests/unicode/utf8_comprehensive_stress_test.rs
@@ -120,7 +120,7 @@ fn get_all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(MD031BlanksAroundFences::default()),
         Box::new(MD032BlanksAroundLists::default()),
         Box::new(MD033NoInlineHtml::default()),
-        Box::new(MD034NoBareUrls), // The rule that had the UTF-8 panic
+        Box::new(MD034NoBareUrls::default()), // The rule that had the UTF-8 panic
         Box::new(MD035HRStyle::default()),
         Box::new(MD036NoEmphasisAsHeading::default()),
         Box::new(MD037NoSpaceInEmphasis),
@@ -192,7 +192,7 @@ fn test_all_rules_no_panic_with_multibyte_utf8() {
 /// This is the exact pattern that caused the kubernetes/website panic
 #[test]
 fn test_md034_email_with_all_scripts() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     for (script_name, script_text) in TEST_SCRIPTS {
         // Create content with email immediately after multi-byte text
@@ -268,7 +268,7 @@ fn test_fix_ranges_are_valid_char_boundaries() {
 /// Test edge case: email address at exact byte positions that could cause issues
 #[test]
 fn test_md034_email_at_various_byte_offsets() {
-    let rule = MD034NoBareUrls;
+    let rule = MD034NoBareUrls::default();
 
     // Create content where the email starts at different byte offsets
     // to test the `start - 5` check for "xmpp:"

--- a/tests/vscode/vscode_extension_fixes.rs
+++ b/tests/vscode/vscode_extension_fixes.rs
@@ -152,7 +152,7 @@ fn create_test_case_for_rule(rule_name: &str) -> Option<(&'static str, Box<dyn R
         )),
         "MD032" => Some(("Text\n* List item\nText", Box::new(MD032BlanksAroundLists::default()))),
         "MD033" => Some(("Text with <div>HTML</div>", Box::new(MD033NoInlineHtml::default()))),
-        "MD034" => Some(("Visit https://example.com", Box::new(MD034NoBareUrls))),
+        "MD034" => Some(("Visit https://example.com", Box::new(MD034NoBareUrls::default()))),
         "MD035" => Some(("Text\n***\nText", Box::new(MD035HRStyle::default()))),
         "MD036" => Some((
             "**Bold text as heading**",


### PR DESCRIPTION
Add a config option in MD034 to turn off automatic fixes while keeding the rule enabled to report violations (the default is still enabled, as before).

This can be useful in at least 2 situations:
- when working with a mix of Markdown and MDX files: MDX compilation of embedded Mardown files breaks when rumdl autofixes .md by surrounding urls with `<` and `>`, which MDX doesn't support.
- You don't like long URLs inside your prose and usually want to hide them behind a human-readable text. This reports those URLs and let's you aply your own fix.

The diff is huge and touches many files since `MD034NoBareUrls` did not have a config before this change, so it now needs `::default()` everywhere it is instanciated.